### PR TITLE
feat: start_chapter_draft tool; flip chapter status at writing start (#23)

### DIFF
--- a/servers/storyforge-server/server.py
+++ b/servers/storyforge-server/server.py
@@ -23,7 +23,7 @@ from mcp.server.fastmcp import FastMCP
 from tools.shared.config import load_config, get_content_root, get_genres_dir, get_reference_dir
 from tools.shared.paths import slugify, resolve_project_path, resolve_chapter_path, resolve_author_path, find_chapters, resolve_series_path, resolve_world_dir
 from tools.state.indexer import StateCache, rebuild
-from tools.state.parsers import parse_frontmatter, count_words_in_file, is_chapter_drafted
+from tools.state.parsers import parse_frontmatter, count_words_in_file, is_chapter_drafted, parse_chapter_readme
 from tools.analysis.manuscript_checker import scan_repetitions, render_report
 from tools.claudemd.manager import (
     append_callback as _append_callback_impl,
@@ -652,6 +652,99 @@ description: "{description}"
         "slug": slug,
         "path": str(char_path),
         "message": f"Character '{name}' created",
+    })
+
+
+@mcp.tool()
+def start_chapter_draft(book_slug: str, chapter_slug: str) -> str:
+    """Mark a chapter as actively being drafted.
+
+    Flips chapter status ``Outline → Draft`` (writes to ``chapter.yaml`` if
+    present, otherwise to README frontmatter). Only moves forward — a
+    chapter already at Draft, Revision/review, Polished, or Final is left
+    untouched.
+
+    The chapter-writer skill should call this BEFORE writing the first
+    scene so ``get_book_progress`` and the book-tier derivation reflect
+    active work immediately, not just after Step 7 when the chapter is
+    complete. Later transitions (Draft → Review/Final) still go through
+    ``update_field``.
+
+    Args:
+        book_slug: Book project slug
+        chapter_slug: Chapter directory name (e.g. "01-invisible")
+
+    Returns JSON with before/after status and whether an update occurred.
+    """
+    import yaml as _yaml
+
+    config = load_config()
+    ch_dir = resolve_chapter_path(config, book_slug, chapter_slug)
+
+    if not ch_dir.exists():
+        return json.dumps({
+            "error": f"Chapter '{chapter_slug}' not found in book '{book_slug}'"
+        })
+
+    # Respect the Issue #16 convention: chapter.yaml is the preferred source
+    # of truth. parse_chapter_readme already merges yaml + README frontmatter.
+    chapter_meta = parse_chapter_readme(ch_dir / "README.md")
+    current_status = chapter_meta.get("status") or "Outline"
+
+    # No-op if the chapter has already moved past Outline — we never regress.
+    if is_chapter_drafted(current_status):
+        return json.dumps({
+            "success": True,
+            "book_slug": book_slug,
+            "chapter_slug": chapter_slug,
+            "chapter_status_before": current_status,
+            "chapter_status_after": current_status,
+            "chapter_updated": False,
+            "message": f"Chapter already at '{current_status}' — no change.",
+        })
+
+    # Flip Outline → Draft. Prefer chapter.yaml; migrate from README
+    # frontmatter to chapter.yaml on first touch (canonical source of
+    # truth per #16).
+    chapter_yaml = ch_dir / "chapter.yaml"
+    migrated = False
+
+    if chapter_yaml.exists():
+        try:
+            loaded = _yaml.safe_load(chapter_yaml.read_text(encoding="utf-8"))
+            meta = loaded if isinstance(loaded, dict) else {}
+        except _yaml.YAMLError:
+            meta = {}
+        meta["status"] = "Draft"
+        chapter_yaml.write_text(
+            _yaml.safe_dump(meta, sort_keys=False, allow_unicode=True),
+            encoding="utf-8",
+        )
+    else:
+        # No chapter.yaml — migrate metadata out of README frontmatter
+        # into a fresh chapter.yaml, then strip the frontmatter from
+        # README so we don't carry two stale sources forward.
+        readme = ch_dir / "README.md"
+        text = readme.read_text(encoding="utf-8")
+        fm_meta, body = parse_frontmatter(text)
+        fm_meta["status"] = "Draft"
+        chapter_yaml.write_text(
+            _yaml.safe_dump(fm_meta, sort_keys=False, allow_unicode=True),
+            encoding="utf-8",
+        )
+        # Remove the frontmatter block; keep the body intact.
+        readme.write_text(body.lstrip("\n") if body else "", encoding="utf-8")
+        migrated = True
+
+    _cache.invalidate()
+    return json.dumps({
+        "success": True,
+        "book_slug": book_slug,
+        "chapter_slug": chapter_slug,
+        "chapter_status_before": current_status,
+        "chapter_status_after": "Draft",
+        "chapter_updated": True,
+        "migrated_to_chapter_yaml": migrated,
     })
 
 

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -58,6 +58,15 @@ Ask the user how they want to write this chapter (use AskUserQuestion):
 
 If the user has already chosen a mode in this session (e.g. during a previous chapter), remember their choice and skip the question — but still mention which mode is active.
 
