### PR TITLE
feat: auto-sync derived book status to README frontmatter (#25)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,9 @@ World Built → Drafting → Revision → Editing → Proofread → Export Ready
 | `Revision` | every chapter at Revision rank or higher (incl. alias `review`) |
 | `Proofread` | every chapter `Final` |
 
-`Editing`, `Export Ready`, and `Published` remain **explicit** — they require qualitative judgment beyond chapter-state aggregation. The raw README frontmatter value is preserved as `book.status_disk` for transparency; auto-derivation never writes back to disk.
+`Editing`, `Export Ready`, and `Published` remain **explicit** — they require qualitative judgment beyond chapter-state aggregation.
+
+**Auto-sync to disk** (Issue #25): `rebuild_state()` writes the derived status back to README frontmatter when it's a **forward move** from the on-disk value. Floor rule — a user-set higher tier (`Export Ready`, `Published`) is never silently downgraded by chapter aggregates. Sync events are returned in the `synced` field of the rebuild response. Books without any frontmatter block get a minimal one created. `book.status_disk` remains as a debug signal (after auto-sync it always matches `book.status`).
 
 Chapter-status aliases for ranking (display string is preserved):
 

--- a/servers/storyforge-server/server.py
+++ b/servers/storyforge-server/server.py
@@ -198,16 +198,28 @@ def update_session(
 
 @mcp.tool()
 def rebuild_state() -> str:
-    """Force rebuild of the state cache from filesystem."""
+    """Force rebuild of the state cache from filesystem.
+
+    Also runs the Issue #25 auto-sync: any book whose derived status
+    (from chapter aggregates) is a forward move from its on-disk README
+    frontmatter gets its README updated in place. Floor rule — never
+    downgrades a user-set higher tier. Sync events are returned in the
+    ``synced`` list so the user can see what changed.
+    """
     state = rebuild(preserve_session=True)
     _cache.invalidate()
     books_count = len(state.get("books", {}))
     authors_count = len(state.get("authors", {}))
+    synced = state.get("sync_log", [])
+    msg = f"Rebuilt state: {books_count} books, {authors_count} authors"
+    if synced:
+        msg += f"; synced {len(synced)} book status(es) to disk"
     return json.dumps({
         "success": True,
         "books": books_count,
         "authors": authors_count,
-        "message": f"Rebuilt state: {books_count} books, {authors_count} authors",
+        "synced": synced,
+        "message": msg,
     })
 
 

--- a/tests/test_auto_sync_book_status.py
+++ b/tests/test_auto_sync_book_status.py
@@ -1,0 +1,306 @@
+"""Tests for auto-sync of derived book status to README frontmatter (Issue #25).
+
+After #19/#21, `get_book_progress` exposes a derived ``status`` (from
+aggregate chapter state) alongside ``status_disk`` (raw frontmatter). The
+divergence was visible but not self-healing: the user had to manually fix
+README to keep the two in sync. Issue #25 closes that loop.
+
+The indexer now writes the derived status back to the README frontmatter
+whenever the derived rank is **higher** than the disk rank. The floor rule
+ensures a user-set higher tier (e.g. ``Export Ready`` set by hand) is
+never silently downgraded by chapter aggregates.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools.state.parsers import parse_frontmatter
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def content_root(tmp_path: Path) -> Path:
+    root = tmp_path / "content"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def mock_config(content_root: Path):
+    fake_config = {
+        "paths": {
+            "content_root": str(content_root),
+            "authors_root": str(content_root / "authors"),
+        },
+        "defaults": {"language": "en", "book_type": "novel"},
+    }
+
+    import server as server_mod  # noqa: WPS433
+    from tools.state import indexer as indexer_mod
+
+    fake_state_path = content_root / "_cache" / "state.json"
+
+    with patch.object(server_mod, "load_config", return_value=fake_config), \
+         patch.object(server_mod, "get_content_root", return_value=content_root), \
+         patch.object(indexer_mod, "load_config", return_value=fake_config), \
+         patch.object(indexer_mod, "STATE_PATH", fake_state_path), \
+         patch.object(indexer_mod, "CACHE_DIR", fake_state_path.parent):
+        server_mod._cache.invalidate()
+        yield fake_config
+
+
+@pytest.fixture
+def server_module(mock_config):
+    import server as server_mod  # noqa: WPS433
+    return server_mod
+
+
+def _write_book_with_frontmatter(
+    content_root: Path, slug: str, disk_status: str, extra_fields: str = ""
+) -> Path:
+    project = content_root / "projects" / slug
+    project.mkdir(parents=True)
+    (project / "README.md").write_text(
+        f'---\ntitle: "Test"\nslug: "{slug}"\nstatus: "{disk_status}"\n'
+        f'target_word_count: 30000\n{extra_fields}---\n\n# {slug}\n\nBody stays intact.\n',
+        encoding="utf-8",
+    )
+    (project / "chapters").mkdir()
+    return project
+
+
+def _write_book_without_frontmatter(content_root: Path, slug: str) -> Path:
+    # Edge case: README with no frontmatter block at all
+    project = content_root / "projects" / slug
+    project.mkdir(parents=True)
+    (project / "README.md").write_text(
+        f"# {slug}\n\nPure markdown body, no frontmatter.\n",
+        encoding="utf-8",
+    )
+    (project / "chapters").mkdir()
+    return project
+
+
+def _write_chapter(book: Path, slug: str, status: str) -> Path:
+    ch = book / "chapters" / slug
+    ch.mkdir(parents=True)
+    (ch / "README.md").write_text("# Body\n", encoding="utf-8")
+    (ch / "chapter.yaml").write_text(
+        f'title: "{slug}"\nstatus: "{status}"\n', encoding="utf-8"
+    )
+    return ch
+
+
+def _read_readme_status(project: Path) -> str:
+    text = (project / "README.md").read_text(encoding="utf-8")
+    meta, _ = parse_frontmatter(text)
+    return meta.get("status", "")
+
+
+# ---------------------------------------------------------------------------
+# Forward-sync cases
+# ---------------------------------------------------------------------------
+
+
+class TestAutoSyncForward:
+    def test_syncs_idea_to_drafting_when_chapter_started(
+        self, server_module, content_root: Path
+    ):
+        project = _write_book_with_frontmatter(content_root, "book-a", "Idea")
+        _write_chapter(project, "01-c", status="Draft")
+
+        server_module.rebuild_state()
+
+        assert _read_readme_status(project) == "Drafting"
+
+    def test_syncs_idea_to_revision_when_all_chapters_reviewed(
+        self, server_module, content_root: Path
+    ):
+        # Bug scenario from #25: blood-and-binary book with lots of "review" chapters.
+        project = _write_book_with_frontmatter(content_root, "book-b", "Idea")
+        _write_chapter(project, "01-c", status="review")
+        _write_chapter(project, "02-c", status="review")
+
+        server_module.rebuild_state()
+
+        assert _read_readme_status(project) == "Revision"
+
+    def test_syncs_drafting_to_revision(self, server_module, content_root: Path):
+        # User had manually set Drafting; all chapters now at review → escalate.
+        project = _write_book_with_frontmatter(content_root, "book-c", "Drafting")
+        _write_chapter(project, "01-c", status="review")
+        _write_chapter(project, "02-c", status="review")
+
+        server_module.rebuild_state()
+
+        assert _read_readme_status(project) == "Revision"
+
+    def test_syncs_idea_to_proofread_when_all_final(
+        self, server_module, content_root: Path
+    ):
+        project = _write_book_with_frontmatter(content_root, "book-d", "Idea")
+        _write_chapter(project, "01-c", status="Final")
+        _write_chapter(project, "02-c", status="Final")
+
+        server_module.rebuild_state()
+
+        assert _read_readme_status(project) == "Proofread"
+
+
+# ---------------------------------------------------------------------------
+# Floor rule: never downgrade a user-set higher status
+# ---------------------------------------------------------------------------
+
+
+class TestFloorRule:
+    def test_export_ready_not_downgraded_by_drafting_chapters(
+        self, server_module, content_root: Path
+    ):
+        # User explicitly marked the book as Export Ready. Draft chapters
+        # (derived: Drafting) must NOT pull it back.
+        project = _write_book_with_frontmatter(content_root, "book-e", "Export Ready")
+        _write_chapter(project, "01-c", status="Draft")
+
+        server_module.rebuild_state()
+
+        assert _read_readme_status(project) == "Export Ready"
+
+    def test_published_not_touched_by_any_chapter_state(
+        self, server_module, content_root: Path
+    ):
+        project = _write_book_with_frontmatter(content_root, "book-f", "Published")
+        _write_chapter(project, "01-c", status="Outline")
+        _write_chapter(project, "02-c", status="Final")
+
+        server_module.rebuild_state()
+
+        assert _read_readme_status(project) == "Published"
+
+    def test_no_change_when_disk_already_matches_derived(
+        self, server_module, content_root: Path
+    ):
+        project = _write_book_with_frontmatter(content_root, "book-g", "Drafting")
+        _write_chapter(project, "01-c", status="Draft")
+        _write_chapter(project, "02-c", status="Outline")
+
+        # Capture mtime before
+        readme = project / "README.md"
+        import os
+        mtime_before = os.path.getmtime(readme)
+
+        # Sleep tiny bit to ensure mtime resolution catches any write
+        import time
+        time.sleep(0.01)
+
+        server_module.rebuild_state()
+
+        mtime_after = os.path.getmtime(readme)
+        assert mtime_before == mtime_after, "README must not be rewritten when disk == derived"
+
+
+# ---------------------------------------------------------------------------
+# Edge: README has no frontmatter block at all
+# ---------------------------------------------------------------------------
+
+
+class TestNoFrontmatterEdgeCase:
+    def test_creates_frontmatter_when_missing(
+        self, server_module, content_root: Path
+    ):
+        # Legacy book with no frontmatter at all. The indexer should add one.
+        project = _write_book_without_frontmatter(content_root, "book-h")
+        _write_chapter(project, "01-c", status="review")
+        _write_chapter(project, "02-c", status="review")
+
+        server_module.rebuild_state()
+
+        text = (project / "README.md").read_text(encoding="utf-8")
+        assert text.startswith("---\n")
+        meta, body = parse_frontmatter(text)
+        assert meta["status"] == "Revision"
+        # Body preserved
+        assert "# book-h" in body or "Pure markdown body" in body
+
+
+# ---------------------------------------------------------------------------
+# Preserves other frontmatter and body content
+# ---------------------------------------------------------------------------
+
+
+class TestPreservesOtherContent:
+    def test_other_frontmatter_fields_intact(
+        self, server_module, content_root: Path
+    ):
+        project = _write_book_with_frontmatter(
+            content_root,
+            "book-i",
+            "Idea",
+            extra_fields=(
+                'author: "test-author"\n'
+                'genres: ["horror", "fantasy"]\n'
+                'language: "en"\n'
+                'description: "A gripping tale."\n'
+            ),
+        )
+        _write_chapter(project, "01-c", status="Draft")
+
+        server_module.rebuild_state()
+
+        meta, _ = parse_frontmatter((project / "README.md").read_text(encoding="utf-8"))
+        assert meta["status"] == "Drafting"  # updated
+        assert meta["author"] == "test-author"
+        assert meta["genres"] == ["horror", "fantasy"]
+        assert meta["language"] == "en"
+        assert meta["description"] == "A gripping tale."
+        assert meta["target_word_count"] == 30000
+
+    def test_body_content_intact(self, server_module, content_root: Path):
+        project = _write_book_with_frontmatter(content_root, "book-j", "Idea")
+        _write_chapter(project, "01-c", status="Draft")
+
+        server_module.rebuild_state()
+
+        text = (project / "README.md").read_text(encoding="utf-8")
+        assert "Body stays intact." in text
+
+
+# ---------------------------------------------------------------------------
+# rebuild_state response includes sync log
+# ---------------------------------------------------------------------------
+
+
+class TestRebuildStateResponse:
+    def test_response_includes_updated_books_log(
+        self, server_module, content_root: Path
+    ):
+        project = _write_book_with_frontmatter(content_root, "book-k", "Idea")
+        _write_chapter(project, "01-c", status="Draft")
+
+        result = json.loads(server_module.rebuild_state())
+
+        assert "synced" in result
+        assert any(
+            s.get("book") == "book-k"
+            and s.get("from") == "Idea"
+            and s.get("to") == "Drafting"
+            for s in result["synced"]
+        )
+
+    def test_response_empty_sync_log_when_nothing_to_update(
+        self, server_module, content_root: Path
+    ):
+        project = _write_book_with_frontmatter(content_root, "book-l", "Drafting")
+        _write_chapter(project, "01-c", status="Draft")
+
+        result = json.loads(server_module.rebuild_state())
+
+        assert result.get("synced", []) == []

--- a/tools/state/indexer.py
+++ b/tools/state/indexer.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from tools.shared.config import CACHE_DIR, CONFIG_PATH, STATE_PATH, load_config
 from tools.state.parsers import (
+    _book_status_rank,
     count_words_in_file,
     derive_book_status,
     parse_author_profile,
@@ -104,6 +105,8 @@ def build_state() -> dict[str, Any]:
     content_root = Path(config["paths"]["content_root"])
     authors_root = Path(config["paths"]["authors_root"])
 
+    sync_log: list[dict[str, str]] = []
+
     state: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "plugin_version": PLUGIN_VERSION,
@@ -113,6 +116,7 @@ def build_state() -> dict[str, Any]:
         "authors": {},
         "series": {},
         "ideas": [],
+        "sync_log": sync_log,
         "session": {
             "last_book": "",
             "last_chapter": "",
@@ -124,7 +128,7 @@ def build_state() -> dict[str, Any]:
     # Scan books
     projects_dir = content_root / "projects"
     if projects_dir.exists():
-        state["books"] = _scan_books(projects_dir)
+        state["books"] = _scan_books(projects_dir, sync_log)
 
     # Scan authors
     if authors_root.exists():
@@ -165,8 +169,16 @@ def rebuild(preserve_session: bool = True) -> dict[str, Any]:
 # --- Scanners ---
 
 
-def _scan_books(projects_dir: Path) -> dict[str, Any]:
-    """Scan all book project directories."""
+def _scan_books(
+    projects_dir: Path, sync_log: list[dict[str, str]] | None = None
+) -> dict[str, Any]:
+    """Scan all book project directories.
+
+    When ``sync_log`` is provided (Issue #25), each book's README frontmatter
+    is updated in place if the derived status is a forward move from the
+    disk status. Forward-sync events are appended to the list. Pass
+    ``None`` to skip disk writes (read-only scan).
+    """
     books = {}
 
     for book_dir in sorted(projects_dir.iterdir()):
@@ -191,10 +203,23 @@ def _scan_books(projects_dir: Path) -> dict[str, Any]:
             book["total_words"] = 0
 
         # Issue #19: derive effective status from chapter aggregates so the
-        # book doesn't stay stuck at "Idea" after drafting begins. Preserve
-        # the disk value separately for transparency / future migration.
-        book["status_disk"] = book["status"]
-        book["status"] = derive_book_status(book["status"], book["chapters_data"])
+        # book doesn't stay stuck at "Idea" after drafting begins.
+        disk_status = book["status"]
+        derived_status = derive_book_status(disk_status, book["chapters_data"])
+
+        # Issue #25: write the derived status back to README frontmatter
+        # when it's a forward move (floor rule — never downgrade a user-set
+        # higher tier like "Export Ready" or "Published").
+        if sync_log is not None:
+            sync_event = _sync_book_status_to_disk(book_dir, disk_status, derived_status)
+            if sync_event is not None:
+                sync_log.append(sync_event)
+                book["status_disk"] = derived_status  # disk now matches derived
+            else:
+                book["status_disk"] = disk_status
+        else:
+            book["status_disk"] = disk_status
+        book["status"] = derived_status
 
         # Scan characters
         chars_dir = book_dir / "characters"
@@ -208,6 +233,45 @@ def _scan_books(projects_dir: Path) -> dict[str, Any]:
         books[slug] = book
 
     return books
+
+
+def _sync_book_status_to_disk(
+    project_dir: Path, disk_status: str, derived_status: str
+) -> dict[str, str] | None:
+    """Write derived book status back to README frontmatter (Issue #25).
+
+    Only writes when ``derived_status`` is a strictly forward move from
+    ``disk_status`` (floor rule — never downgrades a user-set higher tier).
+    Returns a sync event dict on write, ``None`` otherwise.
+
+    Edge case: a README with no frontmatter block at all gets a minimal
+    block prepended. Existing frontmatter fields and body content are
+    preserved verbatim.
+    """
+    import yaml as _yaml
+
+    if _book_status_rank(derived_status) <= _book_status_rank(disk_status):
+        return None
+
+    readme = project_dir / "README.md"
+    text = readme.read_text(encoding="utf-8")
+    meta, body = parse_frontmatter(text)
+
+    if not meta:
+        # parse_frontmatter returned (empty, original_text) — no block found.
+        # Prepend a minimal frontmatter while keeping the original content.
+        new_text = f"---\nstatus: {derived_status}\n---\n\n{body}"
+    else:
+        meta["status"] = derived_status
+        fm = _yaml.safe_dump(meta, sort_keys=False, allow_unicode=True)
+        new_text = f"---\n{fm}---\n{body}"
+
+    readme.write_text(new_text, encoding="utf-8")
+    return {
+        "book": project_dir.name,
+        "from": disk_status or "Idea",
+        "to": derived_status,
+    }
 
 
 def _scan_chapters(chapters_dir: Path) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Closes the self-healing loop #19/#21 left open. Before: `get_book_progress` exposed the divergence between derived `status` (from chapter aggregates) and `status_disk` (from README frontmatter), but fixing the disk value was still manual — and re-diverged every time chapter state progressed.

Now `rebuild_state()` writes the derived value back to README frontmatter whenever it's a strictly forward move. After any rebuild, disk and derived match. No manual maintenance.

## Floor rule

A user-set higher tier (`Export Ready`, `Published`) is **never** silently downgraded by chapter aggregates. The derivation is a floor, not a ceiling:

- Disk `Idea` + derived `Drafting` → write `Drafting` ✓
- Disk `Export Ready` + derived `Drafting` → **no write** (floor rule)
- Disk `Drafting` + derived `Drafting` → **no write** (no change)

## Edge case: no frontmatter

Legacy READMEs without a frontmatter block get a minimal `---\nstatus: <derived>\n---\n` prepended. Body content preserved verbatim.

All other frontmatter fields (`author`, `genres`, `language`, `target_word_count`, etc.) are preserved through a `yaml.safe_dump` round-trip.

## Sync log

New `rebuild_state` response field:

```json
{
  "success": true,
  "books": 3,
  "authors": 1,
  "synced": [
    {"book": "blood-and-binary-firelight", "from": "Idea", "to": "Revision"}
  ],
  "message": "Rebuilt state: 3 books, 1 authors; synced 1 book status(es) to disk"
}
```

Makes the sync visible and auditable — the user sees what changed, and when.

## Design note

Sync runs on every `build_state()` invocation (read-only `_scan_books` callers can pass `sync_log=None` to opt out). In practice `build_state` runs rarely — first access, explicit `rebuild_state`, cache miss after invalidation — so the write amplification is negligible, and each write is idempotent (only if derived > disk).

`book.status_disk` remains in the schema as a debug signal; after any rebuild it always equals `book.status`. Could be deprecated later if we want to simplify, but kept for now to avoid breaking external consumers.

## Test plan

- [x] 12 new tests in `tests/test_auto_sync_book_status.py`:
  - Forward sync (Idea → Drafting, → Revision, → Proofread, Drafting → Revision)
  - Floor rule (Export Ready not downgraded, Published untouched, no-op when matching via mtime check)
  - No-frontmatter edge case (fresh block prepended, body preserved)
  - Other frontmatter fields preserved across write-back
  - Body content preserved
  - `rebuild_state` response includes sync log with `from`/`to` per book
  - Empty sync log when nothing needs updating
- [x] Full suite: 233 passed (was 221, +12 new)
- [x] Ruff clean
- [x] CLAUDE.md updated with auto-sync section
- [x] Manual verification on `blood-and-binary-firelight`: call `rebuild_state()` → expect `{"synced": [{"book": "blood-and-binary-firelight", "from": "Idea", "to": "Drafting"}]}` (or `Revision` depending on current chapter state), README frontmatter updated, subsequent `get_book_progress` returns `status == status_disk`.

## Related

- #16 — chapter.yaml reading — merged (#18)
- #19 — aggregate count + book-status derivation — merged (#20)
- #21 — higher-tier auto-derivation — merged (#22)
- #23 — chapter-writer status flip on write start — merged (#24)
- #17 — world/ vs worldbuilding/ — merged (#18)

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)