### PR TITLE
feat: tonal document + chapter timeline tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,10 +66,10 @@ Use MCP tools for ALL state operations. Never parse project files directly in sk
 2. `/storyforge:study-author` — (Optional) Analyze PDFs for style extraction
 3. `/storyforge:new-book` — Create project scaffold
 4. `/storyforge:book-conceptualizer` — Develop concept in 5 phases
-5. `/storyforge:plot-architect` — Structure plot with acts, beats, arcs
+5. `/storyforge:plot-architect` — Structure plot with acts, beats, arcs + tonal document
 6. `/storyforge:character-creator` — Build characters with depth
 7. `/storyforge:world-builder` — Setting, rules, history
-8. `/storyforge:chapter-writer` — Write chapters in author's voice (loads timeline + travel matrix)
+8. `/storyforge:chapter-writer` — Write chapters in author's voice (loads timeline + travel matrix + tonal document + chapter timeline)
 9. `/storyforge:continuity-checker` — (Optional, after several chapters) Validate timeline and location consistency
 9. `/storyforge:chapter-reviewer` — Review each chapter
 9b. `/storyforge:repetition-checker` — (At drafting → revision transition) Scan for cross-chapter repeated phrases, similes, character tells
@@ -86,7 +86,7 @@ Books live at `{content_root}/projects/{slug}/`:
 {book-slug}/
 ├── README.md           # Book metadata (YAML frontmatter)
 ├── synopsis.md         # Back-cover blurb + long synopsis
-├── plot/               # outline.md, acts.md, timeline.md (story calendar), canon-log.md (story bible), arcs.md
+├── plot/               # outline.md, acts.md, timeline.md (story calendar), tone.md (tonal guard rails), canon-log.md (story bible), arcs.md
 ├── characters/         # INDEX.md + individual character files
 ├── world/              # setting.md (incl. Travel Matrix), rules.md, history.md, glossary.md
 ├── research/           # sources.md + notes/
@@ -162,6 +162,8 @@ Skills MUST load relevant craft references before generating creative content:
 12. ALWAYS load `plot/canon-log.md` before writing any chapter — never contradict established facts
 13. ALWAYS update `plot/canon-log.md` after writing or revising a chapter — track new and changed facts
 14. NEVER blindly accept user corrections — verify the claim, check context, assess impact, and push back if the user is wrong or misunderstood. The user's English comprehension may miss nuances in prose. Quote the relevant text and explain.
+15. ALWAYS load `plot/tone.md` before writing any chapter (if it exists) — tonal consistency is mandatory
+16. ALWAYS update the `## Chapter Timeline` section in the chapter's README.md after writing — intra-day time tracking prevents temporal inconsistencies
 
 ## Code Style
 

--- a/servers/storyforge-server/server.py
+++ b/servers/storyforge-server/server.py
@@ -458,6 +458,7 @@ updated: "{today}"
     (project_dir / "plot" / "outline.md").write_text(f"# {title} — Plot Outline\n\n## Act 1: Setup\n\n## Act 2: Confrontation\n\n## Act 3: Resolution\n", encoding="utf-8")
     (project_dir / "plot" / "acts.md").write_text(f"# {title} — Act Structure\n\n*Use /storyforge:plot-architect to develop.*\n", encoding="utf-8")
     (project_dir / "plot" / "timeline.md").write_text(f"# {title} — Timeline\n\n*Chronological events.*\n", encoding="utf-8")
+    (project_dir / "plot" / "tone.md").write_text(f"# {title} — Tonal Document\n\n*Use /storyforge:plot-architect to develop after plot outline is complete.*\n", encoding="utf-8")
     (project_dir / "plot" / "arcs.md").write_text(f"# {title} — Character Arcs\n\n*Use /storyforge:character-creator to develop.*\n", encoding="utf-8")
 
     # Characters

