### PR TITLE
feat: add get_character MCP tool

### DIFF
--- a/servers/storyforge-server/server.py
+++ b/servers/storyforge-server/server.py
@@ -21,7 +21,7 @@ if plugin_root not in sys.path:
 from mcp.server.fastmcp import FastMCP
 
 from tools.shared.config import load_config, get_content_root, get_genres_dir, get_reference_dir
-from tools.shared.paths import slugify, resolve_project_path, resolve_chapter_path, resolve_author_path, find_chapters, resolve_series_path, resolve_world_dir
+from tools.shared.paths import slugify, resolve_project_path, resolve_chapter_path, resolve_character_path, resolve_author_path, find_chapters, resolve_series_path, resolve_world_dir
 from tools.state.indexer import StateCache, rebuild
 from tools.state.parsers import parse_frontmatter, count_words_in_file, is_chapter_drafted, parse_chapter_readme
 from tools.analysis.manuscript_checker import scan_repetitions, render_report
@@ -1367,6 +1367,32 @@ def get_book_claudemd(book_slug: str) -> str:
     except FileNotFoundError as exc:
         return json.dumps({"error": str(exc)})
     return json.dumps({"content": content})
+
+
+@mcp.tool()
+def get_character(book_slug: str, character_slug: str) -> str:
+    """Read the full character file for a book.
+
+    Args:
+        book_slug: Book slug (exact match)
+        character_slug: Character slug without extension
+    """
+    config = load_config()
+    project_path = resolve_project_path(config, book_slug)
+    if not project_path.exists():
+        return json.dumps({"error": f"Book '{book_slug}' not found"})
+
+    # Primary layout: characters/{slug}.md
+    primary = resolve_character_path(config, book_slug, character_slug)
+    if primary.exists():
+        return json.dumps({"content": primary.read_text(encoding="utf-8")})
+
+    # Legacy layout: characters/{slug}/README.md
+    legacy = project_path / "characters" / character_slug / "README.md"
+    if legacy.exists():
+        return json.dumps({"content": legacy.read_text(encoding="utf-8")})
+
+    return json.dumps({"error": f"Character '{character_slug}' not found in book '{book_slug}'"})
 
 
 @mcp.tool()

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -27,7 +27,7 @@ Before writing a SINGLE word, load ALL of these:
    - `pacing-guide` (scene vs. summary, rhythm)
    - `anti-ai-patterns` (what to avoid at ALL costs)
    - `prose-style` (word choice, rhythm, devices)
-8. **Character files** — Read all characters appearing in this chapter.
+8. **Character files** — For each character appearing in this chapter, call MCP `get_character(book_slug, character_slug)`. Use the slugified name (e.g. "Jane Doe" → "jane-doe"). If the tool returns `{"error": ...}`, note it and proceed — don't fall back to direct file reads.
 9. **World files** — Read `{project}/world/setting.md` (includes the Travel Matrix). Mandatory if the chapter involves any travel or location references.
 10. **Story timeline** — Read `{project}/plot/timeline.md`. Mandatory for ALL chapters. This is the canonical day/date reference.
 11. **Canon log** — Read `{project}/plot/canon-log.md`. Mandatory for ALL chapters. This tracks established facts and revision changes. Pay special attention to facts marked `CHANGED` — never reference the old version.

--- a/tests/test_get_character.py
+++ b/tests/test_get_character.py
@@ -1,0 +1,60 @@
+"""Tests for the get_character MCP tool (issue #29)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import server
+
+
+@pytest.fixture
+def config(tmp_path: Path) -> dict:
+    content_root = tmp_path / "books"
+    book_dir = content_root / "projects" / "my-book" / "characters"
+    book_dir.mkdir(parents=True)
+    return {"paths": {"content_root": str(content_root)}}
+
+
+@pytest.fixture
+def config_with_character(config: dict, tmp_path: Path) -> dict:
+    char_file = tmp_path / "books" / "projects" / "my-book" / "characters" / "jane-doe.md"
+    char_file.write_text("# Jane Doe\n\nProtagonist. Sharp wit, hidden grief.\n", encoding="utf-8")
+    return config
+
+
+@pytest.fixture
+def config_legacy_layout(config: dict, tmp_path: Path) -> dict:
+    """Character stored in legacy folder-per-character layout."""
+    legacy_dir = tmp_path / "books" / "projects" / "my-book" / "characters" / "old-hero"
+    legacy_dir.mkdir(parents=True)
+    (legacy_dir / "README.md").write_text("# Old Hero\n\nLegacy character.\n", encoding="utf-8")
+    return config
+
+
+class TestGetCharacter:
+    def test_hit_returns_content(self, config_with_character: dict, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(server, "load_config", lambda: config_with_character)
+        result = json.loads(server.get_character("my-book", "jane-doe"))
+        assert "content" in result
+        assert "Jane Doe" in result["content"]
+
+    def test_miss_bad_book(self, config: dict, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(server, "load_config", lambda: config)
+        result = json.loads(server.get_character("nonexistent-book", "jane-doe"))
+        assert "error" in result
+        assert "nonexistent-book" in result["error"]
+
+    def test_miss_bad_character(self, config_with_character: dict, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(server, "load_config", lambda: config_with_character)
+        result = json.loads(server.get_character("my-book", "nobody"))
+        assert "error" in result
+        assert "nobody" in result["error"]
+
+    def test_legacy_layout_fallback(self, config_legacy_layout: dict, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(server, "load_config", lambda: config_legacy_layout)
+        result = json.loads(server.get_character("my-book", "old-hero"))
+        assert "content" in result
+        assert "Legacy character" in result["content"]


### PR DESCRIPTION
## Summary

- Adds `get_character(book_slug, character_slug)` to `storyforge-mcp` — same JSON contract as `get_book_claudemd`: `{"content": "..."}` on hit, `{"error": "..."}` on miss
- Supports primary flat layout (`characters/{slug}.md`) with fallback to legacy folder layout (`characters/{slug}/README.md`)
- Updates `chapter-writer` skill step 8 to use the MCP tool instead of direct file reads

## Test plan

- [ ] `test_hit_returns_content` — character file exists, returns content
- [ ] `test_miss_bad_book` — book directory doesn't exist, returns error with book slug
- [ ] `test_miss_bad_character` — book exists but character missing, returns error with character slug
- [ ] `test_legacy_layout_fallback` — character in `{slug}/README.md` folder layout, still returned
- [ ] Full suite: 237 tests pass

Closes #29