+### Step 2b: Mark Chapter as In-Progress
+Before writing a single word of prose, call MCP `start_chapter_draft(book_slug, chapter_slug)`. This flips the chapter's on-disk status from `Outline → Draft` (only forward — chapters already at `Draft`, `Review`, `Polished`, or `Final` are left alone).
+
+Why this matters:
+- `get_book_progress` and the #21 book-tier derivation reflect active work immediately, not only after Step 7 closes the chapter. Without this, dashboards and next-step recommendations lie during active writing.
+- For legacy chapters that still keep metadata in `README.md` frontmatter, the tool migrates it into `chapter.yaml` on first touch (canonical source per #16) and strips the frontmatter from README. No data loss.
+
+The tool is safe to call redundantly (idempotent) — subsequent calls on a Draft chapter are a no-op.
+
 ---
 
 ### Mode A: Scene-by-Scene Writing (Recommended)
@@ -155,8 +164,11 @@ Reference `chapter-construction.md` on endings:
 ### Step 7: Save and Update (both modes)
 1. Write draft to `{project}/chapters/{chapter}/draft.md` (in scene-by-scene mode, the full draft is already assembled)
 2. Count words — report to user
-3. Update chapter status to "Draft" (or "Review"/"Final" if user specified) via MCP `update_field()`
-4. If this is the first chapter being drafted, update book status to "Drafting"
+3. Update chapter status via MCP `update_field()` on `chapter.yaml`:
+   - User says it's good → `"Review"` or `"Final"` (ask which)
+   - User wants another pass → leave at `"Draft"` (no call needed)
+   - Note: the `Outline → Draft` flip already happened in Step 2b; this step only handles later transitions.
+4. Book-level status — no explicit update needed. The #21 indexer derives the effective book status from chapter aggregates on every read, so the book's tier advances automatically (`Drafting` once any chapter is past Outline, `Revision` once all chapters are at Revision-rank, `Proofread` once all are Final). If the user wants the README frontmatter to reflect this on disk, they can run `update_field()` on the book README explicitly.
 5. **Update timeline** — Add all days/events from this chapter to `{project}/plot/timeline.md`. One row per story-day. This is MANDATORY.
 6. **Update Travel Matrix** — If new routes were introduced in this chapter, add them to the Travel Matrix in `{project}/world/setting.md`.
 7. **Update Canon Log** — Add any new facts established in this chapter to `{project}/plot/canon-log.md`. If this is a **revision** of an existing chapter, mark changed facts as `CHANGED` with the old version in Notes, and add all downstream chapters to the Revision Impact Tracker.

--- a/tests/test_start_chapter_draft.py
+++ b/tests/test_start_chapter_draft.py
@@ -1,0 +1,273 @@
+"""Tests for the ``start_chapter_draft`` MCP tool (Issue #23).
+
+The chapter-writer skill must flip chapter status ``Outline → Draft`` at the
+start of writing, not only at Step 7 after the chapter is complete. This
+keeps ``get_book_progress`` and the #21 book-tier derivation honest during
+active work (otherwise books stay at Drafting-tier until chapter 1 is
+finished, which defeats the purpose).
+
+The tool encapsulates the "only flip forward" logic so skills don't have to
+re-implement it. Later transitions (Draft → Review/Final) stay on Step 7's
+existing ``update_field`` call path.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirrored from other integration tests)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def content_root(tmp_path: Path) -> Path:
+    root = tmp_path / "content"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def mock_config(content_root: Path):
+    fake_config = {
+        "paths": {
+            "content_root": str(content_root),
+            "authors_root": str(content_root / "authors"),
+        },
+        "defaults": {"language": "en", "book_type": "novel"},
+    }
+
+    import server as server_mod  # noqa: WPS433
+    from tools.state import indexer as indexer_mod
+
+    fake_state_path = content_root / "_cache" / "state.json"
+
+    with patch.object(server_mod, "load_config", return_value=fake_config), \
+         patch.object(server_mod, "get_content_root", return_value=content_root), \
+         patch.object(indexer_mod, "load_config", return_value=fake_config), \
+         patch.object(indexer_mod, "STATE_PATH", fake_state_path), \
+         patch.object(indexer_mod, "CACHE_DIR", fake_state_path.parent):
+        server_mod._cache.invalidate()
+        yield fake_config
+
+
+@pytest.fixture
+def server_module(mock_config):
+    import server as server_mod  # noqa: WPS433
+    return server_mod
+
+
+def _write_book(content_root: Path, slug: str = "test-book") -> Path:
+    project = content_root / "projects" / slug
+    project.mkdir(parents=True)
+    (project / "README.md").write_text(
+        f'---\ntitle: "Test"\nslug: "{slug}"\nstatus: "Idea"\n---\n# Test\n',
+        encoding="utf-8",
+    )
+    (project / "chapters").mkdir()
+    return project
+
+
+def _write_chapter_with_yaml(book: Path, slug: str, status: str) -> Path:
+    ch_dir = book / "chapters" / slug
+    ch_dir.mkdir(parents=True)
+    (ch_dir / "README.md").write_text(f"# {slug}\n\nOutline body.\n", encoding="utf-8")
+    (ch_dir / "chapter.yaml").write_text(
+        f'title: "{slug}"\nnumber: 1\nstatus: "{status}"\npov_character: "Alex"\n',
+        encoding="utf-8",
+    )
+    return ch_dir
+
+
+def _write_chapter_with_readme_frontmatter(book: Path, slug: str, status: str) -> Path:
+    ch_dir = book / "chapters" / slug
+    ch_dir.mkdir(parents=True)
+    (ch_dir / "README.md").write_text(
+        f'---\ntitle: "{slug}"\nnumber: 1\nstatus: "{status}"\n---\n# {slug}\n',
+        encoding="utf-8",
+    )
+    return ch_dir
+
+
+# ---------------------------------------------------------------------------
+# start_chapter_draft — core contract
+# ---------------------------------------------------------------------------
+
+
+class TestStartChapterDraft:
+    def test_flips_outline_to_draft_via_chapter_yaml(
+        self, server_module, content_root: Path
+    ):
+        book = _write_book(content_root, "book-a")
+        ch = _write_chapter_with_yaml(book, "01-start", status="Outline")
+
+        result = json.loads(
+            server_module.start_chapter_draft("book-a", "01-start")
+        )
+
+        assert result["success"] is True
+        assert result["chapter_status_before"] == "Outline"
+        assert result["chapter_status_after"] == "Draft"
+        assert result["chapter_updated"] is True
+
+        meta = yaml.safe_load((ch / "chapter.yaml").read_text(encoding="utf-8"))
+        assert meta["status"] == "Draft"
+
+    def test_migrates_readme_frontmatter_to_chapter_yaml_on_first_draft(
+        self, server_module, content_root: Path
+    ):
+        # Legacy chapter without chapter.yaml — the tool migrates metadata
+        # from README frontmatter into chapter.yaml (the canonical source
+        # per #16) and strips the frontmatter from README.
+        book = _write_book(content_root, "book-b")
+        ch = _write_chapter_with_readme_frontmatter(book, "01-start", status="Outline")
+        # Add extra fields to verify they migrate cleanly
+        (ch / "README.md").write_text(
+            '---\ntitle: "The Start"\nnumber: 1\nstatus: "Outline"\n'
+            'pov_character: "Alex"\nword_count_target: 3000\n---\n\n'
+            "# Chapter 1\n\nOutline text here.\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(
+            server_module.start_chapter_draft("book-b", "01-start")
+        )
+
+        assert result["success"] is True
+        assert result["chapter_status_after"] == "Draft"
+        assert result.get("migrated_to_chapter_yaml") is True
+
+        # chapter.yaml now exists with migrated metadata + new status
+        chapter_yaml_path = ch / "chapter.yaml"
+        assert chapter_yaml_path.exists()
+        meta = yaml.safe_load(chapter_yaml_path.read_text(encoding="utf-8"))
+        assert meta["status"] == "Draft"
+        assert meta["title"] == "The Start"
+        assert meta["number"] == 1
+        assert meta["pov_character"] == "Alex"
+        assert meta["word_count_target"] == 3000
+
+        # README frontmatter is stripped; body stays
+        readme_text = (ch / "README.md").read_text(encoding="utf-8")
+        assert "---\ntitle:" not in readme_text
+        assert "# Chapter 1" in readme_text
+        assert "Outline text here." in readme_text
+
+    def test_noop_when_already_draft(self, server_module, content_root: Path):
+        book = _write_book(content_root, "book-c")
+        ch = _write_chapter_with_yaml(book, "01-mid", status="Draft")
+
+        result = json.loads(
+            server_module.start_chapter_draft("book-c", "01-mid")
+        )
+
+        assert result["success"] is True
+        assert result["chapter_status_before"] == "Draft"
+        assert result["chapter_status_after"] == "Draft"
+        assert result["chapter_updated"] is False
+
+        # chapter.yaml untouched
+        meta = yaml.safe_load((ch / "chapter.yaml").read_text(encoding="utf-8"))
+        assert meta["status"] == "Draft"
+
+    def test_noop_when_review_status_does_not_regress(
+        self, server_module, content_root: Path
+    ):
+        # User's lowercase "review" must not get reset to Draft.
+        book = _write_book(content_root, "book-d")
+        ch = _write_chapter_with_yaml(book, "01-reviewed", status="review")
+
+        result = json.loads(
+            server_module.start_chapter_draft("book-d", "01-reviewed")
+        )
+
+        assert result["chapter_updated"] is False
+        meta = yaml.safe_load((ch / "chapter.yaml").read_text(encoding="utf-8"))
+        assert meta["status"] == "review"
+
+    def test_noop_when_final(self, server_module, content_root: Path):
+        book = _write_book(content_root, "book-e")
+        ch = _write_chapter_with_yaml(book, "01-done", status="Final")
+
+        result = json.loads(
+            server_module.start_chapter_draft("book-e", "01-done")
+        )
+
+        assert result["chapter_updated"] is False
+        meta = yaml.safe_load((ch / "chapter.yaml").read_text(encoding="utf-8"))
+        assert meta["status"] == "Final"
+
+    def test_error_when_chapter_not_found(
+        self, server_module, content_root: Path
+    ):
+        _write_book(content_root, "book-f")
+
+        result = json.loads(
+            server_module.start_chapter_draft("book-f", "99-missing")
+        )
+
+        assert "error" in result
+
+    def test_error_when_book_not_found(
+        self, server_module, content_root: Path
+    ):
+        result = json.loads(
+            server_module.start_chapter_draft("nope", "01-chapter")
+        )
+
+        assert "error" in result
+
+    def test_preserves_other_chapter_yaml_fields(
+        self, server_module, content_root: Path
+    ):
+        # Make sure updating status doesn't drop other fields.
+        book = _write_book(content_root, "book-g")
+        ch = book / "chapters" / "01-rich"
+        ch.mkdir(parents=True)
+        (ch / "README.md").write_text("# Chapter\n", encoding="utf-8")
+        (ch / "chapter.yaml").write_text(
+            'title: "Rich"\n'
+            "number: 1\n"
+            'status: "Outline"\n'
+            'pov_character: "Alex"\n'
+            'summary: "The opening of the story."\n'
+            "word_count_target: 3500\n"
+            "act: 1\n",
+            encoding="utf-8",
+        )
+
+        server_module.start_chapter_draft("book-g", "01-rich")
+
+        meta = yaml.safe_load((ch / "chapter.yaml").read_text(encoding="utf-8"))
+        assert meta["status"] == "Draft"
+        assert meta["title"] == "Rich"
+        assert meta["number"] == 1
+        assert meta["pov_character"] == "Alex"
+        assert meta["summary"] == "The opening of the story."
+        assert meta["word_count_target"] == 3500
+        assert meta["act"] == 1
+
+    def test_get_book_progress_reflects_flip_immediately(
+        self, server_module, content_root: Path
+    ):
+        # End-to-end: after start_chapter_draft, the book auto-escalates
+        # to Drafting tier via the #21 indexer derivation.
+        book = _write_book(content_root, "book-h")
+        _write_chapter_with_yaml(book, "01-start", status="Outline")
+        _write_chapter_with_yaml(book, "02-next", status="Outline")
+
+        before = json.loads(server_module.get_book_progress("book-h"))
+        assert before["chapters_drafted"] == 0
+        assert before["status"] == "Idea"
+
+        server_module.start_chapter_draft("book-h", "01-start")
+
+        after = json.loads(server_module.get_book_progress("book-h"))
+        assert after["chapters_drafted"] == 1
+        assert after["status"] == "Drafting"

--- a/tools/state/indexer.py
+++ b/tools/state/indexer.py
@@ -45,10 +45,23 @@ class StateCache:
             return self._state or {}
 
     def invalidate(self) -> None:
-        """Force a rebuild on next access."""
+        """Force a full rebuild on next access.
+
+        Clears the in-memory state AND removes the on-disk cache file.
+        Without deleting the file, ``_load_or_rebuild`` would reload the
+        stale snapshot and silently serve pre-mutation data — the exact
+        opposite of what callers expect after writing to disk.
+        """
         with self._lock:
             self._state = None
             self._state_mtime = 0.0
+            try:
+                STATE_PATH.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError:
+                # Don't let a permissions / filesystem quirk block the cache clear.
+                pass
 
     def _is_stale(self) -> bool:
         """Check if cached state is stale."""


### PR DESCRIPTION
## Summary

Fixes the chapter-writer skill's "status stays at Outline during active writing" gap. The skill now flips `Outline → Draft` at a new Step 2b (before writing a single word), not only at Step 7 after the chapter is complete.

Without this, `get_book_progress` and the #21 book-tier derivation were effectively lying during active work: a book with three chapters being drafted still reported `chapters_drafted: 0` and `status: "Idea"` because no chapter had reached Step 7 yet.

## New MCP tool: `start_chapter_draft(book_slug, chapter_slug)`

- **Idempotent** — only flips forward. Chapters at `Draft`, `Review` (user's alias), `Polished`, or `Final` are left untouched.
- **Canonical write target** — updates `chapter.yaml` (source of truth per #16).
- **Legacy migration** — chapters that still keep metadata in `README.md` frontmatter get migrated into a fresh `chapter.yaml`, and the frontmatter is stripped from README. No data loss, no lingering dual-source ambiguity.

## Skill update

New **Step 2b** in `chapter-writer/SKILL.md` invokes the tool before any prose is written.

**Step 7** is simplified:
- The `Outline → Draft` flip is already done by Step 2b, so it only handles later transitions (`Draft → Review/Final`).
- The "update book status to Drafting" line is removed entirely — #21's indexer derivation handles it on every read.

## Bonus fix: `StateCache.invalidate()` now also deletes the on-disk cache file

A pre-existing bug caught by the integration test: `invalidate()` only cleared the in-memory state. The next `_cache.get()` would then reload the stale cache from `STATE_PATH` instead of rebuilding, silently serving pre-mutation data. After the fix, `invalidate()` matches its name — the next read is guaranteed to rebuild from disk.

## Test plan

- [x] 9 new tests in `tests/test_start_chapter_draft.py`:
  - Flip via `chapter.yaml`
  - Legacy migration from README frontmatter (metadata preserved + frontmatter stripped)
  - No-op when already `Draft` / `review` / `Final`
  - Error handling (missing book, missing chapter)
  - Field preservation during YAML rewrites
  - End-to-end: `start_chapter_draft` → `get_book_progress` sees the flip immediately (catches the `invalidate()` cache bug)
- [x] Full suite: 221 passed (was 212, +9 new)
- [x] Ruff clean
- [x] Manual verification: invoke `chapter-writer` on a fresh chapter — `get_book_progress` should show `chapters_drafted: 1` and `status: "Drafting"` as soon as Step 2b runs, not only after Step 7

## Related

- #16 — chapter.yaml as canonical source (leveraged for migration)
- #21 — book-tier auto-derivation (this PR removes the manual book-status update in Step 7 as redundant)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)