--- a/skills/chapter-reviewer/SKILL.md
+++ b/skills/chapter-reviewer/SKILL.md
@@ -21,9 +21,12 @@ argument-hint: "<book-slug> <chapter-slug>"
 - Read `{project}/plot/canon-log.md` — check for facts marked `CHANGED` that this chapter may still reference incorrectly
 - Read `{project}/plot/timeline.md` — verify temporal claims match the canonical timeline
 - Read `{project}/world/setting.md` — verify travel times/distances match the Travel Matrix
+- Read `{project}/plot/tone.md` if it exists — check tonal rules, warning signs, and litmus test for this chapter's arc position
+- Read the `## Chapter Timeline` section from this chapter's `README.md` — verify all time references in the prose match the logged times
+- Read the `## Chapter Timeline` from the PREVIOUS chapter's `README.md` — verify cross-chapter time references (e.g. "an hour ago" across chapter boundaries)
 - Optional: If `{project}/research/repetition-report.md` exists, read it and check whether any of THIS chapter's distinctive 5-7 word phrases already appear in earlier chapters (lightweight cross-chapter repetition check). Flag any matches in the Continuity Report section.
 
-## Review Checklist — 20 Points
+## Review Checklist — 28 Points (20 core + 5 tonal + 3 timeline)
 
 ### Structure (5 points)
 1. **Opening hook** — Does the first paragraph grab? Would you keep reading?
@@ -53,6 +56,18 @@ argument-hint: "<book-slug> <chapter-slug>"
 19. **Stale references** — Is this chapter flagged as `[STALE]` in the Revision Impact Tracker? If so, list all outdated references.
 20. **Character facts** — Do character descriptions/behaviors match established facts? (e.g., does a vampire eat or not?)
 
+### Tonal Consistency (5 points) — only if `plot/tone.md` exists
+21. **Dominant mode** — Does the chapter match the dominant mode defined in the Tonal Arc table for this chapter's position?
+22. **Warning signs** — Does the chapter exhibit any of the warning-sign patterns listed for this stage?
+23. **Non-negotiable rules** — Are ALL non-negotiable rules satisfied? (humor density, dialog ratio, character presence, etc.)
+24. **Litmus test** — Answer every question from the Litmus Test section. Report pass/fail for each.
+25. **Banned patterns** — Does the chapter use any of the book-specific banned prose patterns?
+
+### Intra-Day Timeline (3 points)
+26. **Time anchor** — Does the chapter establish when it starts? Is this consistent with the previous chapter's ending time?
+27. **Internal consistency** — Do all relative time references ("ten minutes later", "an hour ago") match the Chapter Timeline in README.md?
+28. **Cross-chapter consistency** — Do references to earlier events use durations that match the previous chapter's timeline?
+
 ### Anti-AI (5 points)
 21. **AI vocabulary** — Any words from the banned list? (delve, tapestry, nuanced, etc.)
 22. **Structural uniformity** — Are paragraphs/sentences suspiciously uniform in length?
