### PR TITLE
feat: per-book CLAUDE.md with auto-sync via PreCompact hook

### DIFF
--- a/.claude-plugin/hooks.json
+++ b/.claude-plugin/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${HOME}/.storyforge/venv/bin/python3 ${CLAUDE_PLUGIN_ROOT}/hooks/precompact_sync_claudemd.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,5 +7,6 @@
   },
   "license": "MIT",
   "skills": "./skills/",
-  "mcpServers": "./.mcp.json"
+  "mcpServers": "./.mcp.json",
+  "hooks": "./.claude-plugin/hooks.json"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ Use MCP tools for ALL state operations. Never parse project files directly in sk
 | "Cover" / "Buchcover" | `/storyforge:cover-artist` |
 | "Promo" / "Social Media" / "Marketing" / "bewerben" | `/storyforge:promo-writer` |
 | "Neues Genre" / "Genre-Mix" | `/storyforge:genre-creator` |
+| `Regel:` / `Workflow:` / `Callback:` prefix, "merke dir" | `/storyforge:register-callback` |
 | "Hilfe" / "Help" | `/storyforge:help` |
 | "Setup" / "Einrichten" | `/storyforge:setup` |
 | "Config" / "Konfiguration" | `/storyforge:configure` |
@@ -164,6 +165,8 @@ Skills MUST load relevant craft references before generating creative content:
 14. NEVER blindly accept user corrections — verify the claim, check context, assess impact, and push back if the user is wrong or misunderstood. The user's English comprehension may miss nuances in prose. Quote the relevant text and explain.
 15. ALWAYS load `plot/tone.md` before writing any chapter (if it exists) — tonal consistency is mandatory
 16. ALWAYS update the `## Chapter Timeline` section in the chapter's README.md after writing — intra-day time tracking prevents temporal inconsistencies
+17. ALWAYS load the book's `CLAUDE.md` via MCP `get_book_claudemd()` before writing or reviewing a chapter — it contains persisted workflow rules and callbacks that survive session compaction
+18. Prefix grammar for persistence: messages starting with `Regel:`, `Workflow:`, or `Callback:` are extracted by the PreCompact hook and written to the book's CLAUDE.md. Unprefixed messages are never persisted automatically.
 
 ## Code Style
 

