### PR TITLE
fix: tolerate scaffold-convention variants for chapter & world dirs

### DIFF
--- a/servers/storyforge-server/server.py
+++ b/servers/storyforge-server/server.py
@@ -21,7 +21,7 @@ if plugin_root not in sys.path:
 from mcp.server.fastmcp import FastMCP
 
 from tools.shared.config import load_config, get_content_root, get_genres_dir, get_reference_dir
-from tools.shared.paths import slugify, resolve_project_path, resolve_chapter_path, resolve_author_path, find_chapters, resolve_series_path
+from tools.shared.paths import slugify, resolve_project_path, resolve_chapter_path, resolve_author_path, find_chapters, resolve_series_path, resolve_world_dir
 from tools.state.indexer import StateCache, rebuild
 from tools.state.parsers import parse_frontmatter, count_words_in_file
 from tools.analysis.manuscript_checker import scan_repetitions, render_report
@@ -550,6 +550,19 @@ word_count_target: 3000
     (ch_dir / "README.md").write_text(readme, encoding="utf-8")
     (ch_dir / "draft.md").write_text(f"# Chapter {number}: {title}\n\n", encoding="utf-8")
 
+    # Issue #16: write chapter.yaml as the canonical metadata source so the
+    # parser's preferred lookup target stays consistent with what we created.
+    chapter_yaml = (
+        f'title: "{title}"\n'
+        f"number: {number}\n"
+        f'slug: "{slug}"\n'
+        f'status: "Outline"\n'
+        f'pov_character: "{pov_character}"\n'
+        f'summary: "{summary}"\n'
+        f"word_count_target: 3000\n"
+    )
+    (ch_dir / "chapter.yaml").write_text(chapter_yaml, encoding="utf-8")
+
     _cache.invalidate()
     return json.dumps({
         "success": True,
@@ -664,12 +677,22 @@ def resolve_path(book_slug: str, component: str = "", sub_path: str = "") -> str
         book_slug: Book project slug
         component: Component type (chapters, characters, plot, world, cover, export, research)
         sub_path: Optional sub-path within the component
+
+    Note: ``world`` resolves to the first existing of ``world/``,
+    ``worldbuilding/``, or ``world-building/`` (Issue #17). When no world dir
+    exists, the canonical ``world/`` path is returned with ``exists: false``.
     """
     config = load_config()
-    base = resolve_project_path(config, book_slug)
+    project = resolve_project_path(config, book_slug)
 
-    if component:
-        base = base / component
+    if component == "world":
+        world_dir = resolve_world_dir(project)
+        base = world_dir if world_dir is not None else project / "world"
+    elif component:
+        base = project / component
+    else:
+        base = project
+
     if sub_path:
         base = base / sub_path
 
@@ -1012,13 +1035,18 @@ def validate_book_structure(book_slug: str) -> str:
 
     checks = []
 
+    # Issue #17: accept aliases (worldbuilding/, world-building/) for the
+    # world directory so non-canonical scaffolds still validate.
+    world_dir = resolve_world_dir(project_dir) or (project_dir / "world")
+    world_setting = world_dir / "setting.md"
+
     # Required files
     for name, path in [
         ("README.md", project_dir / "README.md"),
         ("synopsis.md", project_dir / "synopsis.md"),
         ("plot/outline.md", project_dir / "plot" / "outline.md"),
         ("characters/INDEX.md", project_dir / "characters" / "INDEX.md"),
-        ("world/setting.md", project_dir / "world" / "setting.md"),
+        (f"{world_dir.name}/setting.md", world_setting),
     ]:
         checks.append({"check": name, "status": "PASS" if path.exists() else "FAIL"})
 

--- a/tests/test_scaffold_conventions.py
+++ b/tests/test_scaffold_conventions.py
@@ -1,0 +1,306 @@
+"""Tests for scaffold-convention tolerance.
+
+Covers two related bugs:
+
+* Issue #16 — chapter status lives in `chapter.yaml` next to README.md, but the
+  parser only reads README frontmatter and silently defaults to "Outline".
+* Issue #17 — the MCP hardcodes `world/` everywhere, so books scaffolded with
+  `worldbuilding/` (or `world-building/`) are silently invisible to
+  `resolve_path`, `validate_book_structure`, and skill prerequisites.
+
+Both bugs share a root cause: the MCP assumed a single canonical layout. The
+fix adds tolerant detection (chapter.yaml fallback, world-dir alias table)
+without forcing a migration.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools.state.indexer import _scan_chapters
+from tools.state.parsers import parse_chapter_readme
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def content_root(tmp_path: Path) -> Path:
+    root = tmp_path / "content"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def mock_config(content_root: Path):
+    fake_config = {
+        "paths": {
+            "content_root": str(content_root),
+            "authors_root": str(content_root / "authors"),
+        },
+        "defaults": {"language": "en", "book_type": "novel"},
+    }
+
+    import server as server_mod  # noqa: WPS433
+
+    with patch.object(server_mod, "load_config", return_value=fake_config), \
+         patch.object(server_mod, "get_content_root", return_value=content_root):
+        server_mod._cache.invalidate()
+        yield fake_config
+
+
+@pytest.fixture
+def server_module(mock_config):
+    import server as server_mod  # noqa: WPS433
+    return server_mod
+
+
+def _write_book_skeleton(content_root: Path, slug: str = "test-book") -> Path:
+    """Create the minimum structure needed by validate_book_structure."""
+    project = content_root / "projects" / slug
+    project.mkdir(parents=True)
+    (project / "README.md").write_text(
+        f'---\ntitle: "Test Book"\nslug: "{slug}"\nstatus: "Drafting"\n---\n# Test\n',
+        encoding="utf-8",
+    )
+    (project / "synopsis.md").write_text("# Synopsis\n", encoding="utf-8")
+    (project / "plot").mkdir()
+    (project / "plot" / "outline.md").write_text("# Outline\n", encoding="utf-8")
+    (project / "characters").mkdir()
+    (project / "characters" / "INDEX.md").write_text("# Chars\n", encoding="utf-8")
+    return project
+
+
+# ---------------------------------------------------------------------------
+# Issue #16 — chapter.yaml fallback in parse_chapter_readme
+# ---------------------------------------------------------------------------
+
+
+class TestChapterYamlFallback:
+    """parse_chapter_readme must consult chapter.yaml when README has no frontmatter."""
+
+    def test_chapter_yaml_supplies_status_when_readme_has_none(self, tmp_path: Path):
+        # README.md without any frontmatter (the bug scenario)
+        ch_dir = tmp_path / "01-invisible"
+        ch_dir.mkdir()
+        (ch_dir / "README.md").write_text(
+            "# Chapter 1\n\nPlain markdown body, no frontmatter at all.\n",
+            encoding="utf-8",
+        )
+        (ch_dir / "chapter.yaml").write_text(
+            'title: "Invisible"\n'
+            "status: review\n"
+            "words: 4047\n"
+            'pov: "Theo Wilkons"\n'
+            "act: 1\n",
+            encoding="utf-8",
+        )
+
+        result = parse_chapter_readme(ch_dir / "README.md")
+
+        # Status from chapter.yaml — normalized to canonical form ("review" → "Revision")
+        assert result["status"] != "Outline", (
+            "Bug #16: status must come from chapter.yaml, not the README default"
+        )
+        assert result["title"] == "Invisible"
+
+    def test_chapter_yaml_takes_precedence_over_readme_default(self, tmp_path: Path):
+        # Both files exist; chapter.yaml wins (Option A from issue #16)
+        ch_dir = tmp_path / "02-conflict"
+        ch_dir.mkdir()
+        (ch_dir / "README.md").write_text(
+            '---\ntitle: "Stale Title"\nstatus: "Outline"\n---\n# Body\n',
+            encoding="utf-8",
+        )
+        (ch_dir / "chapter.yaml").write_text(
+            'title: "Fresh Title"\nstatus: "Draft"\n',
+            encoding="utf-8",
+        )
+
+        result = parse_chapter_readme(ch_dir / "README.md")
+
+        assert result["title"] == "Fresh Title"
+        assert result["status"] == "Draft"
+
+    def test_readme_frontmatter_still_works_when_no_chapter_yaml(self, tmp_path: Path):
+        # Backward compatibility: existing books without chapter.yaml unchanged.
+        ch_dir = tmp_path / "03-classic"
+        ch_dir.mkdir()
+        (ch_dir / "README.md").write_text(
+            '---\ntitle: "Classic"\nstatus: "Final"\nnumber: 3\n---\n# Body\n',
+            encoding="utf-8",
+        )
+
+        result = parse_chapter_readme(ch_dir / "README.md")
+
+        assert result["title"] == "Classic"
+        assert result["status"] == "Final"
+        assert result["number"] == 3
+
+    def test_no_metadata_anywhere_falls_back_to_outline(self, tmp_path: Path):
+        # Edge: neither file has metadata — keep the historical default.
+        ch_dir = tmp_path / "04-empty"
+        ch_dir.mkdir()
+        (ch_dir / "README.md").write_text("# Body only\n", encoding="utf-8")
+
+        result = parse_chapter_readme(ch_dir / "README.md")
+
+        assert result["status"] == "Outline"
+
+    def test_indexer_picks_up_chapter_yaml_status(self, tmp_path: Path):
+        # End-to-end: the indexer reflects chapter.yaml status in scanned data.
+        chapters_dir = tmp_path / "chapters"
+        ch_dir = chapters_dir / "01-invisible"
+        ch_dir.mkdir(parents=True)
+        (ch_dir / "README.md").write_text("# Chapter 1\n\nPlain prose.\n", encoding="utf-8")
+        (ch_dir / "chapter.yaml").write_text(
+            'title: "Invisible"\nstatus: review\n', encoding="utf-8"
+        )
+
+        result = _scan_chapters(chapters_dir)
+
+        assert "01-invisible" in result
+        assert result["01-invisible"]["status"] != "Outline"
+
+
+class TestCreateChapterWritesBoth:
+    """create_chapter must also write chapter.yaml so future reads stay consistent."""
+
+    def test_create_chapter_writes_chapter_yaml_alongside_readme(
+        self, server_module, content_root: Path
+    ):
+        _write_book_skeleton(content_root)
+
+        result = json.loads(
+            server_module.create_chapter(
+                book_slug="test-book",
+                title="Opening",
+                number=1,
+                pov_character="Alex",
+                summary="The hero arrives.",
+            )
+        )
+
+        assert result.get("success") is True
+        ch_dir = content_root / "projects" / "test-book" / "chapters" / "01-opening"
+        assert (ch_dir / "README.md").exists()
+        assert (ch_dir / "chapter.yaml").exists(), (
+            "Bug #16 fix: chapter.yaml must be created alongside README.md"
+        )
+
+        import yaml
+        meta = yaml.safe_load((ch_dir / "chapter.yaml").read_text(encoding="utf-8"))
+        assert meta["title"] == "Opening"
+        assert meta["status"] == "Outline"
+        assert meta["number"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #17 — world/ vs worldbuilding/ alias
+# ---------------------------------------------------------------------------
+
+
+class TestResolveWorldDir:
+    """The world-dir helper must accept multiple sensible directory names."""
+
+    def test_returns_world_when_present(self, tmp_path: Path):
+        from tools.shared.paths import resolve_world_dir
+
+        (tmp_path / "world").mkdir()
+        assert resolve_world_dir(tmp_path) == tmp_path / "world"
+
+    def test_falls_back_to_worldbuilding(self, tmp_path: Path):
+        from tools.shared.paths import resolve_world_dir
+
+        (tmp_path / "worldbuilding").mkdir()
+        assert resolve_world_dir(tmp_path) == tmp_path / "worldbuilding"
+
+    def test_falls_back_to_world_building_with_dash(self, tmp_path: Path):
+        from tools.shared.paths import resolve_world_dir
+
+        (tmp_path / "world-building").mkdir()
+        assert resolve_world_dir(tmp_path) == tmp_path / "world-building"
+
+    def test_canonical_world_wins_when_multiple_exist(self, tmp_path: Path):
+        from tools.shared.paths import resolve_world_dir
+
+        (tmp_path / "world").mkdir()
+        (tmp_path / "worldbuilding").mkdir()
+        assert resolve_world_dir(tmp_path) == tmp_path / "world"
+
+    def test_returns_none_when_no_world_dir_exists(self, tmp_path: Path):
+        from tools.shared.paths import resolve_world_dir
+
+        assert resolve_world_dir(tmp_path) is None
+
+
+class TestResolvePathWorldAlias:
+    """server.resolve_path(component='world') must accept worldbuilding/."""
+
+    def test_resolves_to_worldbuilding_when_only_alias_exists(
+        self, server_module, content_root: Path
+    ):
+        project = _write_book_skeleton(content_root, slug="alt-book")
+        # Remove the canonical scaffold-created world/ if any (none in skeleton helper)
+        # and add the alias instead.
+        (project / "worldbuilding").mkdir()
+        (project / "worldbuilding" / "setting.md").write_text("# Setting\n", encoding="utf-8")
+
+        result = json.loads(server_module.resolve_path("alt-book", component="world"))
+
+        assert result["exists"] is True, (
+            "Bug #17 fix: resolve_path('world') must find worldbuilding/ as fallback"
+        )
+        assert result["path"].endswith("worldbuilding")
+
+    def test_resolves_to_world_when_canonical_exists(
+        self, server_module, content_root: Path
+    ):
+        project = _write_book_skeleton(content_root, slug="canon-book")
+        (project / "world").mkdir()
+        (project / "world" / "setting.md").write_text("# Setting\n", encoding="utf-8")
+
+        result = json.loads(server_module.resolve_path("canon-book", component="world"))
+
+        assert result["exists"] is True
+        assert result["path"].endswith("world")
+
+
+class TestValidateBookStructureWorldAlias:
+    """validate_book_structure must accept any recognized world-dir name."""
+
+    def test_validates_with_worldbuilding(self, server_module, content_root: Path):
+        project = _write_book_skeleton(content_root, slug="alt-book")
+        (project / "worldbuilding").mkdir()
+        (project / "worldbuilding" / "setting.md").write_text("# Setting\n", encoding="utf-8")
+
+        result = json.loads(server_module.validate_book_structure("alt-book"))
+
+        world_check = next(
+            (c for c in result["checks"] if c["check"].endswith("setting.md")),
+            None,
+        )
+        assert world_check is not None, "validate_book_structure must include a world-setting check"
+        assert world_check["status"] == "PASS", (
+            "Bug #17 fix: world-setting check must accept worldbuilding/ as alias"
+        )
+
+    def test_validates_with_canonical_world(self, server_module, content_root: Path):
+        project = _write_book_skeleton(content_root, slug="canon-book")
+        (project / "world").mkdir()
+        (project / "world" / "setting.md").write_text("# Setting\n", encoding="utf-8")
+
+        result = json.loads(server_module.validate_book_structure("canon-book"))
+
+        world_check = next(
+            (c for c in result["checks"] if c["check"].endswith("setting.md")),
+            None,
+        )
+        assert world_check is not None
+        assert world_check["status"] == "PASS"

--- a/tools/shared/paths.py
+++ b/tools/shared/paths.py
@@ -28,6 +28,27 @@ def resolve_chapter_path(
     return resolve_project_path(config, book_slug) / "chapters" / chapter_slug
 
 
+# Issue #17: book scaffolds occasionally use alternate names for the
+# world-building directory. The MCP must recognize them so skill prerequisites
+# (e.g. loading `world/setting.md` for the Travel Matrix) keep working without
+# forcing users to rename their existing layout.
+WORLD_DIR_CANDIDATES: tuple[str, ...] = ("world", "worldbuilding", "world-building")
+
+
+def resolve_world_dir(project_dir: Path) -> Path | None:
+    """Return the existing world-building directory under ``project_dir``.
+
+    Tries the canonical ``world/`` first, then known aliases. Returns ``None``
+    when none exists, leaving the caller to decide whether to use the
+    canonical default for new content.
+    """
+    for name in WORLD_DIR_CANDIDATES:
+        candidate = project_dir / name
+        if candidate.exists():
+            return candidate
+    return None
+
+
 def resolve_character_path(
     config: dict[str, Any], book_slug: str, character_slug: str
 ) -> Path:

--- a/tools/state/parsers.py
+++ b/tools/state/parsers.py
@@ -53,16 +53,38 @@ def parse_book_readme(path: Path) -> dict[str, Any]:
 
 
 def parse_chapter_readme(path: Path) -> dict[str, Any]:
-    """Parse a chapter README.md into structured data."""
+    """Parse chapter metadata for the chapter at ``path.parent``.
+
+    Resolution order (Issue #16): a sibling ``chapter.yaml`` is the preferred
+    source of truth. If absent or empty, fall back to the README's YAML
+    frontmatter. This lets books scaffolded with a separate metadata file work
+    transparently alongside the README-frontmatter convention.
+    """
     text = path.read_text(encoding="utf-8")
-    meta, body = parse_frontmatter(text)
+    readme_meta, _body = parse_frontmatter(text)
+
+    chapter_yaml = path.parent / "chapter.yaml"
+    yaml_meta: dict[str, Any] = {}
+    if chapter_yaml.exists():
+        try:
+            loaded = yaml.safe_load(chapter_yaml.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                yaml_meta = loaded
+        except yaml.YAMLError:
+            yaml_meta = {}
+
+    # chapter.yaml wins; README frontmatter only fills missing keys
+    meta = {**readme_meta, **yaml_meta}
+
+    # Common alternate field names found in older/manual scaffolds
+    pov = meta.get("pov_character") or meta.get("pov", "")
 
     return {
         "slug": path.parent.name,
         "title": meta.get("title", path.parent.name),
         "number": meta.get("number", _extract_number(path.parent.name)),
         "status": _normalize_chapter_status(meta.get("status", "Outline")),
-        "pov_character": meta.get("pov_character", ""),
+        "pov_character": pov,
         "summary": meta.get("summary", ""),
         "word_count_target": meta.get("word_count_target", 0),
     }


### PR DESCRIPTION
## Summary

Fixes two related layout-assumption bugs in the MCP that silently broke books scaffolded with non-canonical conventions.

- **#16** — `parse_chapter_readme` only read README.md frontmatter; books storing chapter metadata in a sibling `chapter.yaml` reported every chapter as `status: \"Outline\"`. Now `chapter.yaml` is the preferred source, README frontmatter the fallback. `create_chapter()` writes both.
- **#17** — `world/` was hardcoded in `resolve_path()`, `validate_book_structure()`, and skill prerequisites. New `resolve_world_dir()` helper accepts `world/`, `worldbuilding/`, `world-building/` (canonical first). `create_book()` still scaffolds the canonical `world/`.

Both fixes are backward-compatible: existing books with README frontmatter and `world/` are untouched.

## Root Cause

Same class of bug in both: MCP assumed a single canonical scaffold, refused to detect alternates. The fix adds tolerant detection without forcing migration.

## Test plan

- [x] 15 new tests in `tests/test_scaffold_conventions.py` covering:
  - chapter.yaml supplies status when README has none
  - chapter.yaml takes precedence over README defaults
  - README frontmatter still works when no chapter.yaml exists
  - indexer reflects chapter.yaml status
  - `create_chapter()` writes both files
  - `resolve_world_dir()` returns correct candidate (canonical first, alias fallback, None when missing)
  - `resolve_path('world')` and `validate_book_structure()` accept `worldbuilding/`
- [x] Full suite green: 187 passed (was 172, +15 new)
- [x] Ruff clean
- [x] Manual verification on `blood-and-binary-firelight` (the bug-report book) after merge

## Behavioral note

`validate_book_structure` now returns the actual directory name in the check label (e.g. `\"worldbuilding/setting.md\"` instead of always `\"world/setting.md\"`). This is intentional — the diagnostic should reflect reality — but is technically a change in the response shape for non-canonical books.

Closes #16
Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)