@@ -65,7 +80,7 @@ argument-hint: "<book-slug> <chapter-slug>"
 ```markdown
 ## Chapter Review: {Chapter Title}
 
-### Score: [X]/25
+### Score: [X]/25 (core) + [X]/5 (tonal, if tone.md exists) + [X]/3 (timeline)
 
 ### Strengths
 - *What works well*
@@ -87,6 +102,18 @@ argument-hint: "<book-slug> <chapter-slug>"
 - Timeline conflicts: [count] — [details]
 - Travel Matrix conflicts: [count] — [details]
 - Stale references (from revisions): [count] — [details]
+
+### Tonal Report (if tone.md exists)
+- Dominant mode match: [yes/no — expected: X, actual: Y]
+- Warning signs triggered: [list or "none"]
+- Non-negotiable rules: [PASS/FAIL per rule]
+- Litmus test: [pass/fail per question]
+- Banned patterns found: [list or "none"]
+
+### Chapter Timeline Report
+- Time anchor: [established / missing / inconsistent with previous chapter]
+- Internal time conflicts: [count] — [details]
+- Cross-chapter time conflicts: [count] — [details]
 
 ### AI-Tell Report
 - Flagged words: [list]

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -32,6 +32,8 @@ Before writing a SINGLE word, load ALL of these:
 10. **Story timeline** — Read `{project}/plot/timeline.md`. Mandatory for ALL chapters. This is the canonical day/date reference.
 11. **Canon log** — Read `{project}/plot/canon-log.md`. Mandatory for ALL chapters. This tracks established facts and revision changes. Pay special attention to facts marked `CHANGED` — never reference the old version.
 12. **Series canon** — If part of a series, read `{series}/world/canon.md`.
+13. **Tonal document** — Read `{project}/plot/tone.md` if it exists. This defines book-specific tonal rules, warning signs, and the litmus test for this chapter's position in the tonal arc. Older books may not have this file — proceed without it, but recommend creating one.
+14. **Previous chapter timeline** — Read the `## Chapter Timeline` section from `{project}/chapters/{prev}/README.md`. This tells you what time of day the previous chapter ended, which determines when this chapter starts. Critical for time references like "an hour ago" or "that morning."
 
 ## Writing Process
 
@@ -98,6 +100,7 @@ Reference `chapter-construction.md` on endings:
 5. **Update timeline** — Add all days/events from this chapter to `{project}/plot/timeline.md`. One row per story-day. This is MANDATORY.
 6. **Update Travel Matrix** — If new routes were introduced in this chapter, add them to the Travel Matrix in `{project}/world/setting.md`.
 7. **Update Canon Log** — Add any new facts established in this chapter to `{project}/plot/canon-log.md`. If this is a **revision** of an existing chapter, mark changed facts as `CHANGED` with the old version in Notes, and add all downstream chapters to the Revision Impact Tracker.
+8. **Update Chapter Timeline** — Fill in the `## Chapter Timeline` section in this chapter's `README.md`. Log every time-anchored event with approximate times (`~HH:MM`). Track elapsed durations. This is MANDATORY — future chapters depend on this for temporal consistency.
 
 ### Step 8: Self-Review
 Before presenting to user, quick-check:
@@ -106,6 +109,8 @@ Before presenting to user, quick-check:
 - Is there conflict in every scene?
 - Does the POV character's emotional state change?
 - Would a reader know which character is speaking without dialog tags?
+- **Litmus test** — If `plot/tone.md` exists, answer EVERY question from the Litmus Test section. If more than 1 answer is "no", flag it to the user and suggest specific revisions before proceeding.
+- **Time consistency** — Verify that every time reference in the chapter (explicit or relative) is consistent with the Chapter Timeline you created in Step 7.
 
 Suggest: `/storyforge:chapter-reviewer` for detailed review.
 
@@ -120,6 +125,9 @@ Suggest: `/storyforge:chapter-reviewer` for detailed review.
 - Never write a day-of-week or date that contradicts `plot/timeline.md`. Update timeline first if needed.
 - Never contradict a fact in the Canon Log. If a fact is marked `CHANGED`, use the NEW version only.
 - When revising a chapter: update the Canon Log FIRST, then write. This ensures downstream impact is tracked.
+- If `plot/tone.md` exists, check the Tonal Arc table for this chapter's position. Write in the dominant mode specified. If you catch yourself drifting into a warning-sign pattern, stop and course-correct.
+- Never write a relative time reference ("an hour ago", "ten minutes later") without checking it against the Chapter Timeline. If the math doesn't work, adjust the prose, not the timeline.
+- The Chapter Timeline in README.md is MANDATORY for every chapter. No exceptions. Future chapters depend on it.
 - Write the chapter in ONE PASS, then offer revision. Don't second-guess mid-flow.
 - Target word count from the chapter README. Respect genre conventions.
 

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -45,14 +45,68 @@ Read the chapter README.md outline:
 - POV character and their emotional state entering this chapter?
 - How does this chapter connect to the previous and next?
 
