### PR TITLE
fix: derive book status; count non-canonical drafted chapters (#19)

### DIFF
--- a/servers/storyforge-server/server.py
+++ b/servers/storyforge-server/server.py
@@ -23,7 +23,7 @@ from mcp.server.fastmcp import FastMCP
 from tools.shared.config import load_config, get_content_root, get_genres_dir, get_reference_dir
 from tools.shared.paths import slugify, resolve_project_path, resolve_chapter_path, resolve_author_path, find_chapters, resolve_series_path, resolve_world_dir
 from tools.state.indexer import StateCache, rebuild
-from tools.state.parsers import parse_frontmatter, count_words_in_file
+from tools.state.parsers import parse_frontmatter, count_words_in_file, is_chapter_drafted
 from tools.analysis.manuscript_checker import scan_repetitions, render_report
 from tools.claudemd.manager import (
     append_callback as _append_callback_impl,
@@ -101,19 +101,24 @@ def get_book_progress(slug: str) -> str:
 
     chapters = book.get("chapters_data", {})
     total = len(chapters)
+    # Issue #19: tolerate non-canonical chapter statuses ("review", etc.) —
+    # anything past "Outline" counts as drafted. Final stays strict.
     final = sum(1 for c in chapters.values() if c.get("status") == "Final")
-    drafted = sum(1 for c in chapters.values() if c.get("status") in ("Draft", "Revision", "Polished", "Final"))
+    drafted = sum(1 for c in chapters.values() if is_chapter_drafted(c.get("status", "")))
     total_words = book.get("total_words", 0)
     target = book.get("target_word_count", 0)
 
     return json.dumps({
         "slug": slug,
         "title": book.get("title", slug),
+        # Indexer already derived this from chapter state (Issue #19).
         "status": book.get("status", "Idea"),
+        "status_disk": book.get("status_disk", book.get("status", "Idea")),
         "chapters_total": total,
         "chapters_drafted": drafted,
         "chapters_final": final,
-        "completion_percent": round(final / total * 100) if total else 0,
+        # Issue #19: completion tracks forward progress (drafted), not sign-off (final).
+        "completion_percent": round(drafted / total * 100) if total else 0,
         "total_words": total_words,
         "target_words": target,
         "word_progress_percent": round(total_words / target * 100) if target else 0,

--- a/tests/test_progress_derivation.py
+++ b/tests/test_progress_derivation.py
@@ -1,0 +1,250 @@
+"""Tests for book-progress aggregation and status derivation (Issue #19).
+
+After #16 fixed per-chapter status reporting, two aggregation bugs remained:
+
+1. ``chapters_drafted`` only counted a hardcoded set of canonical statuses
+   ({Draft, Revision, Polished, Final}). Non-canonical-but-clearly-drafted
+   states (e.g. ``"review"`` from a user's chapter.yaml) fell through to
+   zero. The right rule: anything past ``Outline`` counts as drafted.
+
+2. Book-level ``status`` stayed at whatever the README frontmatter said.
+   A book with 17 reviewed chapters reported ``status: "Idea"``. We now
+   derive an effective status from chapter aggregates and surface it via
+   ``get_book_progress`` (and the indexer for downstream consumers),
+   without writing back to disk.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools.state.parsers import derive_book_status
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirrored from test_ideas.py / test_scaffold_conventions.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def content_root(tmp_path: Path) -> Path:
+    root = tmp_path / "content"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def mock_config(content_root: Path):
+    fake_config = {
+        "paths": {
+            "content_root": str(content_root),
+            "authors_root": str(content_root / "authors"),
+        },
+        "defaults": {"language": "en", "book_type": "novel"},
+    }
+
+    import server as server_mod  # noqa: WPS433
+    from tools.state import indexer as indexer_mod
+
+    # Redirect the persistent state cache to the tmp dir so tests don't
+    # collide with the user's real ~/.storyforge/cache/state.json.
+    fake_state_path = content_root / "_cache" / "state.json"
+
+    with patch.object(server_mod, "load_config", return_value=fake_config), \
+         patch.object(server_mod, "get_content_root", return_value=content_root), \
+         patch.object(indexer_mod, "load_config", return_value=fake_config), \
+         patch.object(indexer_mod, "STATE_PATH", fake_state_path), \
+         patch.object(indexer_mod, "CACHE_DIR", fake_state_path.parent):
+        server_mod._cache.invalidate()
+        yield fake_config
+
+
+@pytest.fixture
+def server_module(mock_config):
+    import server as server_mod  # noqa: WPS433
+    return server_mod
+
+
+def _write_book(content_root: Path, slug: str, status: str = "Idea") -> Path:
+    project = content_root / "projects" / slug
+    project.mkdir(parents=True)
+    (project / "README.md").write_text(
+        f'---\ntitle: "Test"\nslug: "{slug}"\nstatus: "{status}"\n'
+        f'target_word_count: 30000\n---\n# Test\n',
+        encoding="utf-8",
+    )
+    (project / "chapters").mkdir()
+    return project
+
+
+def _write_chapter(book_dir: Path, slug: str, status: str, words: int = 0) -> Path:
+    ch_dir = book_dir / "chapters" / slug
+    ch_dir.mkdir(parents=True)
+    (ch_dir / "README.md").write_text("# Body\n", encoding="utf-8")
+    (ch_dir / "chapter.yaml").write_text(
+        f'title: "{slug}"\nstatus: "{status}"\n', encoding="utf-8"
+    )
+    if words:
+        (ch_dir / "draft.md").write_text(" ".join(["word"] * words), encoding="utf-8")
+    return ch_dir
+
+
+# ---------------------------------------------------------------------------
+# derive_book_status helper
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveBookStatus:
+    def test_no_chapters_keeps_current_status(self):
+        assert derive_book_status("Idea", {}) == "Idea"
+        assert derive_book_status("Plot Outlined", {}) == "Plot Outlined"
+
+    def test_all_outline_keeps_current_status(self):
+        chapters = {
+            "01": {"status": "Outline"},
+            "02": {"status": "Outline"},
+        }
+        assert derive_book_status("Idea", chapters) == "Idea"
+        assert derive_book_status("Plot Outlined", chapters) == "Plot Outlined"
+
+    def test_any_draft_escalates_to_drafting(self):
+        chapters = {
+            "01": {"status": "Draft"},
+            "02": {"status": "Outline"},
+        }
+        assert derive_book_status("Idea", chapters) == "Drafting"
+
+    def test_lowercase_review_escalates_to_drafting(self):
+        # Bug-report case: chapter.yaml uses lowercase "review"
+        chapters = {
+            "01": {"status": "review"},
+            "02": {"status": "Outline"},
+        }
+        assert derive_book_status("Idea", chapters) == "Drafting"
+
+    def test_does_not_regress_past_drafting(self):
+        # If the book is already past Drafting (e.g. Revision), a chapter
+        # at Draft should not pull the book status backward.
+        chapters = {"01": {"status": "Draft"}}
+        assert derive_book_status("Revision", chapters) == "Revision"
+        assert derive_book_status("Editing", chapters) == "Editing"
+        assert derive_book_status("Published", chapters) == "Published"
+
+    def test_unknown_current_status_passes_through_when_no_drafts(self):
+        # Don't mangle unrecognized custom statuses if there's no signal.
+        chapters = {"01": {"status": "Outline"}}
+        assert derive_book_status("Custom Status", chapters) == "Custom Status"
+
+
+# ---------------------------------------------------------------------------
+# get_book_progress: drafted count + completion_percent + derived status
+# ---------------------------------------------------------------------------
+
+
+class TestGetBookProgress:
+    def test_drafted_count_includes_lowercase_review(
+        self, server_module, content_root: Path
+    ):
+        # Reproduces the issue exactly: chapter.yaml status: review
+        project = _write_book(content_root, "review-book")
+        for n in range(1, 4):
+            _write_chapter(project, f"{n:02d}-c", status="review", words=1000)
+        _write_chapter(project, "04-c", status="Outline")
+
+        result = json.loads(server_module.get_book_progress("review-book"))
+
+        assert result["chapters_total"] == 4
+        assert result["chapters_drafted"] == 3, (
+            "Bug #19: 'review' chapters must count toward chapters_drafted"
+        )
+
+    def test_drafted_count_includes_canonical_statuses(
+        self, server_module, content_root: Path
+    ):
+        project = _write_book(content_root, "canon-book")
+        _write_chapter(project, "01-a", status="Draft")
+        _write_chapter(project, "02-b", status="Revision")
+        _write_chapter(project, "03-c", status="Polished")
+        _write_chapter(project, "04-d", status="Final")
+        _write_chapter(project, "05-e", status="Outline")
+
+        result = json.loads(server_module.get_book_progress("canon-book"))
+
+        assert result["chapters_drafted"] == 4
+        assert result["chapters_final"] == 1
+
+    def test_completion_percent_uses_drafted_not_final(
+        self, server_module, content_root: Path
+    ):
+        # Bug #19: 17 of 34 reviewed should be ~50%, not 0%.
+        project = _write_book(content_root, "halfway")
+        for n in range(1, 18):
+            _write_chapter(project, f"{n:02d}-c", status="review", words=2000)
+        for n in range(18, 35):
+            _write_chapter(project, f"{n:02d}-c", status="Outline")
+
+        result = json.loads(server_module.get_book_progress("halfway"))
+
+        assert result["chapters_total"] == 34
+        assert result["chapters_drafted"] == 17
+        assert result["chapters_final"] == 0
+        assert result["completion_percent"] == 50
+
+    def test_status_derived_from_chapter_state(
+        self, server_module, content_root: Path
+    ):
+        # Bug #19: book disk-status "Idea" + drafted chapters → effective "Drafting".
+        project = _write_book(content_root, "stuck-on-idea", status="Idea")
+        _write_chapter(project, "01-c", status="review", words=3000)
+        _write_chapter(project, "02-c", status="Outline")
+
+        result = json.loads(server_module.get_book_progress("stuck-on-idea"))
+
+        assert result["status"] == "Drafting", (
+            "Bug #19: status must reflect chapter-derived progress, not stale frontmatter"
+        )
+
+    def test_status_does_not_regress_when_book_past_drafting(
+        self, server_module, content_root: Path
+    ):
+        project = _write_book(content_root, "in-revision", status="Revision")
+        _write_chapter(project, "01-c", status="Draft")  # backward chapter state
+
+        result = json.loads(server_module.get_book_progress("in-revision"))
+
+        assert result["status"] == "Revision"
+
+    def test_status_unchanged_when_no_chapters_drafted(
+        self, server_module, content_root: Path
+    ):
+        project = _write_book(content_root, "still-planning", status="Plot Outlined")
+        _write_chapter(project, "01-c", status="Outline")
+        _write_chapter(project, "02-c", status="Outline")
+
+        result = json.loads(server_module.get_book_progress("still-planning"))
+
+        assert result["status"] == "Plot Outlined"
+
+
+# ---------------------------------------------------------------------------
+# Indexer surfaces derived status (so list_books, get_book, etc. are consistent)
+# ---------------------------------------------------------------------------
+
+
+class TestIndexerDerivedStatus:
+    def test_list_books_reflects_derived_status(
+        self, server_module, content_root: Path
+    ):
+        project = _write_book(content_root, "indexed-book", status="Idea")
+        _write_chapter(project, "01-c", status="review", words=2000)
+
+        result = json.loads(server_module.list_books())
+        book = next(b for b in result["books"] if b["slug"] == "indexed-book")
+
+        assert book["status"] == "Drafting", (
+            "Bug #19: list_books must reflect derived status from chapter state"
+        )

--- a/tools/state/indexer.py
+++ b/tools/state/indexer.py
@@ -15,6 +15,7 @@ from typing import Any
 from tools.shared.config import CACHE_DIR, CONFIG_PATH, STATE_PATH, load_config
 from tools.state.parsers import (
     count_words_in_file,
+    derive_book_status,
     parse_author_profile,
     parse_book_readme,
     parse_chapter_readme,
@@ -175,6 +176,12 @@ def _scan_books(projects_dir: Path) -> dict[str, Any]:
             book["chapters_data"] = {}
             book["chapter_count"] = 0
             book["total_words"] = 0
+
+        # Issue #19: derive effective status from chapter aggregates so the
+        # book doesn't stay stuck at "Idea" after drafting begins. Preserve
+        # the disk value separately for transparency / future migration.
+        book["status_disk"] = book["status"]
+        book["status"] = derive_book_status(book["status"], book["chapters_data"])
 
         # Scan characters
         chars_dir = book_dir / "characters"

--- a/tools/state/parsers.py
+++ b/tools/state/parsers.py
@@ -213,3 +213,64 @@ def _normalize_character_status(raw: str) -> str:
     if not raw:
         return "Concept"
     return _CHARACTER_STATUS_MAP.get(raw.strip().lower(), raw.strip())
+
+
+# Issue #19: derive book-level status from chapter aggregates so books don't
+# stay stuck at "Idea" after the user starts drafting.
+
+# Ordered book-status progression (lowest → highest). Statuses missing from
+# this list rank as 0 so unknown custom statuses pass through untouched.
+_BOOK_STATUS_RANK = [
+    "Idea",
+    "Concept",
+    "Research",
+    "Plot Outlined",
+    "Characters Created",
+    "World Built",
+    "Drafting",
+    "Revision",
+    "Editing",
+    "Proofread",
+    "Export Ready",
+    "Published",
+]
+
+
+def _book_status_rank(status: str) -> int:
+    try:
+        return _BOOK_STATUS_RANK.index(status)
+    except ValueError:
+        return 0
+
+
+def is_chapter_drafted(status: str) -> bool:
+    """Return True if a chapter status indicates *any* progress past outline.
+
+    Tolerant of case and unknown values: anything other than ``"outline"``
+    (case-insensitive) counts as drafted. This lets non-canonical statuses
+    like ``"review"`` from a user's chapter.yaml be recognized correctly.
+    """
+    if not status:
+        return False
+    return status.strip().lower() != "outline"
+
+
+def derive_book_status(current: str, chapters: dict[str, Any]) -> str:
+    """Derive the effective book status from chapter state.
+
+    Only escalates forward — never moves the book backward. The minimum
+    rule: if any chapter is past Outline, the book is at least "Drafting".
+    Higher tiers (Revision, Editing, …) remain skill-driven because they
+    require qualitative judgment beyond chapter-state aggregation.
+    """
+    current = current or "Idea"
+    if not chapters:
+        return current
+
+    any_drafted = any(is_chapter_drafted(c.get("status", "")) for c in chapters.values())
+    if not any_drafted:
+        return current
+
+    if _book_status_rank(current) < _book_status_rank("Drafting"):
+        return "Drafting"
+    return current


### PR DESCRIPTION
## Summary

Follow-up to #16. Once `chapter.yaml` was being read correctly, three aggregation bugs surfaced in `get_book_progress`.

1. **`chapters_drafted` undercount** — only counted `{Draft, Revision, Polished, Final}`. User's `status: review` (lowercase, from `chapter.yaml`) fell through to zero. New `is_chapter_drafted()` helper: anything past `outline` (case-insensitive) counts.

2. **`completion_percent` based on final, not drafted** — a book with 17/34 reviewed chapters reported 0%. Now uses `drafted / total`. `chapters_final` stays as the separate strict counter.

3. **Book status stuck at `Idea` forever** — derived nothing from chapter state. New `derive_book_status()`: if any chapter is past Outline, the book is at least `Drafting`. Higher tiers stay skill-driven (qualitative judgment beyond aggregation).

## Approach

Derivation runs once in the indexer, so all read tools (`list_books`, `get_book`, `get_book_full`, `get_book_progress`) automatically reflect it. The disk value is preserved as `book["status_disk"]` for transparency. Nothing is written back to disk — README frontmatter stays the source of truth, the derivation just reflects reality at read time.

## Test plan

- [x] 13 new tests in `tests/test_progress_derivation.py`:
  - `derive_book_status` in isolation (no chapters, all outline, any draft, lowercase review, no regression past Drafting)
  - `get_book_progress` integration (drafted count includes lowercase, drafted count includes canonical, completion uses drafted, status derived, no regression, unchanged when no chapters drafted)
  - `list_books` reflects derived status (proves indexer-level derivation)
- [x] Full suite: 200 passed (was 187, +13 new)
- [x] Ruff clean
- [x] Manual verification on `blood-and-binary-firelight` after merge — expect `status: "Drafting"`, `chapters_drafted: 17`, `completion_percent: 50`

## Note on response shape

`get_book_progress` now returns an additional `status_disk` field with the raw README frontmatter value, so callers can detect divergence if needed.

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)