### PR TITLE
feat: add per-idea file state management with status progression

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ Use MCP tools for ALL state operations. Never parse project files directly in sk
 |------------|-------|
 | "New book" / "Neues Buch" | `/storyforge:new-book` IMMEDIATELY |
 | "Brainstorm" / "Idee" / "Was könnte ich schreiben?" | `/storyforge:brainstorm` |
+| "Meine Ideen" / "Ideas" / "Was habe ich gespeichert?" | `/storyforge:ideas` |
 | Book title/name mentioned | `/storyforge:resume [name]` |
 | "What's next?" / "Was steht an?" | `/storyforge:next-step` |
 | "Dashboard" / "Status" / "Fortschritt" | `/storyforge:book-dashboard` |

--- a/servers/storyforge-server/server.py
+++ b/servers/storyforge-server/server.py
@@ -9,6 +9,8 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 # Ensure tools directory is on path
 plugin_root = os.environ.get(
     "CLAUDE_PLUGIN_ROOT", str(Path(__file__).resolve().parent.parent.parent)
@@ -790,38 +792,191 @@ def add_book_to_series(series_slug: str, book_slug: str, number: int) -> str:
 # ============================================================
 
 
+def _get_ideas_dir(config: dict) -> Path:
+    """Return the ideas directory path for the current content root."""
+    return get_content_root(config) / "ideas"
+
+
+def _idea_path(ideas_dir: Path, slug: str) -> Path:
+    """Return the file path for a given idea slug."""
+    return ideas_dir / f"{slug}.md"
+
+
+def _read_idea(ideas_dir: Path, slug: str) -> tuple[dict, str] | None:
+    """Read and parse an idea file. Returns (meta, body) or None if not found."""
+    path = _idea_path(ideas_dir, slug)
+    if not path.exists():
+        return None
+    return parse_frontmatter(path.read_text(encoding="utf-8"))
+
+
+def _write_idea(path: Path, meta: dict, body: str) -> None:
+    """Write frontmatter + body back to an idea file."""
+    frontmatter = yaml.dump(meta, allow_unicode=True, sort_keys=False, default_flow_style=False)
+    path.write_text(f"---\n{frontmatter}---\n\n{body}", encoding="utf-8")
+
+
 @mcp.tool()
-def create_idea(title: str, genres: str = "", concept: str = "") -> str:
-    """Save a book idea to IDEAS.md."""
+def create_idea(title: str, genres: str = "", logline: str = "", concept: str = "") -> str:
+    """Create a new idea file in ideas/{slug}.md with YAML frontmatter.
+
+    Args:
+        title:   Human-readable title of the idea.
+        genres:  Comma-separated genre names (e.g. "fantasy,mystery").
+        logline: One-sentence pitch.
+        concept: Free-text body content describing the idea.
+    """
     config = load_config()
-    ideas_file = get_content_root(config) / "IDEAS.md"
-    ideas_file.parent.mkdir(parents=True, exist_ok=True)
+    ideas_dir = _get_ideas_dir(config)
+    ideas_dir.mkdir(parents=True, exist_ok=True)
 
-    entry = f"\n## {title}\n\n"
-    if genres:
-        entry += f"**Genres:** {genres}\n\n"
-    if concept:
-        entry += f"{concept}\n"
-    entry += f"\n*Added: {date.today().isoformat()}*\n"
+    slug = slugify(title)
+    genres_list = [g.strip() for g in genres.split(",") if g.strip()] if genres else []
+    today = date.today().isoformat()
 
-    if ideas_file.exists():
-        content = ideas_file.read_text(encoding="utf-8")
-    else:
-        content = "# Book Ideas\n"
+    meta: dict[str, Any] = {
+        "title": title,
+        "slug": slug,
+        "status": "raw",
+        "genres": genres_list,
+        "logline": logline,
+        "created": today,
+        "last_touched": today,
+        "promoted_to": None,
+    }
 
-    content += entry
-    ideas_file.write_text(content, encoding="utf-8")
+    path = _idea_path(ideas_dir, slug)
+    _write_idea(path, meta, concept)
 
     _cache.invalidate()
-    return json.dumps({"success": True, "title": title})
+    return json.dumps({"slug": slug, "title": title, "file_path": str(path)})
 
 
 @mcp.tool()
-def list_ideas() -> str:
-    """List all book ideas from IDEAS.md."""
-    state = _cache.get()
-    ideas = state.get("ideas", [])
+def list_ideas(status: str = "", genre: str = "") -> str:
+    """List all ideas from the ideas/ directory, with optional filters.
+
+    Args:
+        status: Filter by exact status value (e.g. "raw", "explored").
+        genre:  Filter by genre (partial match against each idea's genres list).
+    """
+    config = load_config()
+    ideas_dir = _get_ideas_dir(config)
+
+    if not ideas_dir.exists():
+        return json.dumps({"ideas": [], "count": 0})
+
+    ideas = []
+    for md_file in sorted(ideas_dir.glob("*.md")):
+        if not md_file.is_file():
+            continue
+        try:
+            meta, _ = parse_frontmatter(md_file.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if not meta:
+            continue
+
+        idea_status = meta.get("status", "raw")
+        idea_genres = meta.get("genres", [])
+
+        if status and idea_status != status:
+            continue
+        if genre and genre not in idea_genres:
+            continue
+
+        ideas.append({
+            "slug": meta.get("slug", md_file.stem),
+            "title": meta.get("title", md_file.stem),
+            "status": idea_status,
+            "genres": idea_genres,
+            "logline": meta.get("logline", ""),
+            "created": str(meta.get("created", "")),
+            "last_touched": str(meta.get("last_touched", "")),
+            "promoted_to": meta.get("promoted_to"),
+        })
+
     return json.dumps({"ideas": ideas, "count": len(ideas)})
+
+
+@mcp.tool()
+def get_idea(slug: str) -> str:
+    """Return the full content of a single idea file.
+
+    Args:
+        slug: The idea's slug (filename without .md extension).
+    """
+    config = load_config()
+    ideas_dir = _get_ideas_dir(config)
+    result = _read_idea(ideas_dir, slug)
+
+    if result is None:
+        return json.dumps({"error": f"Idea '{slug}' not found"})
+
+    meta, body = result
+    return json.dumps({
+        "slug": meta.get("slug", slug),
+        "title": meta.get("title", slug),
+        "status": meta.get("status", "raw"),
+        "genres": meta.get("genres", []),
+        "logline": meta.get("logline", ""),
+        "created": str(meta.get("created", "")),
+        "last_touched": str(meta.get("last_touched", "")),
+        "promoted_to": meta.get("promoted_to"),
+        "body": body.strip(),
+    })
+
+
+@mcp.tool()
+def update_idea(slug: str, field: str, value: str) -> str:
+    """Update a single frontmatter field of an existing idea.
+
+    Args:
+        slug:  The idea's slug.
+        field: The frontmatter key to update (e.g. "status", "logline").
+        value: The new value as a string.
+    """
+    config = load_config()
+    ideas_dir = _get_ideas_dir(config)
+    result = _read_idea(ideas_dir, slug)
+
+    if result is None:
+        return json.dumps({"error": f"Idea '{slug}' not found"})
+
+    meta, body = result
+    meta[field] = value
+    meta["last_touched"] = date.today().isoformat()
+
+    _write_idea(_idea_path(ideas_dir, slug), meta, body)
+    _cache.invalidate()
+    return json.dumps({"success": True, "slug": slug, "field": field, "value": value})
+
+
+@mcp.tool()
+def promote_idea(slug: str, book_slug: str) -> str:
+    """Mark an idea as promoted and link it to a book project.
+
+    Sets status to "promoted" and records the book slug in promoted_to.
+
+    Args:
+        slug:      The idea's slug.
+        book_slug: The slug of the book project this idea was turned into.
+    """
+    config = load_config()
+    ideas_dir = _get_ideas_dir(config)
+    result = _read_idea(ideas_dir, slug)
+
+    if result is None:
+        return json.dumps({"error": f"Idea '{slug}' not found"})
+
+    meta, body = result
+    meta["status"] = "promoted"
+    meta["promoted_to"] = book_slug
+    meta["last_touched"] = date.today().isoformat()
+
+    _write_idea(_idea_path(ideas_dir, slug), meta, body)
+    _cache.invalidate()
+    return json.dumps({"success": True, "slug": slug, "promoted_to": book_slug})
 
 
 # ============================================================

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -38,13 +38,25 @@ Once the user picks a direction:
 - **Comparable titles:** "X meets Y"
 
 ### Phase 4: Save
-Save the idea via MCP `create_idea()` with title, genres, and concept.
+Save the idea via MCP `create_idea()` with title, genres, logline, and concept body.
 
-Ask: "Ready to turn this into a project? → `/storyforge:new-book`"
-Or: "Want to let it marinate and brainstorm another?"
+The idea gets status `raw` by default. If the user has fully developed it (logline + themes + comps),
+call `update_idea(slug, "status", "explored")` immediately after saving.
+
+Tell the user the slug so they can reference it later: "Saved as `{slug}`."
+
+Ask: "Ready to turn this into a project? → `/storyforge:new-book --from-idea {slug}`"
+Or: "Want to let it marinate? Check your ideas with `/storyforge:ideas`."
+
+### Phase 5: Resuming an idea (optional)
+If the user returns to an existing idea (e.g. "continue the clockmaker idea"):
+1. Load it via MCP `get_idea(slug)`
+2. Continue development from where it left off
+3. Update fields via `update_idea()` as the concept grows
 
 ## Rules
 - Be provocative and unexpected. Don't offer safe, generic ideas.
 - Push the user toward specificity — "a vampire story" is not enough. WHOSE vampire story? What makes it THEIRS?
 - Mix genres freely. The best ideas live at intersections.
 - Always save ideas — even rejected ones might resurface later.
+- Always fill in the logline before saving — a vague idea without a logline is hard to revisit.

--- a/skills/ideas/SKILL.md
+++ b/skills/ideas/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: ideas
+description: |
+  List, filter, and manage book ideas. Shows ideas by status and genre.
+  Use when: (1) User says "meine Ideen", "ideas", "was habe ich gespeichert",
+  (2) User wants to pick up a parked idea, (3) User asks what ideas are ready.
+model: claude-haiku-4-5-20251001
+user-invocable: true
+argument-hint: "[status] [genre]"
+---
+
+# Ideas Dashboard
+
+## Workflow
+
+### 1. Load ideas
+Call MCP `list_ideas()` with optional filters:
+- If user provided a status argument (e.g. "ready", "explored"), pass it as `status`
+- If user mentioned a genre, pass it as `genre`
+- Default: load all ideas (no filters)
+
+### 2. Display
+
+If no ideas exist:
+```
+No ideas saved yet. Start with `/storyforge:brainstorm` to capture your first one.
+```
+
+Otherwise, group by status in this order:
+`ready` → `developed` → `explored` → `raw` → `shelved` → `promoted`
+
+For each idea, show:
+```
+**{title}** (`{slug}`) — {status}
+Genres: {genres}
+{logline}
+```
+
+Show counts per group. Example:
+```
+## Ready (1)
+## Explored (3)
+## Raw (5)
+```
+
+### 3. Offer actions
+
+After listing, offer contextual follow-ups:
+- If any `ready` ideas exist: "Turn an idea into a book: `/storyforge:new-book --from-idea {slug}`"
+- If any `raw` ideas exist: "Develop a raw idea further: `/storyforge:brainstorm` (mention the slug)"
+- Always: "Filter by status: `/storyforge:ideas ready`"
+
+### 4. Single idea view
+
+If user asks about a specific idea (e.g. "show me the clockmaker idea"):
+1. Call `get_idea(slug)` or find the matching slug from the list
+2. Show full details including body content
+3. Offer: update status, continue brainstorming, or promote to book
+
+### 5. Status update (inline)
+
+If user says "mark X as developed" or "shelve the clockmaker idea":
+1. Call `update_idea(slug, "status", new_status)`
+2. Confirm the change
+
+## Rules
+- This is a read-mostly skill — be fast, don't over-explain
+- `promoted` ideas should be greyed out / shown last — they're done
+- `shelved` ideas: show them but make clear they're parked, not abandoned
+- Never delete ideas — only shelve them

--- a/skills/new-book/SKILL.md
+++ b/skills/new-book/SKILL.md
@@ -13,6 +13,13 @@ argument-hint: "[title]"
 
 ## Workflow
 
+### If called with `--from-idea {slug}`
+1. Load the idea via MCP `get_idea(slug)`
+2. Pre-fill title, genres, and logline from the idea's frontmatter
+3. Skip re-asking for fields that are already populated (ask only for missing ones)
+4. After creating the book, call MCP `promote_idea(slug, book_slug)` to mark the idea as promoted
+
+### Standard flow
 1. **Gather information** — Ask the user (use AskUserQuestion):
    - **Title** — What's the working title?
    - **Genre(s)** — Show available genres via MCP `list_genres()`. Allow 1-3 selections. Mention genre-mixing.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,3 +7,7 @@ from pathlib import Path
 plugin_root = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(plugin_root / "tools"))
 sys.path.insert(0, str(plugin_root))
+
+# The MCP server directory has a hyphen in its name, which is not a valid Python
+# module identifier. Add it directly to sys.path so tests can import it as "server".
+sys.path.insert(0, str(plugin_root / "servers" / "storyforge-server"))

--- a/tests/test_ideas.py
+++ b/tests/test_ideas.py
@@ -1,0 +1,336 @@
+"""Tests for the per-file idea state management system (Issue #8).
+
+Tests cover:
+- 5 new MCP tools: create_idea, list_ideas, get_idea, update_idea, promote_idea
+- New _scan_ideas_dir() indexer helper
+- Filtering by status and genre
+- Promotion workflow
+- Frontmatter updates
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools.state.indexer import _scan_ideas_dir
+from tools.state.parsers import parse_frontmatter
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def content_root(tmp_path: Path) -> Path:
+    """Provide a temporary content root directory."""
+    root = tmp_path / "content"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def mock_config(content_root: Path):
+    """Patch load_config in both server and indexer modules to point at tmp_path."""
+    fake_config = {
+        "paths": {
+            "content_root": str(content_root),
+            "authors_root": str(content_root / "authors"),
+        },
+        "defaults": {"language": "en", "book_type": "novel"},
+    }
+
+    # Import by plain name — conftest.py adds the server directory to sys.path
+    import server as server_mod  # noqa: WPS433
+
+    with patch.object(server_mod, "load_config", return_value=fake_config), \
+         patch.object(server_mod, "get_content_root", return_value=content_root):
+        # Invalidate the cache so subsequent reads re-scan the new content root
+        server_mod._cache.invalidate()
+        yield fake_config
+
+
+@pytest.fixture
+def server_module(mock_config):
+    """Return the storyforge server module with config mocked."""
+    import server as server_mod  # noqa: WPS433
+    return server_mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_idea_file(
+    ideas_dir: Path,
+    slug: str,
+    title: str,
+    status: str = "raw",
+    genres: list[str] | None = None,
+    logline: str = "",
+    body: str = "",
+    promoted_to: str | None = None,
+) -> Path:
+    """Write a minimal idea file for tests."""
+    ideas_dir.mkdir(parents=True, exist_ok=True)
+    path = ideas_dir / f"{slug}.md"
+    genres_yaml = "[" + ", ".join(f'"{g}"' for g in (genres or [])) + "]"
+    promoted_line = f'"{promoted_to}"' if promoted_to else "null"
+    content = (
+        "---\n"
+        f'title: "{title}"\n'
+        f'slug: "{slug}"\n'
+        f'status: "{status}"\n'
+        f"genres: {genres_yaml}\n"
+        f'logline: "{logline}"\n'
+        f"created: {date.today().isoformat()}\n"
+        f"last_touched: {date.today().isoformat()}\n"
+        f"promoted_to: {promoted_line}\n"
+        "---\n\n"
+        f"{body}\n"
+    )
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# create_idea
+# ---------------------------------------------------------------------------
+
+
+class TestCreateIdea:
+    def test_creates_file_with_frontmatter(self, server_module, content_root: Path):
+        result = json.loads(
+            server_module.create_idea(
+                title="The Glass Clockmaker",
+                genres="fantasy,mystery",
+                logline="A clockmaker discovers his creations predict deaths.",
+                concept="A dark tale of horology and fate.",
+            )
+        )
+
+        assert result["slug"] == "the-glass-clockmaker"
+        assert result["title"] == "The Glass Clockmaker"
+        ideas_file = content_root / "ideas" / "the-glass-clockmaker.md"
+        assert ideas_file.exists()
+        assert result["file_path"] == str(ideas_file)
+
+        text = ideas_file.read_text(encoding="utf-8")
+        meta, body = parse_frontmatter(text)
+        assert meta["title"] == "The Glass Clockmaker"
+        assert meta["slug"] == "the-glass-clockmaker"
+        assert meta["status"] == "raw"
+        assert meta["genres"] == ["fantasy", "mystery"]
+        assert meta["logline"] == "A clockmaker discovers his creations predict deaths."
+        assert meta["promoted_to"] is None
+        assert "horology" in body
+
+    def test_creates_ideas_dir_if_missing(self, server_module, content_root: Path):
+        assert not (content_root / "ideas").exists()
+        server_module.create_idea(title="Spark")
+        assert (content_root / "ideas").is_dir()
+
+    def test_empty_genres_and_logline_defaults(self, server_module, content_root: Path):
+        server_module.create_idea(title="Bare Idea")
+        path = content_root / "ideas" / "bare-idea.md"
+        meta, _ = parse_frontmatter(path.read_text(encoding="utf-8"))
+        assert meta["genres"] == []
+        assert meta["logline"] == ""
+
+    def test_slug_is_unique_stable(self, server_module, content_root: Path):
+        result = json.loads(server_module.create_idea(title="Hello World"))
+        assert result["slug"] == "hello-world"
+
+
+# ---------------------------------------------------------------------------
+# list_ideas
+# ---------------------------------------------------------------------------
+
+
+class TestListIdeas:
+    def test_lists_all_ideas(self, server_module, content_root: Path):
+        ideas_dir = content_root / "ideas"
+        _write_idea_file(ideas_dir, "one", "One", status="raw")
+        _write_idea_file(ideas_dir, "two", "Two", status="explored")
+
+        result = json.loads(server_module.list_ideas())
+        assert result["count"] == 2
+        slugs = {i["slug"] for i in result["ideas"]}
+        assert slugs == {"one", "two"}
+
+    def test_empty_when_no_ideas(self, server_module):
+        result = json.loads(server_module.list_ideas())
+        assert result["count"] == 0
+        assert result["ideas"] == []
+
+    def test_filter_by_status(self, server_module, content_root: Path):
+        ideas_dir = content_root / "ideas"
+        _write_idea_file(ideas_dir, "raw-one", "Raw One", status="raw")
+        _write_idea_file(ideas_dir, "raw-two", "Raw Two", status="raw")
+        _write_idea_file(ideas_dir, "explored", "Explored", status="explored")
+
+        result = json.loads(server_module.list_ideas(status="raw"))
+        assert result["count"] == 2
+        assert all(i["status"] == "raw" for i in result["ideas"])
+
+    def test_filter_by_genre(self, server_module, content_root: Path):
+        ideas_dir = content_root / "ideas"
+        _write_idea_file(ideas_dir, "a", "A", genres=["fantasy", "mystery"])
+        _write_idea_file(ideas_dir, "b", "B", genres=["sci-fi"])
+        _write_idea_file(ideas_dir, "c", "C", genres=["fantasy"])
+
+        result = json.loads(server_module.list_ideas(genre="fantasy"))
+        assert result["count"] == 2
+        slugs = {i["slug"] for i in result["ideas"]}
+        assert slugs == {"a", "c"}
+
+    def test_excludes_archive(self, server_module, content_root: Path):
+        ideas_dir = content_root / "ideas"
+        archive_dir = ideas_dir / "_archive"
+        _write_idea_file(ideas_dir, "active", "Active")
+        _write_idea_file(archive_dir, "shelved", "Shelved", status="shelved")
+
+        result = json.loads(server_module.list_ideas())
+        slugs = {i["slug"] for i in result["ideas"]}
+        assert slugs == {"active"}
+
+
+# ---------------------------------------------------------------------------
+# get_idea
+# ---------------------------------------------------------------------------
+
+
+class TestGetIdea:
+    def test_returns_full_idea(self, server_module, content_root: Path):
+        ideas_dir = content_root / "ideas"
+        _write_idea_file(
+            ideas_dir, "clockmaker", "The Clockmaker",
+            status="explored", genres=["fantasy"],
+            logline="Clocks predict deaths.",
+            body="A rich body describing the concept.",
+        )
+
+        result = json.loads(server_module.get_idea("clockmaker"))
+        assert result["slug"] == "clockmaker"
+        assert result["title"] == "The Clockmaker"
+        assert result["status"] == "explored"
+        assert result["genres"] == ["fantasy"]
+        assert result["logline"] == "Clocks predict deaths."
+        assert "rich body" in result["body"]
+
+    def test_unknown_slug_returns_error(self, server_module):
+        result = json.loads(server_module.get_idea("does-not-exist"))
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# update_idea
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateIdea:
+    def test_updates_status(self, server_module, content_root: Path):
+        ideas_dir = content_root / "ideas"
+        _write_idea_file(ideas_dir, "x", "X", status="raw")
+
+        result = json.loads(server_module.update_idea("x", "status", "explored"))
+        assert result["success"] is True
+
+        meta, _ = parse_frontmatter(
+            (ideas_dir / "x.md").read_text(encoding="utf-8")
+        )
+        assert meta["status"] == "explored"
+
+    def test_updates_logline(self, server_module, content_root: Path):
+        ideas_dir = content_root / "ideas"
+        _write_idea_file(ideas_dir, "x", "X", logline="old")
+
+        server_module.update_idea("x", "logline", "new logline")
+        meta, _ = parse_frontmatter(
+            (ideas_dir / "x.md").read_text(encoding="utf-8")
+        )
+        assert meta["logline"] == "new logline"
+
+    def test_preserves_body(self, server_module, content_root: Path):
+        ideas_dir = content_root / "ideas"
+        _write_idea_file(ideas_dir, "x", "X", body="Body stays intact.")
+
+        server_module.update_idea("x", "status", "developed")
+        _, body = parse_frontmatter((ideas_dir / "x.md").read_text(encoding="utf-8"))
+        assert "Body stays intact." in body
+
+    def test_unknown_slug(self, server_module):
+        result = json.loads(server_module.update_idea("nope", "status", "raw"))
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# promote_idea
+# ---------------------------------------------------------------------------
+
+
+class TestPromoteIdea:
+    def test_sets_status_and_promoted_to(self, server_module, content_root: Path):
+        ideas_dir = content_root / "ideas"
+        _write_idea_file(ideas_dir, "seed", "Seed", status="ready")
+
+        result = json.loads(server_module.promote_idea("seed", "my-book"))
+        assert result["success"] is True
+
+        meta, _ = parse_frontmatter(
+            (ideas_dir / "seed.md").read_text(encoding="utf-8")
+        )
+        assert meta["status"] == "promoted"
+        assert meta["promoted_to"] == "my-book"
+
+    def test_unknown_slug(self, server_module):
+        result = json.loads(server_module.promote_idea("nope", "book"))
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# _scan_ideas_dir (indexer)
+# ---------------------------------------------------------------------------
+
+
+class TestScanIdeasDir:
+    def test_scans_all_idea_files(self, content_root: Path):
+        ideas_dir = content_root / "ideas"
+        _write_idea_file(ideas_dir, "one", "One", status="raw")
+        _write_idea_file(ideas_dir, "two", "Two", status="explored", genres=["fantasy"])
+
+        result = _scan_ideas_dir(ideas_dir)
+        assert len(result) == 2
+        by_slug = {i["slug"]: i for i in result}
+        assert by_slug["one"]["status"] == "raw"
+        assert by_slug["two"]["genres"] == ["fantasy"]
+
+    def test_ignores_archive_subdir(self, content_root: Path):
+        ideas_dir = content_root / "ideas"
+        _write_idea_file(ideas_dir, "active", "Active")
+        _write_idea_file(ideas_dir / "_archive", "shelved", "Shelved", status="shelved")
+
+        result = _scan_ideas_dir(ideas_dir)
+        slugs = {i["slug"] for i in result}
+        assert slugs == {"active"}
+
+    def test_returns_empty_list_for_missing_dir(self, content_root: Path):
+        missing = content_root / "nonexistent"
+        result = _scan_ideas_dir(missing)
+        assert result == []
+
+    def test_ignores_non_md_files(self, content_root: Path):
+        ideas_dir = content_root / "ideas"
+        ideas_dir.mkdir()
+        (ideas_dir / "README.txt").write_text("not an idea", encoding="utf-8")
+        _write_idea_file(ideas_dir, "valid", "Valid")
+
+        result = _scan_ideas_dir(ideas_dir)
+        assert len(result) == 1
+        assert result[0]["slug"] == "valid"

--- a/tools/state/indexer.py
+++ b/tools/state/indexer.py
@@ -19,6 +19,7 @@ from tools.state.parsers import (
     parse_book_readme,
     parse_chapter_readme,
     parse_character_file,
+    parse_frontmatter,
     parse_series_readme,
 )
 
@@ -121,9 +122,8 @@ def build_state() -> dict[str, Any]:
         state["series"] = _scan_series(series_dir)
 
     # Scan ideas
-    ideas_file = content_root / "IDEAS.md"
-    if ideas_file.exists():
-        state["ideas"] = _scan_ideas(ideas_file)
+    ideas_dir = content_root / "ideas"
+    state["ideas"] = _scan_ideas_dir(ideas_dir)
 
     _write_state(state)
     return state
@@ -262,22 +262,35 @@ def _scan_series(series_dir: Path) -> dict[str, Any]:
     return all_series
 
 
-def _scan_ideas(ideas_file: Path) -> list[dict[str, str]]:
-    """Parse IDEAS.md into a list of idea entries."""
-    text = ideas_file.read_text(encoding="utf-8")
+def _scan_ideas_dir(ideas_dir: Path) -> list[dict]:
+    """Scan ideas/ directory and return a list of idea metadata dicts.
+
+    Each .md file (excluding _archive/ subdirectory) is parsed for its
+    YAML frontmatter. Non-.md files are silently ignored.
+    """
+    if not ideas_dir.exists():
+        return []
+
     ideas = []
-    current: dict[str, str] = {}
-
-    for line in text.splitlines():
-        if line.startswith("## "):
-            if current:
-                ideas.append(current)
-            current = {"title": line[3:].strip(), "notes": ""}
-        elif current:
-            current["notes"] += line + "\n"
-
-    if current:
-        ideas.append(current)
+    for md_file in sorted(ideas_dir.glob("*.md")):
+        if not md_file.is_file():
+            continue
+        try:
+            meta, _ = parse_frontmatter(md_file.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if not meta:
+            continue
+        ideas.append({
+            "slug": meta.get("slug", md_file.stem),
+            "title": meta.get("title", md_file.stem),
+            "status": meta.get("status", "raw"),
+            "genres": meta.get("genres", []),
+            "logline": meta.get("logline", ""),
+            "created": str(meta.get("created", "")),
+            "last_touched": str(meta.get("last_touched", "")),
+            "promoted_to": meta.get("promoted_to"),
+        })
 
     return ideas
 


### PR DESCRIPTION
## Summary

- Replaces flat `IDEAS.md` with individual `ideas/{slug}.md` files using YAML frontmatter
- Each idea tracks: `status` (raw → explored → developed → ready → shelved → promoted), genres, logline, created/last_touched dates, `promoted_to` book slug
- **5 new MCP tools:** `create_idea`, `list_ideas` (filterable by status + genre), `get_idea`, `update_idea`, `promote_idea`
- **State indexer** updated: `_scan_ideas_dir()` replaces `_scan_ideas()`, scans `ideas/` directory, ignores `_archive/` subdirectory
- **Skills updated:** `brainstorm` saves logline + status, `new-book` supports `--from-idea {slug}` flow
- **New skill:** `/storyforge:ideas` for listing + managing ideas with status groups

## Test plan

- [x] 21 new tests in `tests/test_ideas.py` — all green
- [x] 75/75 total tests pass — no regressions
- [x] TDD: tests written before implementation (Red → Green)
- [x] No migration needed (no existing `IDEAS.md`)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)