-### Step 2: Opening Hook
+### Step 2: Choose Writing Mode
+Ask the user how they want to write this chapter (use AskUserQuestion):
+
+- **Scene-by-scene (Recommended)** — Write one scene at a time (~900 words). User reviews and corrects each scene before the next one is written. After all scenes are complete, user reads the full chapter for a final pass. This is slower per-chapter but produces higher quality with fewer full rewrites.
+- **Full chapter** — Write the entire chapter in one pass. Traditional approach.
+- **Batch all chapters** — Write all remaining chapter drafts sequentially. Only for rough first drafts when speed matters more than quality.
+
+If the user has already chosen a mode in this session (e.g. during a previous chapter), remember their choice and skip the question — but still mention which mode is active.
+
+---
+
+### Mode A: Scene-by-Scene Writing (Recommended)
+
+#### Step A1: Scene Plan
+Before writing, break the chapter outline into individual scenes based on the Scene Beats in the chapter README.md. Present the plan to the user:
+
+```
+Scene 1: [Brief description] (~XXX words)
+Scene 2: [Brief description] (~XXX words)
+Scene 3: [Brief description] (~XXX words)
+...
+```
+
+Target ~900 words per scene (can vary — some scenes need 600, others 1200). The total should approximate the chapter's target word count.
+
+#### Step A2: Write One Scene
+For the current scene, apply ALL craft rules (Steps 3-6 from Mode B below). Write ONLY this scene — do not continue into the next scene.
+
+After writing the scene:
+1. Present it to the user
+2. Report word count for this scene
+3. **WAIT for user feedback.** Do NOT proceed to the next scene until the user approves or corrects.
+
+#### Step A3: User Review Loop
+The user reads and may correct the scene. Handle corrections per the User Feedback Handling rules (verify, check context, assess impact, push back if wrong).
+
+Once the user approves the scene (explicitly or by asking to continue):
+1. Append the approved scene to `{project}/chapters/{chapter}/draft.md`
+2. Move to the next scene (Step A2)
+
+#### Step A4: Chapter Completion
+After ALL scenes are approved and appended to draft.md:
+1. Notify the user: "Alle Szenen stehen. Bitte lies das komplette Kapitel und sag mir ob noch etwas geändert werden soll."
+2. **WAIT for the user's final read.**
+3. If corrections needed: apply them (with the usual verification).
+4. When the user is satisfied: proceed to Step 7 (Save and Update).
+5. Chapter status depends on user's verdict:
+   - User says it's good → status "Review" or "Final" (ask which)
+   - User wants another pass → stay in "Draft"
+
+---
+
+### Mode B: Full Chapter Writing
+
+#### Step 3: Opening Hook
 Write the first paragraph with extreme care. Reference `openings-and-endings.md`:
 - Start with action, voice, or tension — NEVER with weather or waking up
 - Ground the reader: who, where, when (subtly)
 - Create a micro-question that pulls the reader forward
 - Match the author's established voice from the FIRST sentence
 
-### Step 3: Write Scene by Scene
+#### Step 4: Write Scene by Scene
 Follow the Scene-Sequel structure from `chapter-construction.md`:
 
 **Scene:**
@@ -65,7 +119,7 @@ Follow the Scene-Sequel structure from `chapter-construction.md`:
 - Dilemma: What choices do they face?
 - Decision: What do they decide to do next?
 
-### Step 4: Apply Author Voice
+#### Step 5: Apply Author Voice
 For EVERY paragraph, check against the author profile:
 - **Tone:** Does this match the author's tone descriptors?
 - **Sentence rhythm:** Vary length per the author's style. Short. Then a longer, winding sentence that builds and breathes. Then short again.
@@ -74,7 +128,7 @@ For EVERY paragraph, check against the author profile:
 - **Sensory details:** All five senses, not just visual. Smell is the most evocative.
 - **Specificity:** "A 1987 Oldsmobile with a cracked windshield" not "an old car."
 
