### PR TITLE
feat(repetition-checker): honor per-book CLAUDE.md rules (#10)

### DIFF
--- a/skills/repetition-checker/SKILL.md
+++ b/skills/repetition-checker/SKILL.md
@@ -138,6 +138,13 @@ This keeps the canon log honest about what was changed during revision.
   think the detector is wrong about a finding, push back.
 - Honor the author profile. If a profile defines a signature phrase as
   intentional, exclude it from rewrite recommendations.
+- **Honor the book's CLAUDE.md rules.** The scan automatically loads
+  `<book>/CLAUDE.md`, extracts the `## Rules` section (static entries + the
+  `<!-- RULES:START -->` block), and reports matches as `book_rule_violation`
+  findings with severity `high` — independent of n-gram frequency. These
+  always sort to the top of the report, and the offending rule text is shown
+  verbatim so the user sees *why* something was flagged. Treat these as the
+  most important findings: the user explicitly wrote the rule for this book.
 
 ## Algorithmic notes (for transparency)
 
@@ -154,6 +161,24 @@ The underlying detector lives at `tools/analysis/repetition_checker.py`.
   (`the kind of`, `for X years`), and sensory tokens.
 - Pure stdlib — no NLP dependencies — so the scan runs in seconds even on
   100k-word manuscripts.
+
+### Book-rule pattern extraction
+
+For `book_rule_violation` findings, the scanner extracts patterns from each
+rule bullet using simple heuristics:
+
+- **Backtick-wrapped regex** — if the content contains regex metacharacters
+  (`|`, `(`, `)`, `[`, `]`, `\`, `^`, `$`, `?`, `+`, `*`, `{`, `}`), it's
+  compiled as a case-insensitive regex. Example: `` `the (specific|particular) [a-z]+ (that|of)` ``
+- **Backtick-wrapped literal** — otherwise treated as a literal case-insensitive
+  substring. Example: `` ` thing ` ``
+- **Double-quoted phrases** (≥3 chars) — treated as literal substring patterns.
+  Example: `"opened his mouth. Closed it."`
+- Italics (`*foo*`) are **ignored** — they're used for narrative examples, not
+  scannable bans.
+- Rules without any extractable pattern produce no findings, even if the rule
+  text references a concept. Rephrase the rule with backticks or quotes to
+  make it machine-readable.
 
 ## Error handling
 

--- a/tests/test_repetition_checker.py
+++ b/tests/test_repetition_checker.py
@@ -1,0 +1,300 @@
+"""Tests for the repetition checker, especially the per-book CLAUDE.md rule scan.
+
+Covers:
+- Parsing rules out of a book's CLAUDE.md (static entries + RULES:START block).
+- Heuristic extraction of scannable patterns from rule text.
+- The `_scan_book_rules` pass that turns rule violations into high-severity
+  findings with a `source_rule` field pointing back to the offending rule.
+- Integration into `scan_repetitions` so book-rule findings appear alongside
+  n-gram findings and ignore frequency thresholds.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.analysis.repetition_checker import (
+    _extract_patterns_from_rule,
+    _read_book_rules,
+    _scan_book_rules,
+    scan_repetitions,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+CLAUDEMD_WITH_RULES = """# Test Book
+
+## Book Facts
+- **POV:** third person
+
+## Rules
+
+- **Imperial units only** — Pacific Northwest setting, no metric.
+
+<!-- RULES:START -->
+- **Avoid vague-noun "thing" as a fallback** — banned: "doing a thing with his hand". How to apply: grep for ` thing ` in narration.
+- **Do not use "clocked" as a verb for noticing** — alternatives: noticed, saw, registered.
+- **Limit "specific kind of X that Y" construction** — scan for `the (specific|particular|kind of|sort of) [a-z]+ (that|of)`.
+<!-- RULES:END -->
+
+## Callback Register
+- **Gary the cat** — must return.
+"""
+
+
+CLAUDEMD_EMPTY_RULES = """# Test Book
+
+## Book Facts
+- **POV:** third person
+
+## Rules
+
+<!-- RULES:START -->
+<!-- RULES:END -->
+
+## Callback Register
+"""
+
+
+def _write_book(tmp_path: Path, claudemd: str, chapters: dict[str, str]) -> Path:
+    """Create a minimal book layout: CLAUDE.md + chapters/<slug>/draft.md."""
+    book = tmp_path / "book"
+    book.mkdir()
+    (book / "CLAUDE.md").write_text(claudemd, encoding="utf-8")
+    chapters_dir = book / "chapters"
+    chapters_dir.mkdir()
+    for slug, content in chapters.items():
+        d = chapters_dir / slug
+        d.mkdir()
+        (d / "draft.md").write_text(content, encoding="utf-8")
+    return book
+
+
+# ---------------------------------------------------------------------------
+# _read_book_rules
+# ---------------------------------------------------------------------------
+
+
+class TestReadBookRules:
+    def test_parses_static_and_dynamic_entries(self, tmp_path: Path) -> None:
+        book = _write_book(tmp_path, CLAUDEMD_WITH_RULES, {})
+        rules = _read_book_rules(book)
+        joined = " ".join(rules)
+        assert "Imperial units only" in joined
+        assert "vague-noun" in joined
+        assert "clocked" in joined
+        assert "specific kind of X that Y" in joined
+        # Callback section must NOT leak in
+        assert "Gary the cat" not in joined
+
+    def test_returns_empty_when_claudemd_missing(self, tmp_path: Path) -> None:
+        book = tmp_path / "book"
+        book.mkdir()
+        assert _read_book_rules(book) == []
+
+    def test_returns_empty_when_rules_section_absent(self, tmp_path: Path) -> None:
+        book = _write_book(tmp_path, "# Book\n\nNo rules here.\n", {})
+        assert _read_book_rules(book) == []
+
+    def test_returns_empty_when_rules_section_is_empty(self, tmp_path: Path) -> None:
+        book = _write_book(tmp_path, CLAUDEMD_EMPTY_RULES, {})
+        assert _read_book_rules(book) == []
+
+    def test_strips_leading_bullet_marker(self, tmp_path: Path) -> None:
+        book = _write_book(tmp_path, CLAUDEMD_WITH_RULES, {})
+        rules = _read_book_rules(book)
+        # No rule should still start with "- " after parsing
+        for r in rules:
+            assert not r.startswith("- ")
+
+
+# ---------------------------------------------------------------------------
+# _extract_patterns_from_rule
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPatterns:
+    def test_extracts_backtick_literal_substring(self) -> None:
+        rule = "grep for ` thing ` in narration"
+        patterns = _extract_patterns_from_rule(rule)
+        hay = "he was doing a thing with his hand"
+        assert any(p.search(hay) for _, p in patterns)
+
+    def test_extracts_backtick_regex(self) -> None:
+        rule = "scan for `the (specific|particular) [a-z]+ (that|of)`"
+        patterns = _extract_patterns_from_rule(rule)
+        hay = "the specific quality of quiet"
+        assert any(p.search(hay) for _, p in patterns)
+
+    def test_extracts_double_quoted_phrase(self) -> None:
+        rule = 'banned: "doing a thing with his hand"'
+        patterns = _extract_patterns_from_rule(rule)
+        hay = "he was doing a thing with his hand, softly"
+        assert any(p.search(hay) for _, p in patterns)
+
+    def test_case_insensitive_matching(self) -> None:
+        rule = 'banned: "Clocked"'
+        patterns = _extract_patterns_from_rule(rule)
+        hay = "She clocked him walking into the store."
+        assert any(p.search(hay) for _, p in patterns)
+
+    def test_ignores_italics(self) -> None:
+        # Italics are used for examples/narrative, not scannable patterns.
+        rule = "reader disliked *a long exhale* as a default move"
+        patterns = _extract_patterns_from_rule(rule)
+        hay = "He gave a long exhale."
+        # No italic-sourced pattern should match — otherwise we'd flag examples
+        assert not any(p.search(hay) for _, p in patterns)
+
+    def test_skips_too_short_quoted_strings(self) -> None:
+        rule = 'ban: "a" and "ok"'
+        patterns = _extract_patterns_from_rule(rule)
+        assert patterns == []
+
+    def test_no_patterns_returns_empty(self) -> None:
+        rule = "Keep the narrative voice consistent and grounded."
+        assert _extract_patterns_from_rule(rule) == []
+
+    def test_quoted_strings_require_ban_cue(self) -> None:
+        # Rule WITHOUT a ban cue — quoted phrases are examples, not bans.
+        rule = 'e.g. Kael ordering "a second coffee in a diner" is fine'
+        patterns = _extract_patterns_from_rule(rule)
+        assert not any(p.search("a second coffee in a diner") for _, p in patterns)
+
+    def test_quoted_strings_extracted_with_cue(self) -> None:
+        rule = 'banned: "doing a thing with his hand"'
+        patterns = _extract_patterns_from_rule(rule)
+        assert any(p.search("doing a thing with his hand") for _, p in patterns)
+
+    def test_preserves_backtick_whitespace(self) -> None:
+        # ` thing ` (with spaces) should NOT match "something" or "things".
+        rule = "grep for ` thing ` in narration"
+        patterns = _extract_patterns_from_rule(rule)
+        hay_bad = "there was something wrong"
+        hay_good = "doing a thing with his hand"
+        assert not any(p.search(hay_bad) for _, p in patterns)
+        assert any(p.search(hay_good) for _, p in patterns)
+
+    def test_dedups_identical_patterns(self) -> None:
+        # Same pattern appearing as both backtick and quote should collapse.
+        rule = 'banned: "clocked" — avoid `clocked`'
+        patterns = _extract_patterns_from_rule(rule)
+        assert len(patterns) == 1
+
+
+# ---------------------------------------------------------------------------
+# _scan_book_rules (integration with chapter drafts)
+# ---------------------------------------------------------------------------
+
+
+class TestScanBookRules:
+    def test_finds_literal_violation(self, tmp_path: Path) -> None:
+        chapters = {
+            "01-open": "# Chapter 1\n\nHe was doing a thing with his hand, quietly.\n",
+        }
+        book = _write_book(tmp_path, CLAUDEMD_WITH_RULES, chapters)
+        findings = _scan_book_rules(book)
+        assert findings, "expected at least one violation finding"
+        assert any("thing" in f.phrase.lower() for f in findings)
+
+    def test_finds_regex_violation(self, tmp_path: Path) -> None:
+        chapters = {
+            "01-open": "# Chapter 1\n\nIt had the specific quality of quiet that pubs knew.\n",
+        }
+        book = _write_book(tmp_path, CLAUDEMD_WITH_RULES, chapters)
+        findings = _scan_book_rules(book)
+        assert any(f.category == "book_rule_violation" for f in findings)
+
+    def test_populates_source_rule(self, tmp_path: Path) -> None:
+        chapters = {
+            "01-open": "# Chapter 1\n\nShe clocked him across the room.\n",
+        }
+        book = _write_book(tmp_path, CLAUDEMD_WITH_RULES, chapters)
+        findings = _scan_book_rules(book)
+        clocked_finding = next(
+            f for f in findings if "clocked" in f.phrase.lower()
+        )
+        assert clocked_finding.source_rule is not None
+        assert "clocked" in clocked_finding.source_rule.lower()
+
+    def test_severity_always_high(self, tmp_path: Path) -> None:
+        # Even a single occurrence must be flagged — user-authored rules
+        # override frequency thresholds.
+        chapters = {
+            "01-open": "# Chapter 1\n\nShe clocked him once, just once.\n",
+        }
+        book = _write_book(tmp_path, CLAUDEMD_WITH_RULES, chapters)
+        findings = _scan_book_rules(book)
+        assert findings
+        assert all(f.severity == "high" for f in findings)
+
+    def test_category_is_book_rule_violation(self, tmp_path: Path) -> None:
+        chapters = {
+            "01-open": "# Chapter 1\n\nShe clocked him across the room.\n",
+        }
+        book = _write_book(tmp_path, CLAUDEMD_WITH_RULES, chapters)
+        findings = _scan_book_rules(book)
+        assert all(f.category == "book_rule_violation" for f in findings)
+
+    def test_no_violations_returns_empty(self, tmp_path: Path) -> None:
+        chapters = {
+            "01-open": "# Chapter 1\n\nClean prose without any banned terms.\n",
+        }
+        book = _write_book(tmp_path, CLAUDEMD_WITH_RULES, chapters)
+        assert _scan_book_rules(book) == []
+
+    def test_missing_claudemd_returns_empty(self, tmp_path: Path) -> None:
+        book = tmp_path / "book"
+        (book / "chapters" / "01-x").mkdir(parents=True)
+        (book / "chapters" / "01-x" / "draft.md").write_text("clocked him.", encoding="utf-8")
+        assert _scan_book_rules(book) == []
+
+    def test_records_all_occurrences(self, tmp_path: Path) -> None:
+        chapters = {
+            "01-open": "# Chapter 1\n\nShe clocked him.\nHe clocked her.\n",
+            "02-mid": "# Chapter 2\n\nThey all clocked each other.\n",
+        }
+        book = _write_book(tmp_path, CLAUDEMD_WITH_RULES, chapters)
+        findings = _scan_book_rules(book)
+        clocked = next(f for f in findings if "clocked" in f.phrase.lower())
+        assert clocked.count >= 3
+        chapters_hit = {o.chapter for o in clocked.occurrences}
+        assert chapters_hit == {"01-open", "02-mid"}
+
+
+# ---------------------------------------------------------------------------
+# Integration: scan_repetitions returns book-rule findings
+# ---------------------------------------------------------------------------
+
+
+class TestScanRepetitionsIntegration:
+    def test_book_rule_findings_are_merged(self, tmp_path: Path) -> None:
+        chapters = {
+            "01-open": "# Chapter 1\n\nShe clocked him at the counter.\n",
+        }
+        book = _write_book(tmp_path, CLAUDEMD_WITH_RULES, chapters)
+        result = scan_repetitions(book)
+        categories = {f["category"] for f in result["findings"]}
+        assert "book_rule_violation" in categories
+
+    def test_book_rule_findings_precede_ngram_findings(self, tmp_path: Path) -> None:
+        # Rule violations must sort to the top even with severity=="high" ngrams.
+        chapters = {
+            "01-open": "# Chapter 1\n\nShe clocked him once.\n",
+        }
+        book = _write_book(tmp_path, CLAUDEMD_WITH_RULES, chapters)
+        result = scan_repetitions(book)
+        assert result["findings"], "expected at least the rule finding"
+        assert result["findings"][0]["category"] == "book_rule_violation"
+
+    def test_summary_contains_book_rule_category(self, tmp_path: Path) -> None:
+        chapters = {
+            "01-open": "# Chapter 1\n\nShe clocked him.\n",
+        }
+        book = _write_book(tmp_path, CLAUDEMD_WITH_RULES, chapters)
+        result = scan_repetitions(book)
+        assert "book_rule_violation" in result["summary"]

--- a/tools/analysis/repetition_checker.py
+++ b/tools/analysis/repetition_checker.py
@@ -129,6 +129,10 @@ class Finding:
     severity: str  # "high" | "medium"
     count: int
     occurrences: list[Occurrence] = field(default_factory=list)
+    # Populated only for category == "book_rule_violation": the verbatim rule
+    # from the book's CLAUDE.md that triggered the finding, so the user sees
+    # *why* a phrase was flagged.
+    source_rule: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -282,6 +286,216 @@ def _read_chapter_drafts(book_path: Path) -> list[tuple[str, str]]:
     return drafts
 
 
+# ---------------------------------------------------------------------------
+# Per-book CLAUDE.md rule scan
+# ---------------------------------------------------------------------------
+
+# Match "## Rules" heading through to the next "## " heading or EOF.
+_RULES_SECTION_RE = re.compile(
+    r"^##\s+Rules\s*$(.*?)(?=^##\s+\S|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+
+# Match a markdown list item that spans until the next blank line, next list
+# item, or section end. This preserves multi-sentence rules written on one
+# logical bullet (continued across wrapped lines).
+_RULE_BULLET_RE = re.compile(
+    r"^-\s+(?P<body>.+?)(?=^-\s+|^\s*$|^<!--|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+
+# Comment markers inside the Rules section — stripped before bullet parsing.
+_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+# Backtick-wrapped content. We split on these to distinguish regex hints from
+# plain-literal tokens.
+_BACKTICK_CONTENT_RE = re.compile(r"`([^`\n]+)`")
+
+# Double-quoted phrases ≥3 chars of content. Deliberately excludes short words
+# like "a" or "ok" which produce noisy false positives.
+_QUOTED_CONTENT_RE = re.compile(r'"([^"\n]{3,})"')
+
+# Characters that strongly suggest a backtick-wrapped string is intended as a
+# regex rather than a literal substring.
+_REGEX_HINT_CHARS = set("|()[]\\^$?+*{}")
+
+# Cue keywords that mark a rule as containing bannable quoted phrases. Without
+# a cue, quoted strings are treated as examples, not patterns.
+_BAN_CUE_RE = re.compile(
+    r"\b(banned|ban|avoid|never|don[\u2019']?t\s+use|do\s+not\s+use|limit|no\s+\w+)\b",
+    re.IGNORECASE,
+)
+
+
+def _read_book_rules(book_path: Path) -> list[str]:
+    """Extract rule text entries from a book's CLAUDE.md.
+
+    Returns one string per bullet item found under the ``## Rules`` section,
+    including entries inside the ``<!-- RULES:START --> ... <!-- RULES:END -->``
+    block and any static entries listed above it. Comment markers are stripped
+    before bullet parsing so they don't break list items.
+
+    Returns an empty list when CLAUDE.md is missing or has no Rules section.
+    """
+    claudemd = book_path / "CLAUDE.md"
+    if not claudemd.is_file():
+        return []
+    try:
+        text = claudemd.read_text(encoding="utf-8")
+    except OSError:
+        return []
+
+    match = _RULES_SECTION_RE.search(text)
+    if not match:
+        return []
+    section = _COMMENT_RE.sub("", match.group(1))
+
+    rules: list[str] = []
+    for m in _RULE_BULLET_RE.finditer(section):
+        body = m.group("body").strip()
+        # Collapse internal whitespace (from line wrapping) to single spaces.
+        body = re.sub(r"\s+", " ", body)
+        if body:
+            rules.append(body)
+    return rules
+
+
+def _extract_patterns_from_rule(rule: str) -> list[tuple[str, re.Pattern[str]]]:
+    """Extract scannable patterns from a single rule text.
+
+    Returns a list of ``(display_label, compiled_regex)`` tuples. Heuristic
+    extraction — stdlib only:
+
+    1. Backtick-wrapped strings are always extracted. If the content contains
+       regex metacharacters it's compiled as a regex, otherwise as a literal
+       substring. Whitespace inside the backticks is preserved so the user
+       can encode word-boundary intent (e.g. `` ` thing ` ``).
+    2. Double-quoted phrases are extracted *only* when the rule contains a
+       ban cue (``banned``, ``avoid``, ``never``, ``don't use``, ``do not
+       use``, ``ban``, ``limit``, ``no X``). This prevents positive rewrite
+       examples from being interpreted as patterns to ban.
+    3. Italics (``*foo*``) are intentionally ignored — they're used for
+       narrative examples, not scannable bans.
+    4. Malformed regex strings are skipped rather than raising.
+    """
+    patterns: list[tuple[str, re.Pattern[str]]] = []
+    seen: set[str] = set()
+
+    def _add(label: str, compiled: re.Pattern[str]) -> None:
+        key = compiled.pattern.lower()
+        if key in seen:
+            return
+        seen.add(key)
+        patterns.append((label, compiled))
+
+    # Backticks: always extracted.
+    for m in _BACKTICK_CONTENT_RE.finditer(rule):
+        raw = m.group(1)
+        inner = raw.strip()
+        if len(inner) < 2:
+            continue
+        if any(c in _REGEX_HINT_CHARS for c in inner):
+            try:
+                _add(inner, re.compile(raw, re.IGNORECASE))
+            except re.error:
+                continue
+        else:
+            _add(inner, re.compile(re.escape(raw), re.IGNORECASE))
+
+    # Quoted phrases: only if the rule contains a ban cue. Require at least
+    # 6 chars after strip — shorter quoted strings are usually concept
+    # references (e.g. the title `"thing"`) rather than bannable phrases.
+    if _BAN_CUE_RE.search(rule):
+        for m in _QUOTED_CONTENT_RE.finditer(rule):
+            raw = m.group(1).strip()
+            if len(raw) < 6 or raw.lower() in STOP_WORDS:
+                continue
+            _add(raw, re.compile(re.escape(raw), re.IGNORECASE))
+
+    return patterns
+
+
+def _rule_label(rule: str, max_len: int = 80) -> str:
+    """Short display label for a rule — typically the bold'd title prefix."""
+    # Prefer text inside the first **bold** span if present.
+    bold = re.match(r"\*\*(?P<title>[^*]+)\*\*", rule)
+    if bold:
+        title = bold.group("title").strip()
+    else:
+        title = rule
+    title = re.sub(r"\s+", " ", title)
+    if len(title) > max_len:
+        title = title[: max_len - 1].rstrip() + "…"
+    return title
+
+
+def _scan_book_rules(book_path: Path) -> list[Finding]:
+    """Scan chapter drafts for violations of rules in the book's CLAUDE.md.
+
+    Produces one ``Finding`` per (rule × pattern) that has at least one hit,
+    with severity always ``"high"`` because user-authored rules override
+    frequency thresholds.
+    """
+    rules = _read_book_rules(book_path)
+    if not rules:
+        return []
+    drafts = _read_chapter_drafts(book_path)
+    if not drafts:
+        return []
+
+    findings: list[Finding] = []
+    for rule in rules:
+        patterns = _extract_patterns_from_rule(rule)
+        if not patterns:
+            continue
+        rule_label = _rule_label(rule)
+        # Aggregate all patterns of a rule into a single finding. Dedupe
+        # per (chapter, line) so overlapping patterns within the same rule
+        # don't produce double-counted occurrences.
+        seen_positions: set[tuple[str, int]] = set()
+        occurrences: list[Occurrence] = []
+        matched_labels: dict[str, None] = {}  # insertion-ordered unique set
+        for display, pattern in patterns:
+            pattern_hit = False
+            for chapter_slug, raw_text in drafts:
+                cleaned = _strip_markdown(raw_text)
+                for line_no, line in enumerate(cleaned.splitlines(), start=1):
+                    stripped = line.strip()
+                    if not stripped:
+                        continue
+                    for m in pattern.finditer(stripped):
+                        key = (chapter_slug, line_no)
+                        if key in seen_positions:
+                            continue
+                        seen_positions.add(key)
+                        snippet = _make_snippet(stripped, m.group(0).lower())
+                        occurrences.append(
+                            Occurrence(chapter=chapter_slug, line=line_no, snippet=snippet)
+                        )
+                        pattern_hit = True
+            if pattern_hit:
+                matched_labels[display] = None
+        if not occurrences:
+            continue
+        phrase = " / ".join(matched_labels) if matched_labels else rule_label
+        findings.append(
+            Finding(
+                phrase=phrase,
+                category="book_rule_violation",
+                severity="high",
+                count=len(occurrences),
+                occurrences=sorted(occurrences, key=lambda o: (o.chapter, o.line)),
+                source_rule=rule_label,
+            )
+        )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Scanning
+# ---------------------------------------------------------------------------
+
+
 def scan_repetitions(
     book_path: Path,
     ngram_sizes: Iterable[int] = DEFAULT_NGRAM_SIZES,
@@ -365,9 +579,20 @@ def scan_repetitions(
         )
         seen_long.append((phrase, len(occs)))
 
-    # Sort: severity desc, count desc, phrase asc.
+    # Merge in per-book CLAUDE.md rule violations. These are high-severity
+    # by definition and ignore the n-gram frequency thresholds above.
+    findings.extend(_scan_book_rules(book_path))
+
+    # Sort: book_rule_violation first, then severity desc, count desc, phrase asc.
     severity_rank = {"high": 0, "medium": 1}
-    findings.sort(key=lambda f: (severity_rank[f.severity], -f.count, f.phrase))
+    findings.sort(
+        key=lambda f: (
+            0 if f.category == "book_rule_violation" else 1,
+            severity_rank[f.severity],
+            -f.count,
+            f.phrase,
+        )
+    )
 
     if max_findings_per_category is not None:
         per_cat: dict[str, int] = defaultdict(int)
@@ -402,6 +627,7 @@ def _finding_to_dict(f: Finding) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 CATEGORY_LABELS = {
+    "book_rule_violation": "Book Rule Violations",
     "simile": "Similes & Metaphors",
     "blocking_tic": "Blocking Tics",
     "character_tell": "Character Tells",
@@ -411,6 +637,7 @@ CATEGORY_LABELS = {
 }
 
 CATEGORY_ORDER = [
+    "book_rule_violation",
     "simile",
     "character_tell",
     "blocking_tic",
@@ -467,6 +694,9 @@ def render_report(scan_result: dict[str, Any]) -> str:
             severity_marker = "**HIGH**" if f["severity"] == "high" else "MEDIUM"
             lines.append(f"### `{f['phrase']}` — {f['count']}× ({severity_marker})")
             lines.append("")
+            if f.get("source_rule"):
+                lines.append(f"> **Rule:** {f['source_rule']}")
+                lines.append("")
             for occ in f["occurrences"]:
                 lines.append(f"- **{occ['chapter']}** (line {occ['line']}): {occ['snippet']}")
             lines.append("")
@@ -479,6 +709,13 @@ def _recommendation_for(finding: dict[str, Any]) -> str:
     """Short, category-aware revision recommendation."""
     cat = finding["category"]
     count = finding["count"]
+    if cat == "book_rule_violation":
+        return (
+            f"_Recommendation:_ This violates a rule from the book's CLAUDE.md. "
+            f"Rewrite per the user-authored guidance above — all {count} "
+            f"occurrence{'s' if count != 1 else ''} should be revised unless "
+            f"the rule explicitly allows an exception."
+        )
     if cat == "simile":
         return (
             f"_Recommendation:_ Keep the strongest occurrence (usually the first) "


### PR DESCRIPTION
Closes #10.

## Summary

The `repetition-checker` now loads `<book>/CLAUDE.md` and uses its `## Rules` section as scannable patterns, reporting matches as `book_rule_violation` findings with severity `high` (independent of n-gram frequency thresholds). This closes the gap between user-authored book rules and the automated scan.

## What changed

- `_read_book_rules(book_path)` parses the Rules section (static entries + `<!-- RULES:START -->` block)
- `_extract_patterns_from_rule(rule)`:
  - **Backticks** are always extracted — regex if metachars present, literal otherwise, whitespace preserved (so ``` ` thing ` ``` matches only word-bounded "thing")
  - **Quoted phrases** are only extracted when the rule contains a ban cue (`banned`, `avoid`, `never`, `don't use`, `do not use`, `ban`, `limit`, `no X`) AND are ≥6 chars (kills concept-reference quotes like `"thing"` in rule titles)
  - Italics ignored — they're narrative examples, not bans
- `_scan_book_rules()` aggregates per rule (one Finding per rule), dedupes occurrences by `(chapter, line)`
- Findings expose a `source_rule` field so the offending rule text is shown verbatim in the report
- `render_report()` sorts `book_rule_violation` to the top and quotes the rule as a blockquote
- SKILL.md §Rules + §Algorithmic notes updated

## Test plan

- [x] 27 new tests in `tests/test_repetition_checker.py` (rule parsing, pattern extraction, cue gating, whitespace preservation, dedupe, integration with `scan_repetitions`)
- [x] `pytest tests/` → 144/144 green (existing tests unchanged)
- [x] `ruff check .` → clean
- [x] Smoke test on `blood-and-binary-firelight`: the three real rules (`thing`, `clocked`, `specific kind of X that Y`) are flagged with correct source rules and deduplicated occurrences

## Notes

- Rule 1's pseudo-regex ``the (specific|particular|kind of|sort of) [noun] (that|of)`` doesn't match because `[noun]` is interpreted as a char class — that's an authoring quirk in the rule, not a bug in the scanner. A future follow-up could surface a warning when a compiled regex returns zero matches.
- The `thing` rule flags 43 occurrences on the real book — that's the actual count of ` thing ` in the narration, not noise. Per-rule aggregation collapses what would otherwise be many duplicate findings into one actionable entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)