--- a/hooks/precompact_sync_claudemd.py
+++ b/hooks/precompact_sync_claudemd.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""PreCompact hook: Extract prefixed entries from the session transcript
+and persist them to the active book's CLAUDE.md.
+
+Claude Code invokes this hook right before compacting the conversation
+context. The hook receives a JSON payload on stdin with the transcript
+path. We scan user messages for the deterministic prefixes ``Regel:``,
+``Workflow:``, and ``Callback:`` and append matches to the CLAUDE.md of
+the book referenced by the current StoryForge session.
+
+The hook never calls an LLM; all extraction is pure regex. This keeps
+compaction cheap even on long sessions.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+PLUGIN_ROOT = Path(
+    os.environ.get("CLAUDE_PLUGIN_ROOT", str(Path(__file__).resolve().parent.parent))
+)
+
+# Make tools package importable when the hook runs standalone.
+if str(PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_ROOT))
+
+
+def _read_transcript(path: Path) -> list[dict[str, Any]]:
+    """Read a Claude Code transcript (JSONL) and return parsed entries."""
+    if not path.exists():
+        return []
+    entries: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return entries
+
+
+def _extract_user_text(entries: list[dict[str, Any]]) -> str:
+    """Concatenate all user-message text from a transcript."""
+    parts: list[str] = []
+    for entry in entries:
+        if entry.get("type") != "user":
+            continue
+        message = entry.get("message") or {}
+        content = message.get("content")
+        if isinstance(content, str):
+            parts.append(content)
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text = block.get("text")
+                    if isinstance(text, str):
+                        parts.append(text)
+    return "\n".join(parts)
+
+
+def _active_book_slug() -> str | None:
+    """Look up the current book slug from the StoryForge state cache.
+
+    StoryForge stores session info at ``~/.storyforge/cache/state.json``
+    under the ``session.last_book`` key (see server ``update_session``).
+    """
+    from tools.shared.config import STATE_PATH  # local import after sys.path
+
+    if not STATE_PATH.exists():
+        return None
+    try:
+        state = json.loads(STATE_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+    session = state.get("session") or {}
+    slug = session.get("last_book")
+    return slug if isinstance(slug, str) and slug else None
+
+
+def run(payload: dict[str, Any]) -> dict[str, Any]:
+    """Process a PreCompact payload and return a result summary."""
+    transcript_path = payload.get("transcript_path") or payload.get("transcript")
+    if not transcript_path:
+        return {"skipped": "no transcript_path"}
+
+    book_slug = _active_book_slug()
+    if not book_slug:
+        return {"skipped": "no active book in session"}
+
+    from tools.claudemd.manager import (
+        append_callback,
+        append_rule,
+        append_workflow,
+        resolve_claudemd_path,
+    )
+    from tools.claudemd.parser import extract_prefixed_lines
+    from tools.shared.config import load_config
+
+    config = load_config()
+    claudemd_path = resolve_claudemd_path(config, book_slug)
+    if not claudemd_path.exists():
+        return {"skipped": f"no CLAUDE.md for book '{book_slug}'"}
+
+    entries = _read_transcript(Path(transcript_path))
+    text = _extract_user_text(entries)
+    prefixed = extract_prefixed_lines(text)
+
+    counts = {"rule": 0, "workflow": 0, "callback": 0, "errors": 0}
+    impl = {"rule": append_rule, "workflow": append_workflow, "callback": append_callback}
+
+    for kind, body in prefixed:
+        try:
+            impl[kind](config, book_slug, body)
+            counts[kind] += 1
+        except Exception:
+            counts["errors"] += 1
+
+    return {"book": book_slug, "counts": counts}
+
+
+def main() -> None:
+    """Entry point. Reads JSON from stdin, writes a summary to stderr."""
+    try:
+        raw = sys.stdin.read()
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        payload = {}
+
+    try:
+        result = run(payload)
+    except Exception as exc:  # pragma: no cover — belt-and-suspenders
+        # Never fail compaction: log and continue.
+        print(f"precompact_sync_claudemd error: {exc}", file=sys.stderr)
+        sys.exit(0)
+
+    # Print summary to stderr so Claude Code can log it; stdout is reserved
+    # for hook protocol output.
+    print(json.dumps(result), file=sys.stderr)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/servers/storyforge-server/server.py
+++ b/servers/storyforge-server/server.py
@@ -24,6 +24,16 @@ from tools.shared.paths import slugify, resolve_project_path, resolve_chapter_pa
 from tools.state.indexer import StateCache, build_state, rebuild
 from tools.state.parsers import parse_frontmatter, count_words_in_file
 from tools.analysis.repetition_checker import scan_repetitions, render_report
+from tools.claudemd.manager import (
+    append_callback as _append_callback_impl,
+    append_rule as _append_rule_impl,
+    append_workflow as _append_workflow_impl,
+    get_claudemd as _get_claudemd_impl,
+    init_claudemd as _init_claudemd_impl,
+    resolve_claudemd_path as _resolve_claudemd_path_impl,
+    update_book_facts as _update_book_facts_impl,
+)
+from tools.claudemd.parser import extract_prefixed_lines as _extract_prefixed_lines
 
 mcp = FastMCP("storyforge-mcp")
 _cache = StateCache()
@@ -1002,6 +1012,156 @@ def list_craft_references() -> str:
     if genre_dir.exists():
         result["genre"] = sorted(f.stem for f in genre_dir.glob("*.md"))
 
+    return json.dumps(result)
+
+
+# ============================================================
+# Per-Book CLAUDE.md Tools
+# ============================================================
+
+
+@mcp.tool()
+def init_book_claudemd(
+    book_slug: str,
+    book_title: str = "",
+    pov: str = "",
+    tense: str = "",
+    genre: str = "",
+    writing_mode: str = "scene-by-scene",
+    overwrite: bool = False,
+) -> str:
+    """Create CLAUDE.md from template in the book project root.
+
+    Called by new-book after scaffolding a project. Populates the Book Facts
+    section from the given metadata. Use overwrite=True to regenerate.
+
+    Ephemeral state (current chapter, next beat) is NOT stored here — it
+    belongs in the session cache (``update_session``) because it changes
+    after every chapter.
+    """
+    config = load_config()
+    facts = {
+        "book_title": book_title or book_slug,
+        "pov": pov,
+        "tense": tense,
+        "genre": genre,
+        "writing_mode": writing_mode,
+    }
+    try:
+        path = _init_claudemd_impl(
+            config, Path(plugin_root), book_slug, facts=facts, overwrite=overwrite
+        )
+    except FileExistsError as exc:
+        return json.dumps({"error": str(exc)})
+    except FileNotFoundError as exc:
+        return json.dumps({"error": str(exc)})
+    return json.dumps({"path": str(path), "created": True})
+
+
+@mcp.tool()
+def get_book_claudemd(book_slug: str) -> str:
+    """Read the current CLAUDE.md for a book."""
+    config = load_config()
+    try:
+        content = _get_claudemd_impl(config, book_slug)
+    except FileNotFoundError as exc:
+        return json.dumps({"error": str(exc)})
+    return json.dumps({"content": content})
+
+
+@mcp.tool()
+def append_book_rule(book_slug: str, text: str) -> str:
+    """Append a rule to the Rules section of a book's CLAUDE.md."""
+    config = load_config()
+    try:
+        path = _append_rule_impl(config, book_slug, text)
+    except (FileNotFoundError, ValueError) as exc:
+        return json.dumps({"error": str(exc)})
+    return json.dumps({"path": str(path), "kind": "rule", "text": text})
+
+
+@mcp.tool()
+def append_book_workflow(book_slug: str, text: str) -> str:
+    """Append a workflow instruction to a book's CLAUDE.md."""
+    config = load_config()
+    try:
+        path = _append_workflow_impl(config, book_slug, text)
+    except (FileNotFoundError, ValueError) as exc:
+        return json.dumps({"error": str(exc)})
+    return json.dumps({"path": str(path), "kind": "workflow", "text": text})
+
+
+@mcp.tool()
+def append_book_callback(book_slug: str, text: str) -> str:
+    """Append a callback to the Callback Register of a book's CLAUDE.md."""
+    config = load_config()
+    try:
+        path = _append_callback_impl(config, book_slug, text)
+    except (FileNotFoundError, ValueError) as exc:
+        return json.dumps({"error": str(exc)})
+    return json.dumps({"path": str(path), "kind": "callback", "text": text})
+
+
+@mcp.tool()
+def update_book_claudemd_facts(
+    book_slug: str,
+    pov: str = "",
+    tense: str = "",
+    genre: str = "",
+    writing_mode: str = "",
+) -> str:
+    """Update one or more Book Facts fields in a book's CLAUDE.md.
+
+    Empty strings are ignored (field left unchanged). Only stable facts
+    live in CLAUDE.md; per-chapter progress belongs in the session cache.
+    """
+    config = load_config()
+    provided = {
+        "pov": pov,
+        "tense": tense,
+        "genre": genre,
+        "writing_mode": writing_mode,
+    }
+    facts = {k: v for k, v in provided.items() if v}
+    if not facts:
+        return json.dumps({"error": "No fields provided"})
+    try:
+        path = _update_book_facts_impl(config, book_slug, facts)
+    except FileNotFoundError as exc:
+        return json.dumps({"error": str(exc)})
+    return json.dumps({"path": str(path), "updated": list(facts.keys())})
+
+
+@mcp.tool()
+def sync_book_claudemd_from_text(book_slug: str, text: str) -> str:
+    """Extract prefixed entries (Regel:/Workflow:/Callback:) and persist them.
+
+    Used by the PreCompact hook: pass a text blob (e.g. recent session
+    messages) and all matching lines are appended to the appropriate
+    sections. Returns counts per kind.
+    """
+    config = load_config()
+    entries = _extract_prefixed_lines(text)
+    counts = {"rule": 0, "workflow": 0, "callback": 0, "errors": 0}
+    errors: list[str] = []
+
+    impl_map = {
+        "rule": _append_rule_impl,
+        "workflow": _append_workflow_impl,
+        "callback": _append_callback_impl,
+    }
+
+    for kind, body in entries:
+        try:
+            impl_map[kind](config, book_slug, body)
+            counts[kind] += 1
+        except (FileNotFoundError, ValueError) as exc:
+            counts["errors"] += 1
+            errors.append(f"{kind}: {exc}")
+
+    result: dict[str, Any] = {"counts": counts}
+    if errors:
+        result["errors"] = errors
     return json.dumps(result)
 
 

--- a/skills/chapter-reviewer/SKILL.md
+++ b/skills/chapter-reviewer/SKILL.md
@@ -25,6 +25,7 @@ argument-hint: "<book-slug> <chapter-slug>"
 - Read the `## Chapter Timeline` section from this chapter's `README.md` — verify all time references in the prose match the logged times
 - Read the `## Chapter Timeline` from the PREVIOUS chapter's `README.md` — verify cross-chapter time references (e.g. "an hour ago" across chapter boundaries)
 - Optional: If `{project}/research/repetition-report.md` exists, read it and check whether any of THIS chapter's distinctive 5-7 word phrases already appear in earlier chapters (lightweight cross-chapter repetition check). Flag any matches in the Continuity Report section.
+- **Per-book CLAUDE.md** — MCP `get_book_claudemd(book_slug)`. Mandatory. Check the draft against every **Rule** (deduct points if violated) and verify that **Callbacks** are either honored, intentionally deferred, or not applicable to this chapter. Flag missed callbacks in the Continuity Report section.
 
 ## Review Checklist — 28 Points (20 core + 5 tonal + 3 timeline)
 

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -34,6 +34,10 @@ Before writing a SINGLE word, load ALL of these:
 12. **Series canon** — If part of a series, read `{series}/world/canon.md`.
 13. **Tonal document** — Read `{project}/plot/tone.md` if it exists. This defines book-specific tonal rules, warning signs, and the litmus test for this chapter's position in the tonal arc. Older books may not have this file — proceed without it, but recommend creating one.
 14. **Previous chapter timeline** — Read the `## Chapter Timeline` section from `{project}/chapters/{prev}/README.md`. This tells you what time of day the previous chapter ended, which determines when this chapter starts. Critical for time references like "an hour ago" or "that morning."
+15. **Per-book CLAUDE.md** — MCP `get_book_claudemd(book_slug)`. Mandatory. Contains workflow rules, book-scoped rules, and callback register. Honor every entry:
+    - **Rules**: Apply to this chapter's prose (e.g. "avoid passive voice").
+    - **Workflow**: Follow the stated process (e.g. "scene-by-scene").
+    - **Callbacks**: Weave in the listed characters, objects, or plot threads where natural. Do not force them, but look for an organic moment.
 
 ## Writing Process
 

--- a/skills/new-book/SKILL.md
+++ b/skills/new-book/SKILL.md
@@ -28,11 +28,13 @@ argument-hint: "[title]"
 
 2. **Create project** — Use MCP `create_book_structure()` with collected info
 
-3. **Update session** — Use MCP `update_session()` with the new book as active
+3. **Create CLAUDE.md** — Use MCP `init_book_claudemd(book_slug, book_title, pov, tense, genre, writing_mode)` to scaffold the per-book context file. Ask the user for `writing_mode` if not obvious: `scene-by-scene` (default), `chapter`, or `book`. Per-chapter progress is NOT stored here — it lives in `update_session()`.
 
-4. **Load genre README(s)** — Use MCP `get_genre()` for each selected genre. Show key conventions to the user.
+4. **Update session** — Use MCP `update_session()` with the new book as active
 
-5. **Suggest next steps** — Based on the genre and book type:
+5. **Load genre README(s)** — Use MCP `get_genre()` for each selected genre. Show key conventions to the user.
+
+6. **Suggest next steps** — Based on the genre and book type:
    - "Start with `/storyforge:book-conceptualizer` to develop your concept"
    - "Or jump to `/storyforge:plot-architect` if you already know the story"
    - "Need characters first? Try `/storyforge:character-creator`"

--- a/skills/register-callback/SKILL.md
+++ b/skills/register-callback/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: register-callback
+description: |
+  Register a rule, workflow instruction, or callback for the active book.
+  Use when: (1) User types a line starting with `Regel:`, `Workflow:`, or `Callback:`,
+  (2) User says "merke dir", "callback", "neue Regel", "ab jetzt immer",
+  (3) User wants to persist a detail across sessions (e.g. "Gary soll wiederkommen").
+  The entry is appended to the book's CLAUDE.md and survives context compaction.
+model: claude-haiku-4-5
+user-invocable: true
+argument-hint: "<Regel|Workflow|Callback>: <text>"
+---
+
+# Register Callback / Rule / Workflow
+
+Deterministic persistence of per-book context. No creativity needed — just extract and store.
+
+## Inputs
+
+- **Explicit prefix message**: `Regel: ...`, `Workflow: ...`, `Callback: ...`
+- **Slash invocation with argument**: `/storyforge:register-callback Callback: Gary the cat`
+- **Free-form user intent**: "merk dir Gary" → ask for the prefix, don't guess
+
+## Workflow
+
+1. **Resolve active book** — MCP `get_session()` returns the current `book_slug`.
+   - If no active book: tell user to `/storyforge:resume <book>` first and stop.
+
+2. **Verify CLAUDE.md exists** — MCP `get_book_claudemd(book_slug)`.
+   - If missing: run `init_book_claudemd(book_slug, ...)` with best-effort facts
+     pulled from `get_book_full(book_slug)`.
+
+3. **Parse input** — Match one of the three prefixes (case-insensitive):
+   - `Regel:` / `Rule:` → **rule**
+   - `Workflow:` → **workflow**
+   - `Callback:` → **callback**
+   - Anything else: ask the user to add a prefix. Do NOT guess.
+
+4. **Append via MCP** — Call the matching tool with the trimmed body:
+   - rule → `append_book_rule(book_slug, text)`
+   - workflow → `append_book_workflow(book_slug, text)`
+   - callback → `append_book_callback(book_slug, text)`
+
+5. **Confirm** — One-line confirmation: `✅ [kind] gespeichert in CLAUDE.md: "[text]"`
+
+## Batch Mode
+
+If the user provides multiple prefixed lines in one message, use
+`sync_book_claudemd_from_text(book_slug, text)` to extract and persist all at once.
+Report counts per kind.
+
+## Rules
+
+- Never invent a callback from context — only register what the user explicitly marks.
+- Do not write plot details, character reveals, or world info here. Those belong in
+  `plot/`, `characters/`, `world/`. Tell the user if they try to put plot content in
+  a callback.
+- Trim surrounding whitespace but preserve the exact text the user typed.
+- Idempotent: duplicate entries are silently skipped by the MCP tool.

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -42,7 +42,14 @@ argument-hint: "<book-slug>"
    |---|-------|--------|-------|
    ```
 
-8. **Recommend next action** — Based on book status:
+8. **Load per-book CLAUDE.md** — MCP `get_book_claudemd(book_slug)`. If it exists, show a compact summary:
+   - Active **Workflow** entries (verbatim)
+   - Active **Rules** (verbatim, up to 10 most recent)
+   - **Callbacks** pending resolution (verbatim)
+
+   If the file is missing (older book predating this feature): offer to run `init_book_claudemd` with the collected book facts.
+
+9. **Recommend next action** — Based on book status:
 
    | Book Status | Recommended Skill |
    |-------------|-------------------|

--- a/templates/book-claude-md.template
+++ b/templates/book-claude-md.template
@@ -1,0 +1,36 @@
+# {{book_title}}
+
+Per-book context file. Loaded automatically by StoryForge skills and persisted across sessions.
+
+## Book Facts
+
+- **POV:** {{pov}}
+- **Tense:** {{tense}}
+- **Genre:** {{genre}}
+- **Writing Mode:** {{writing_mode}}
+
+## Workflow
+
+- Writing mode: **{{writing_mode}}** (scene-by-scene | chapter | book)
+- Wait for explicit user approval before setting `status: review`
+- Chapter Timeline in `README.md` is mandatory at review-status
+- Review comments come in ```textile Markus: ... ``` blocks
+
+<!-- WORKFLOW:START -->
+<!-- WORKFLOW:END -->
+
+## Rules
+
+<!-- RULES:START -->
+<!-- RULES:END -->
+
+## Callback Register
+
+Characters, objects, or plot threads the user wants to recur in later chapters.
+
+<!-- CALLBACKS:START -->
+<!-- CALLBACKS:END -->
+
+---
+
+_Managed by StoryForge. Add entries via `Regel:`, `Workflow:`, or `Callback:` prefixes in your messages, or use `/storyforge:register-callback`._

--- a/templates/book-claude-md.template
+++ b/templates/book-claude-md.template
@@ -14,7 +14,7 @@ Per-book context file. Loaded automatically by StoryForge skills and persisted a
 - Writing mode: **{{writing_mode}}** (scene-by-scene | chapter | book)
 - Wait for explicit user approval before setting `status: review`
 - Chapter Timeline in `README.md` is mandatory at review-status
-- Review comments come in ```textile Markus: ... ``` blocks
+- Review comments come in ` ```textile Markus: ... ``` ` blocks inside the draft — **verify first, implement second**: quote the passage, check the claim against tone/canon/craft context, and push back if the comment is wrong or based on a misreading. Only fix after verification passes. Fix only what is commented, do not assume other changes.
 
 <!-- WORKFLOW:START -->
 <!-- WORKFLOW:END -->

--- a/tests/test_claudemd.py
+++ b/tests/test_claudemd.py
@@ -1,0 +1,275 @@
+"""Tests for per-book CLAUDE.md management."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.claudemd.manager import (
+    append_callback,
+    append_rule,
+    append_workflow,
+    get_claudemd,
+    init_claudemd,
+    resolve_claudemd_path,
+    update_book_facts,
+)
+from tools.claudemd.parser import (
+    extract_prefixed_lines,
+    parse_prefixed_entry,
+)
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture
+def book_config(tmp_path: Path) -> dict:
+    """Config with tmp_path as content_root and a pre-created book directory."""
+    content_root = tmp_path / "books"
+    book_dir = content_root / "projects" / "my-book"
+    book_dir.mkdir(parents=True)
+    # Book README so find_projects would recognize it.
+    (book_dir / "README.md").write_text("# My Book\n", encoding="utf-8")
+    return {"paths": {"content_root": str(content_root)}}
+
+
+class TestParser:
+    def test_regel_prefix_german(self):
+        assert parse_prefixed_entry("Regel: sparsam mit Adverbien") == (
+            "rule",
+            "sparsam mit Adverbien",
+        )
+
+    def test_rule_prefix_english(self):
+        assert parse_prefixed_entry("Rule: avoid passive voice") == (
+            "rule",
+            "avoid passive voice",
+        )
+
+    def test_workflow_prefix(self):
+        assert parse_prefixed_entry("Workflow: scene-by-scene, not whole chapter") == (
+            "workflow",
+            "scene-by-scene, not whole chapter",
+        )
+
+    def test_callback_prefix(self):
+        assert parse_prefixed_entry("Callback: Gary the cat") == (
+            "callback",
+            "Gary the cat",
+        )
+
+    def test_case_insensitive(self):
+        assert parse_prefixed_entry("CALLBACK: thing") == ("callback", "thing")
+        assert parse_prefixed_entry("callback: thing") == ("callback", "thing")
+
+    def test_leading_whitespace(self):
+        assert parse_prefixed_entry("   Regel: X") == ("rule", "X")
+
+    def test_no_prefix_returns_none(self):
+        assert parse_prefixed_entry("Just a normal sentence.") is None
+
+    def test_empty_body_returns_none(self):
+        assert parse_prefixed_entry("Regel:") is None
+        assert parse_prefixed_entry("Regel:    ") is None
+
+    def test_similar_but_not_prefix(self):
+        assert parse_prefixed_entry("The rule here is important") is None
+
+    def test_extract_from_multiline(self):
+        text = (
+            "Normal line.\n"
+            "Regel: stay tight\n"
+            "Another normal line.\n"
+            "Callback: Gary\n"
+            "Workflow: scene-by-scene\n"
+        )
+        result = extract_prefixed_lines(text)
+        assert result == [
+            ("rule", "stay tight"),
+            ("callback", "Gary"),
+            ("workflow", "scene-by-scene"),
+        ]
+
+    def test_extract_empty(self):
+        assert extract_prefixed_lines("") == []
+        assert extract_prefixed_lines("no prefixes here\nnothing") == []
+
+
+class TestResolvePath:
+    def test_resolve_claudemd_path(self, book_config):
+        path = resolve_claudemd_path(book_config, "my-book")
+        assert path.name == "CLAUDE.md"
+        assert path.parent.name == "my-book"
+
+
+class TestInitClaudemd:
+    def test_creates_file(self, book_config):
+        path = init_claudemd(
+            book_config,
+            PLUGIN_ROOT,
+            "my-book",
+            facts={"book_title": "My Book", "pov": "first", "genre": "fantasy"},
+        )
+        assert path.exists()
+        content = path.read_text(encoding="utf-8")
+        assert "# My Book" in content
+        assert "**POV:** first" in content
+        assert "**Genre:** fantasy" in content
+
+    def test_contains_section_markers(self, book_config):
+        path = init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        content = path.read_text(encoding="utf-8")
+        assert "<!-- RULES:START -->" in content
+        assert "<!-- RULES:END -->" in content
+        assert "<!-- CALLBACKS:START -->" in content
+        assert "<!-- WORKFLOW:START -->" in content
+
+    def test_missing_facts_render_as_dash(self, book_config):
+        path = init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        content = path.read_text(encoding="utf-8")
+        # book_title was not provided
+        assert "# —" in content
+
+    def test_refuses_overwrite_by_default(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        with pytest.raises(FileExistsError):
+            init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+
+    def test_overwrite_flag(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book", facts={"pov": "first"})
+        init_claudemd(
+            book_config,
+            PLUGIN_ROOT,
+            "my-book",
+            facts={"pov": "third"},
+            overwrite=True,
+        )
+        content = get_claudemd(book_config, "my-book")
+        assert "**POV:** third" in content
+        assert "**POV:** first" not in content
+
+
+class TestGetClaudemd:
+    def test_reads_content(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        content = get_claudemd(book_config, "my-book")
+        assert "<!-- RULES:END -->" in content
+
+    def test_raises_if_missing(self, book_config):
+        with pytest.raises(FileNotFoundError):
+            get_claudemd(book_config, "nonexistent")
+
+
+class TestAppendRule:
+    def test_appends_rule(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        append_rule(book_config, "my-book", "avoid passive voice")
+        content = get_claudemd(book_config, "my-book")
+        assert "avoid passive voice" in content
+
+    def test_rule_before_end_marker(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        append_rule(book_config, "my-book", "new rule")
+        content = get_claudemd(book_config, "my-book")
+        rule_pos = content.index("new rule")
+        end_pos = content.index("<!-- RULES:END -->")
+        assert rule_pos < end_pos
+
+    def test_rule_not_in_callbacks_section(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        append_rule(book_config, "my-book", "unique-rule-marker")
+        content = get_claudemd(book_config, "my-book")
+        callbacks_start = content.index("<!-- CALLBACKS:START -->")
+        callbacks_end = content.index("<!-- CALLBACKS:END -->")
+        callbacks_section = content[callbacks_start:callbacks_end]
+        assert "unique-rule-marker" not in callbacks_section
+
+    def test_multiple_rules(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        append_rule(book_config, "my-book", "first rule")
+        append_rule(book_config, "my-book", "second rule")
+        content = get_claudemd(book_config, "my-book")
+        assert "first rule" in content
+        assert "second rule" in content
+
+    def test_idempotent(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        append_rule(book_config, "my-book", "same rule")
+        append_rule(book_config, "my-book", "same rule")
+        content = get_claudemd(book_config, "my-book")
+        assert content.count("same rule") == 1
+
+    def test_empty_rejected(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        with pytest.raises(ValueError):
+            append_rule(book_config, "my-book", "   ")
+
+    def test_fails_if_not_initialized(self, book_config):
+        with pytest.raises(FileNotFoundError):
+            append_rule(book_config, "my-book", "something")
+
+
+class TestAppendWorkflow:
+    def test_appends_to_workflow_section(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        append_workflow(book_config, "my-book", "scene-by-scene")
+        content = get_claudemd(book_config, "my-book")
+        wf_start = content.index("<!-- WORKFLOW:START -->")
+        wf_end = content.index("<!-- WORKFLOW:END -->")
+        assert "scene-by-scene" in content[wf_start:wf_end]
+
+
+class TestAppendCallback:
+    def test_appends_to_callbacks_section(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        append_callback(book_config, "my-book", "Gary the cat")
+        content = get_claudemd(book_config, "my-book")
+        cb_start = content.index("<!-- CALLBACKS:START -->")
+        cb_end = content.index("<!-- CALLBACKS:END -->")
+        assert "Gary the cat" in content[cb_start:cb_end]
+
+    def test_callback_not_in_rules_section(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        append_callback(book_config, "my-book", "Gary-unique")
+        content = get_claudemd(book_config, "my-book")
+        rules_start = content.index("<!-- RULES:START -->")
+        rules_end = content.index("<!-- RULES:END -->")
+        assert "Gary-unique" not in content[rules_start:rules_end]
+
+
+class TestUpdateBookFacts:
+    def test_updates_writing_mode(self, book_config):
+        init_claudemd(
+            book_config,
+            PLUGIN_ROOT,
+            "my-book",
+            facts={"writing_mode": "chapter"},
+        )
+        update_book_facts(
+            book_config, "my-book", {"writing_mode": "scene-by-scene"}
+        )
+        content = get_claudemd(book_config, "my-book")
+        assert "**Writing Mode:** scene-by-scene" in content
+        # Header bullet should not retain old value.
+        assert content.count("**Writing Mode:** chapter") == 0
+
+    def test_updates_multiple_fields(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        update_book_facts(
+            book_config,
+            "my-book",
+            {"pov": "first", "tense": "present"},
+        )
+        content = get_claudemd(book_config, "my-book")
+        assert "**POV:** first" in content
+        assert "**Tense:** present" in content
+
+    def test_unknown_key_ignored(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        # Ephemeral keys no longer live in CLAUDE.md — silently ignored.
+        update_book_facts(book_config, "my-book", {"current_chapter": "01"})
+
+    def test_raises_if_missing(self, book_config):
+        with pytest.raises(FileNotFoundError):
+            update_book_facts(book_config, "nonexistent", {"pov": "first"})

--- a/tests/test_precompact_hook.py
+++ b/tests/test_precompact_hook.py
@@ -1,0 +1,125 @@
+"""Tests for the PreCompact CLAUDE.md sync hook."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hooks.precompact_sync_claudemd import (
+    _extract_user_text,
+    _read_transcript,
+    run,
+)
+from tools.claudemd.manager import get_claudemd, init_claudemd
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _write_transcript(path: Path, entries: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8"
+    )
+
+
+class TestReadTranscript:
+    def test_reads_jsonl(self, tmp_path):
+        path = tmp_path / "t.jsonl"
+        _write_transcript(
+            path, [{"type": "user", "message": {"content": "hi"}}, {"type": "assistant"}]
+        )
+        entries = _read_transcript(path)
+        assert len(entries) == 2
+
+    def test_missing_returns_empty(self, tmp_path):
+        assert _read_transcript(tmp_path / "nope.jsonl") == []
+
+    def test_skips_invalid_lines(self, tmp_path):
+        path = tmp_path / "t.jsonl"
+        path.write_text('{"valid": 1}\nnot-json\n{"valid": 2}\n', encoding="utf-8")
+        assert len(_read_transcript(path)) == 2
+
+
+class TestExtractUserText:
+    def test_string_content(self):
+        entries = [
+            {"type": "user", "message": {"content": "Regel: X"}},
+            {"type": "assistant", "message": {"content": "ignored"}},
+        ]
+        assert _extract_user_text(entries) == "Regel: X"
+
+    def test_block_content(self):
+        entries = [
+            {
+                "type": "user",
+                "message": {
+                    "content": [{"type": "text", "text": "Callback: Gary"}]
+                },
+            }
+        ]
+        assert _extract_user_text(entries) == "Callback: Gary"
+
+    def test_ignores_assistant(self):
+        entries = [{"type": "assistant", "message": {"content": "Regel: no"}}]
+        assert _extract_user_text(entries) == ""
+
+
+class TestRun:
+    @pytest.fixture
+    def book_setup(self, tmp_path):
+        """Set up a book with CLAUDE.md and a mock state.json pointing to it."""
+        content_root = tmp_path / "books"
+        book_dir = content_root / "projects" / "test-book"
+        book_dir.mkdir(parents=True)
+        (book_dir / "README.md").write_text("# Test Book\n", encoding="utf-8")
+
+        state_path = tmp_path / "state.json"
+        state_path.write_text(
+            json.dumps({"session": {"last_book": "test-book"}}),
+            encoding="utf-8",
+        )
+
+        config = {"paths": {"content_root": str(content_root)}}
+        init_claudemd(config, PLUGIN_ROOT, "test-book", facts={"pov": "first"})
+
+        return {"config": config, "state_path": state_path}
+
+    def test_extracts_and_persists(self, book_setup, tmp_path):
+        transcript = tmp_path / "transcript.jsonl"
+        _write_transcript(
+            transcript,
+            [
+                {"type": "user", "message": {"content": "Regel: keep it tight"}},
+                {"type": "user", "message": {"content": "Callback: Gary the cat"}},
+                {"type": "user", "message": {"content": "just chatting"}},
+            ],
+        )
+
+        with patch(
+            "tools.shared.config.STATE_PATH", book_setup["state_path"]
+        ), patch(
+            "tools.shared.config.load_config", return_value=book_setup["config"]
+        ):
+            result = run({"transcript_path": str(transcript)})
+
+        assert result["book"] == "test-book"
+        assert result["counts"]["rule"] == 1
+        assert result["counts"]["callback"] == 1
+        assert result["counts"]["workflow"] == 0
+
+        content = get_claudemd(book_setup["config"], "test-book")
+        assert "keep it tight" in content
+        assert "Gary the cat" in content
+
+    def test_skip_no_transcript(self):
+        assert run({}) == {"skipped": "no transcript_path"}
+
+    def test_skip_no_session(self, tmp_path):
+        transcript = tmp_path / "transcript.jsonl"
+        transcript.write_text("", encoding="utf-8")
+        missing_state = tmp_path / "nonexistent-state.json"
+        with patch("tools.shared.config.STATE_PATH", missing_state):
+            result = run({"transcript_path": str(transcript)})
+        assert result == {"skipped": "no active book in session"}

--- a/tools/claudemd/__init__.py
+++ b/tools/claudemd/__init__.py
@@ -1,0 +1,43 @@
+"""Per-book CLAUDE.md management.
+
+Provides functions to initialize and maintain a CLAUDE.md file in each book
+project root that persists workflow rules, callbacks, and book facts across
+Claude Code sessions.
+
+The file is structured with HTML-comment markers that allow deterministic
+appending without parsing markdown:
+
+    <!-- RULES:START -->
+    <!-- RULES:END -->
+
+User-facing prefixes (Regel:, Workflow:, Callback:) are extracted by the
+PreCompact hook and persisted via these functions.
+"""
+
+from tools.claudemd.manager import (
+    append_callback,
+    append_rule,
+    append_workflow,
+    get_claudemd,
+    init_claudemd,
+    resolve_claudemd_path,
+    update_book_facts,
+)
+from tools.claudemd.parser import (
+    SECTION_MARKERS,
+    extract_prefixed_lines,
+    parse_prefixed_entry,
+)
+
+__all__ = [
+    "SECTION_MARKERS",
+    "append_callback",
+    "append_rule",
+    "append_workflow",
+    "extract_prefixed_lines",
+    "get_claudemd",
+    "init_claudemd",
+    "parse_prefixed_entry",
+    "resolve_claudemd_path",
+    "update_book_facts",
+]

--- a/tools/claudemd/manager.py
+++ b/tools/claudemd/manager.py
@@ -1,0 +1,179 @@
+"""Read and mutate per-book CLAUDE.md files.
+
+CLAUDE.md lives at ``{book_root}/CLAUDE.md`` and contains workflow rules,
+callback register entries, and book facts. Appending to a section is a
+deterministic string operation using HTML-comment markers to avoid markdown
+parsing.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from tools.claudemd.parser import SECTION_MARKERS, EntryKind
+from tools.shared.paths import resolve_project_path
+
+CLAUDE_MD_FILENAME = "CLAUDE.md"
+DEFAULT_TEMPLATE_REL = "templates/book-claude-md.template"
+
+
+def resolve_claudemd_path(config: dict[str, Any], book_slug: str) -> Path:
+    """Return the absolute path to a book's CLAUDE.md file."""
+    return resolve_project_path(config, book_slug) / CLAUDE_MD_FILENAME
+
+
+def _load_template(plugin_root: Path) -> str:
+    template_path = plugin_root / DEFAULT_TEMPLATE_REL
+    if not template_path.exists():
+        raise FileNotFoundError(f"CLAUDE.md template missing: {template_path}")
+    return template_path.read_text(encoding="utf-8")
+
+
+def _render_template(template: str, facts: dict[str, str]) -> str:
+    """Replace ``{{key}}`` placeholders with values from ``facts``.
+
+    Missing keys are replaced with an em-dash so the output stays readable.
+    """
+    def replace(match: re.Match[str]) -> str:
+        key = match.group(1).strip()
+        return facts.get(key, "—")
+
+    return re.sub(r"\{\{\s*([a-z_]+)\s*\}\}", replace, template)
+
+
+def init_claudemd(
+    config: dict[str, Any],
+    plugin_root: Path,
+    book_slug: str,
+    facts: dict[str, str] | None = None,
+    overwrite: bool = False,
+) -> Path:
+    """Create ``CLAUDE.md`` for a book from the template.
+
+    Returns the path to the written file. Raises ``FileExistsError`` if the
+    file already exists and ``overwrite`` is ``False``.
+    """
+    target = resolve_claudemd_path(config, book_slug)
+    if target.exists() and not overwrite:
+        raise FileExistsError(f"CLAUDE.md already exists: {target}")
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    template = _load_template(plugin_root)
+    rendered = _render_template(template, facts or {})
+    target.write_text(rendered, encoding="utf-8")
+    return target
+
+
+def get_claudemd(config: dict[str, Any], book_slug: str) -> str:
+    """Return the current CLAUDE.md content for a book."""
+    path = resolve_claudemd_path(config, book_slug)
+    if not path.exists():
+        raise FileNotFoundError(f"CLAUDE.md not found for book '{book_slug}': {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _insert_before_marker(content: str, marker_end: str, new_line: str) -> str:
+    """Insert ``new_line`` on its own line before the end-marker.
+
+    Raises ``ValueError`` if the marker is not present.
+    """
+    if marker_end not in content:
+        raise ValueError(f"End marker not found in CLAUDE.md: {marker_end}")
+
+    # Keep a newline before the marker; avoid duplicate blank lines.
+    replacement = f"{new_line}\n{marker_end}"
+    return content.replace(marker_end, replacement, 1)
+
+
+def _append_entry(
+    config: dict[str, Any],
+    book_slug: str,
+    kind: EntryKind,
+    text: str,
+) -> Path:
+    """Append a single entry to the appropriate section."""
+    text = text.strip()
+    if not text:
+        raise ValueError("Entry text must not be empty")
+
+    path = resolve_claudemd_path(config, book_slug)
+    if not path.exists():
+        raise FileNotFoundError(
+            f"CLAUDE.md not found for book '{book_slug}'. Call init_claudemd first."
+        )
+
+    _, end_marker = SECTION_MARKERS[kind]
+    content = path.read_text(encoding="utf-8")
+
+    today = date.today().isoformat()
+    bullet = f"- {text} _(added {today})_"
+
+    # Idempotency: same bullet text (ignoring date) already present → skip.
+    existing_pattern = re.escape(f"- {text} ")
+    if re.search(existing_pattern, content):
+        return path
+
+    updated = _insert_before_marker(content, end_marker, bullet)
+    path.write_text(updated, encoding="utf-8")
+    return path
+
+
+def append_rule(config: dict[str, Any], book_slug: str, text: str) -> Path:
+    """Append a rule entry to CLAUDE.md."""
+    return _append_entry(config, book_slug, "rule", text)
+
+
+def append_workflow(config: dict[str, Any], book_slug: str, text: str) -> Path:
+    """Append a workflow entry to CLAUDE.md."""
+    return _append_entry(config, book_slug, "workflow", text)
+
+
+def append_callback(config: dict[str, Any], book_slug: str, text: str) -> Path:
+    """Append a callback entry to CLAUDE.md."""
+    return _append_entry(config, book_slug, "callback", text)
+
+
+# Matches "- **Key:** value" lines in the Book Facts section.
+_FACT_LINE_RE = re.compile(
+    r"^(?P<prefix>- \*\*(?P<label>[^*:]+):\*\*\s*).*$",
+    re.MULTILINE,
+)
+
+_FACT_LABEL_MAP = {
+    "pov": "POV",
+    "tense": "Tense",
+    "genre": "Genre",
+    "writing_mode": "Writing Mode",
+}
+
+
+def update_book_facts(
+    config: dict[str, Any],
+    book_slug: str,
+    facts: dict[str, str],
+) -> Path:
+    """Update one or more Book Facts fields in CLAUDE.md.
+
+    ``facts`` maps internal keys (e.g. ``"current_chapter"``) to new values.
+    Keys not present in the label map are ignored.
+    """
+    path = resolve_claudemd_path(config, book_slug)
+    if not path.exists():
+        raise FileNotFoundError(f"CLAUDE.md not found for book '{book_slug}'")
+
+    content = path.read_text(encoding="utf-8")
+
+    def replace(match: re.Match[str]) -> str:
+        label = match.group("label").strip()
+        # Find which key maps to this label (reverse lookup).
+        for key, mapped_label in _FACT_LABEL_MAP.items():
+            if mapped_label == label and key in facts:
+                return f"{match.group('prefix')}{facts[key]}"
+        return match.group(0)
+
+    updated = _FACT_LINE_RE.sub(replace, content)
+    path.write_text(updated, encoding="utf-8")
+    return path

--- a/tools/claudemd/parser.py
+++ b/tools/claudemd/parser.py
@@ -1,0 +1,65 @@
+"""Parse user messages for CLAUDE.md-relevant prefixes.
+
+Deterministic extraction — no LLM calls. Recognized prefixes:
+
+- ``Regel:`` — a new book-scoped rule
+- ``Workflow:`` — a new workflow instruction
+- ``Callback:`` — a character, object, or plot thread to recur later
+
+Lines without one of these prefixes are ignored.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+EntryKind = Literal["rule", "workflow", "callback"]
+
+PREFIX_MAP: dict[str, EntryKind] = {
+    "regel": "rule",
+    "rule": "rule",
+    "workflow": "workflow",
+    "callback": "callback",
+}
+
+SECTION_MARKERS: dict[EntryKind, tuple[str, str]] = {
+    "rule": ("<!-- RULES:START -->", "<!-- RULES:END -->"),
+    "workflow": ("<!-- WORKFLOW:START -->", "<!-- WORKFLOW:END -->"),
+    "callback": ("<!-- CALLBACKS:START -->", "<!-- CALLBACKS:END -->"),
+}
+
+_PREFIX_RE = re.compile(
+    r"^\s*(?P<prefix>regel|rule|workflow|callback)\s*:\s*(?P<body>.+?)\s*$",
+    re.IGNORECASE,
+)
+
+
+def parse_prefixed_entry(line: str) -> tuple[EntryKind, str] | None:
+    """Parse a single line for a prefix entry.
+
+    Returns ``(kind, text)`` tuple or ``None`` if the line has no recognized
+    prefix. The prefix itself is stripped from the returned text.
+    """
+    match = _PREFIX_RE.match(line)
+    if not match:
+        return None
+    kind = PREFIX_MAP[match.group("prefix").lower()]
+    body = match.group("body").strip()
+    if not body:
+        return None
+    return kind, body
+
+
+def extract_prefixed_lines(text: str) -> list[tuple[EntryKind, str]]:
+    """Extract all prefixed entries from a multi-line text block.
+
+    Scans each line independently. Multi-line entries are not supported;
+    users must put the entire entry on one line after the prefix.
+    """
+    results: list[tuple[EntryKind, str]] = []
+    for raw_line in text.splitlines():
+        entry = parse_prefixed_entry(raw_line)
+        if entry is not None:
+            results.append(entry)
+    return results


### PR DESCRIPTION
## Summary

Persist book-scoped context across Claude Code sessions. Solves #6.

- Messages prefixed with \`Regel:\`, \`Workflow:\`, or \`Callback:\` are deterministically extracted by a PreCompact hook and appended to the book's \`CLAUDE.md\`. No LLM call — pure regex, zero token overhead.
- 7 new MCP tools (\`init_book_claudemd\`, \`get_book_claudemd\`, \`append_book_rule/workflow/callback\`, \`update_book_claudemd_facts\`, \`sync_book_claudemd_from_text\`).
- New skill \`/storyforge:register-callback\` for manual entries.
- \`chapter-writer\` and \`chapter-reviewer\` now load CLAUDE.md as a mandatory prerequisite; \`resume\` surfaces a summary.
- Ephemeral state (current chapter, next beat) stays in the session cache — only stable facts live in CLAUDE.md to avoid stale hand-maintained fields.

## Test plan

- [x] 42 new tests (parser, manager, PreCompact hook) — all green
- [x] Full suite: 96/96 passing
- [x] Manual: run \`/storyforge:new-book\` → verify CLAUDE.md scaffolded
- [x] Manual: type \`Callback: X\` in a session, trigger compaction → verify entry persisted
- [x] Manual: \`/storyforge:resume\` shows CLAUDE.md summary

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)