-### Step 5: Anti-AI Checks (DURING writing)
+#### Step 6: Anti-AI Checks (DURING writing)
 Reference `anti-ai-patterns.md` continuously:
 - [ ] Sentence length varies wildly (2 words to 30+)
 - [ ] No "delve", "tapestry", "nuanced", "vibrant", or other AI-tells
@@ -86,24 +140,26 @@ Reference `anti-ai-patterns.md` continuously:
 - [ ] Imperfections exist — favorite transitions, recurring metaphors, the author's "tics"
 - [ ] Not every scene wraps up neatly with an emotional bow
 
-### Step 6: Chapter Ending
+#### Step 6b: Chapter Ending
 Reference `chapter-construction.md` on endings:
 - Cliffhanger, revelation, decision, question, or emotional beat
 - MUST make the reader want to turn the page
 - Connect to the next chapter's opening (if planned)
 
-### Step 7: Save and Update
-1. Write draft to `{project}/chapters/{chapter}/draft.md`
+---
+
+### Step 7: Save and Update (both modes)
+1. Write draft to `{project}/chapters/{chapter}/draft.md` (in scene-by-scene mode, the full draft is already assembled)
 2. Count words — report to user
-3. Update chapter status to "Draft" via MCP `update_field()`
+3. Update chapter status to "Draft" (or "Review"/"Final" if user specified) via MCP `update_field()`
 4. If this is the first chapter being drafted, update book status to "Drafting"
 5. **Update timeline** — Add all days/events from this chapter to `{project}/plot/timeline.md`. One row per story-day. This is MANDATORY.
 6. **Update Travel Matrix** — If new routes were introduced in this chapter, add them to the Travel Matrix in `{project}/world/setting.md`.
 7. **Update Canon Log** — Add any new facts established in this chapter to `{project}/plot/canon-log.md`. If this is a **revision** of an existing chapter, mark changed facts as `CHANGED` with the old version in Notes, and add all downstream chapters to the Revision Impact Tracker.
 8. **Update Chapter Timeline** — Fill in the `## Chapter Timeline` section in this chapter's `README.md`. Log every time-anchored event with approximate times (`~HH:MM`). Track elapsed durations. This is MANDATORY — future chapters depend on this for temporal consistency.
 
-### Step 8: Self-Review
-Before presenting to user, quick-check:
+### Step 8: Self-Review (both modes)
+Before presenting to user (in full-chapter mode) or after all scenes assembled (in scene-by-scene mode), quick-check:
 - Does the opening hook?
 - Does the ending compel?
 - Is there conflict in every scene?
@@ -128,7 +184,8 @@ Suggest: `/storyforge:chapter-reviewer` for detailed review.
 - If `plot/tone.md` exists, check the Tonal Arc table for this chapter's position. Write in the dominant mode specified. If you catch yourself drifting into a warning-sign pattern, stop and course-correct.
 - Never write a relative time reference ("an hour ago", "ten minutes later") without checking it against the Chapter Timeline. If the math doesn't work, adjust the prose, not the timeline.
 - The Chapter Timeline in README.md is MANDATORY for every chapter. No exceptions. Future chapters depend on it.
-- Write the chapter in ONE PASS, then offer revision. Don't second-guess mid-flow.
+- In full-chapter mode: Write in ONE PASS, then offer revision. Don't second-guess mid-flow.
+- In scene-by-scene mode: Write ONLY the current scene. STOP and WAIT for user feedback. NEVER proceed to the next scene without explicit approval. Each scene applies ALL craft rules (author voice, anti-AI, sensory details) — short scenes are not an excuse for lower quality.
 - Target word count from the chapter README. Respect genre conventions.
 
 ## User Feedback Handling — CRITICAL

--- a/skills/plot-architect/SKILL.md
+++ b/skills/plot-architect/SKILL.md
@@ -98,6 +98,29 @@ This step is MANDATORY. A book without a timeline anchor cannot maintain tempora
 
 Update book status to "Plot Outlined" via MCP `update_field()`.
 
+### Step 9: Create Tonal Document
+Create `{project}/plot/tone.md` from template `plot-tone.md`. This step is MANDATORY for new books.
+
+1. **Interview the user** (use AskUserQuestion or conversational flow):
+   - What should this book feel like to read? (overall emotional texture)
+   - Which authors or works should we channel for tone? Which to avoid?
+   - Are there non-negotiable rules? (e.g. humor must always be present, certain characters always felt)
+   - What would be a WARNING sign that the tone is drifting?
+
+2. **Populate the Tonal Arc** based on the act structure from Step 3:
+   - Map dominant/secondary tone per act/stage
+   - Define warning signs per stage (what would be WRONG)
+   - The tonal arc should SHIFT across the story — monotone is death
+
+3. **Define the Litmus Test** — 5-6 yes/no questions the chapter-writer answers after every chapter.
+   These should be specific to THIS book, not generic craft questions.
+
+4. **Non-Negotiable Rules** — Book-specific prose rules beyond the author profile's general style.
+
+5. Write the completed document to `{project}/plot/tone.md`.
+
+This document guards against tonal drift during long-form writing. Without it, books tend to collapse into generic "literary" mode after ~15 chapters.
+
 ## Rules
 - Structure serves story — never force a story into a structure that doesn't fit
 - Every beat must have emotional PURPOSE, not just plot function

--- a/templates/chapter.md
+++ b/templates/chapter.md
@@ -29,6 +29,22 @@ word_count_target: 3000
 
 *What does the POV character feel at the start vs. end of this chapter?*
 
+## Chapter Timeline
+
+*Intra-day time tracking. The chapter-writer MUST update this after writing.*
+*The chapter-reviewer checks all time references against this table.*
+
+| Time | Event | Notes |
+|------|-------|-------|
+| | | |
+
+**Instructions:**
+- Log every time-anchored event (explicit clock times, "ten minutes later", sunrise/sunset)
+- Use approximate times with `~` prefix (e.g. `~8:45`) when not stated explicitly
+- Track elapsed durations in Notes (e.g. "11 min since arrival")
+- The previous chapter's timeline determines this chapter's starting time
+- Any "X hours/minutes ago" reference MUST be consistent with the logged times
+
 ## Notes
 
 *Writing notes, research needed, continuity reminders.*

--- a/templates/plot-tone.md
+++ b/templates/plot-tone.md
@@ -1,0 +1,85 @@
+# {{title}} — Tonal Document
+
+> **PURPOSE:** This document prevents tonal drift — the #1 killer of long-form fiction.
+> The author profile defines *how* you write. This document defines *how this specific book should feel*.
+> The chapter-writer MUST load this file before writing any chapter.
+
+## The Core Problem This Document Solves
+
+*What tonal failure would ruin this book? Describe the specific drift you're guarding against.*
+*Example: "This book must never read as literary romance. The humor must always be present, even in dark scenes."*
+
+## Reference Bookshelf
+
+### Channel These Authors/Works
+*Whose voice or energy should influence this book's tone?*
+
+| Author/Work | What to Channel | What NOT to Take |
+|-------------|-----------------|------------------|
+| | | |
+
+### Avoid These Patterns
+*Which styles would be wrong for this book?*
+
+| Anti-Reference | Why It's Wrong for This Book |
+|----------------|------------------------------|
+| | |
+
+## Tonal Arc
+
+*Map the dominant tone per story stage. The tone should SHIFT — a book that feels the same throughout is monotone.*
+
+| Stage | Chapters | Dominant Mode | Secondary Mode | Warning Signs |
+|-------|----------|---------------|----------------|---------------|
+| Act 1 Opening | Ch. 1-3 | *e.g. humor-forward* | *e.g. mystery undercurrent* | *e.g. if it reads as depressive, it's wrong* |
+| Act 1 Inciting | Ch. 4-5 | | | |
+| Act 2A Rising | Ch. 6-10 | | | |
+| Midpoint | Ch. 11-13 | | | |
+| Act 2B Complications | Ch. 14-18 | | | |
+| All Is Lost | Ch. 19-20 | | | |
+| Act 3 Climax | Ch. 21-24 | | | |
+| Denouement | Ch. 25+ | | | |
+
+## Non-Negotiable Rules
+
+*Rules that apply to EVERY chapter of this book, no exceptions.*
+
+### Humor Density
+*e.g. "At least one genuine laugh per chapter, even in grief scenes. Humor is how these characters cope."*
+
+### Dialog Ratio
+*e.g. "Minimum 40% dialog. These characters talk — they process the world through banter."*
+
+### Character Voice Rules
+*e.g. "Jace must exist in every chapter's universe, even off-page. If Jace isn't mentioned or felt, the chapter is incomplete."*
+
+### Banned Prose Patterns (Book-Specific)
+*Beyond the author profile's banned list — what's specifically wrong for THIS book?*
+
+- *e.g. No extended interiority without interruption — if a character thinks for more than 3 paragraphs without dialog or action, break it up.*
+- *e.g. No weather descriptions as mood-setting. The mood comes from the characters.*
+
+## Litmus Test
+
+*After writing each chapter, answer these questions. If more than 1 answer is "no", revise before proceeding.*
+
+1. [ ] *e.g. Did someone laugh (or would a reader smile) at least twice?*
+2. [ ] *e.g. Is there at least one moment of genuine human warmth?*
+3. [ ] *e.g. Does the chapter end with forward momentum (not just a mood)?*
+4. [ ] *e.g. Would you want to read the next chapter after this ending?*
+5. [ ] *e.g. Does the POV character sound like themselves, not a generic narrator?*
+6. [ ] *e.g. Is the dominant mode from the Tonal Arc table present?*
+
+## Tone Examples from Existing Chapters
+
+*As chapters are finalized, add snippets that perfectly capture the correct tone. These serve as calibration references for future chapters.*
+
+### Example 1: [Chapter Title]
+> *Quote that nails the tone.*
+
+**Why this works:** *Brief explanation.*
+
+### Example 2: [Chapter Title]
+> *Quote that nails the tone.*
+
+**Why this works:** *Brief explanation.*


### PR DESCRIPTION
## Summary

- **Tonal Document** (`plot/tone.md`) — book-specific tonal guard rails with arc mapping, warning signs, litmus test, and non-negotiable rules. Prevents tonal drift that killed the first B&BF draft. Created by `plot-architect` (new Step 9), consumed by `chapter-writer` and `chapter-reviewer`.
- **Chapter Timeline** — intra-day time tracking via `## Chapter Timeline` section in each chapter's README.md. Prevents temporal inconsistency errors ("ninety minutes ago" when it was actually 3 hours).

### Files changed
- `templates/plot-tone.md` — New template
- `templates/chapter.md` — Added Chapter Timeline section
- `servers/storyforge-server/server.py` — Scaffold creates `plot/tone.md`
- `skills/plot-architect/SKILL.md` — New Step 9: Create Tonal Document
- `skills/chapter-writer/SKILL.md` — Prerequisites #13-14, Save Step 8, Self-Review + Rules
- `skills/chapter-reviewer/SKILL.md` — 8 new review points (5 tonal + 3 timeline), output sections
- `CLAUDE.md` — Updated project structure, workflow, and rules #15-16

Closes #3, Closes #4

## Test plan
- [x] Run `/storyforge:new-book` and verify `plot/tone.md` appears in scaffold
- [x] Run `/storyforge:plot-architect` and verify Step 9 (tonal document) executes
- [x] Run `/storyforge:chapter-writer` and verify tone.md + chapter timeline are loaded/created
- [x] Run `/storyforge:chapter-reviewer` and verify new Tonal Report + Timeline Report in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)