### PR TITLE
feat: add simile discipline scan to chapter-writer (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Nothing yet
+- `reference/craft/simile-discipline.md` — new craft reference codifying the two-question test for similes (literal resemblance? real work?), failure modes, author-voice bias, and revision moves (closes #31)
+- `chapter-writer` Step 6c: mandatory pre-save Simile Discipline Scan in both scene-by-scene and full-chapter modes, with per-marker inspection (`like`, `as if`, `as [adj] as`, `the way X`, `the kind of X that Y`, etc.), stack-density check, dead-simile rejection, and book-CLAUDE.md override check
+- `chapter-reviewer`: new review point 10b "Simile discipline" under Craft, plus a dedicated Simile Report block in the output format
+- `manuscript-checker`: simile-discipline reference note clarifying that the existing `simile` category is cross-chapter repetition while per-simile quality lives in the craft doc; interactive-fix rules now apply the two-question test to each `simile` finding
 
 ### Changed
-- Nothing yet
+- `chapter-writer` mandatory loads (Prerequisites item 7): `simile-discipline` added to the craft-reference list
+- `chapter-reviewer` mandatory loads: `simile-discipline` added to the craft-reference list
+- Root `CLAUDE.md` skill-load map: chapter-writer and chapter-reviewer entries updated to list simile-discipline (chapter-writer now also correctly lists prose-style)
 
 ### Deprecated
 - Nothing yet

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,8 @@ Books can combine 1-3 genres.
 `{plugin_root}/reference/genre/` contains genre-specific craft guides.
 
 Skills MUST load relevant craft references before generating creative content:
-- `chapter-writer` → loads: chapter-construction, dialog-craft, show-dont-tell, pacing-guide, anti-ai-patterns + genre craft
+- `chapter-writer` → loads: chapter-construction, dialog-craft, show-dont-tell, pacing-guide, anti-ai-patterns, prose-style, simile-discipline + genre craft
+- `chapter-reviewer` → loads: dos-and-donts, anti-ai-patterns, chapter-construction, dialog-craft, show-dont-tell, simile-discipline
 - `plot-architect` → loads: story-structure, plot-craft, tension-and-suspense
 - `character-creator` → loads: character-creation, character-arcs
 - `world-builder` → loads: world-building

--- a/reference/craft/simile-discipline.md
+++ b/reference/craft/simile-discipline.md
@@ -1,0 +1,168 @@
+# Simile Discipline: When Comparisons Work and When They Don't
+
+Similes are among the most abused tools in fiction. Used well, a simile sharpens an image the reader couldn't otherwise picture, reveals character through the comparison itself, or lands a tonal beat that bare description misses. Used badly, it is decoration — pretty-sounding placeholder prose that tells the reader nothing, and worse, that trains their eye to skim.
+
+This document draws a line between the two. The test is not whether a simile is present. It is whether the simile **does work** that the sentence could not do without it.
+
+## The Core Test
+
+Before every simile survives a scene, two questions must be answered honestly:
+
+1. **Can the reader picture it literally?** If the vehicle (the thing being compared to) doesn't resemble the tenor (the thing being described) in any concrete, imaginable way, the simile fails. Comparisons must be *actually true*, not vaguely poetic.
+2. **Does it do work that a concrete beat couldn't?** If a plain, specific sentence would convey the same meaning without loss — and the simile only adds flourish — cut the simile. Flourish is not work.
+
+If a comparison passes both, it earns its place. If it fails either, it is decoration.
+
+> **The Replacement Test** (from `prose-style.md`): If you can replace a simile with a simple declarative statement and lose no meaning, the simile is likely clichéd or empty. The simile must carry information the replacement cannot.
+
+## The Failure Modes
+
+Most bad similes fall into one of these categories. Learn to recognize them on sight.
+
+### 1. The Illogical Comparison
+
+The comparison doesn't make literal sense. The vehicle cannot actually resemble the tenor in any physical, sensory, or structural way. It sounds vaguely meaningful but describes nothing.
+
+**Failing:**
+> Viktor worked through a drill that moved like a conversation.
+
+A drill does not move like a conversation. Conversations are not movements. The reader cannot picture this. It sounds thoughtful, but it is empty.
+
+**Working:**
+> Viktor worked through a drill with the rhythm of an argument — strike, pause, counter, pause, strike again, faster now.
+
+Here the vehicle (an argument's rhythm) actually resembles the tenor (the drill's cadence) in a specific, describable way: alternation, escalation, the pressure of call-and-response. The reader can picture it.
+
+### 2. The Empty Abstraction
+
+The comparison reaches for an abstract concept where a concrete one would land. Abstract vehicles almost never resemble concrete tenors, because abstractions have no shape.
+
+**Failing:**
+> Her grief was like the weight of history.
+
+History has no weight. "Weight of history" is itself already a dead metaphor. The simile is decorating an abstraction with another abstraction.
+
+**Working:**
+> Her grief was like a wet coat she had forgotten she was wearing, until she tried to move.
+
+A wet coat is specific. It has weight, it is uncomfortable, it drags at the shoulders, it is forgotten in stillness and noticed in motion. The comparison does work.
+
+### 3. The Decorative "The Kind Of X That Y"
+
+The "the kind of [noun] that [verb]" construction is a frequent AI-tell and a frequent writer-tell for a simile that is trying to sound profound without doing anything.
+
+**Failing:**
+> He had the kind of voice that made silence feel like an accusation.
+
+What does that mean? Silence made accusing by a voice? Try to picture it. You can't. It's a sentence that wants to be quoted, not read.
+
+**Working (or cut):**
+Often the right move is to delete the sentence and replace it with what the voice actually *does* in the scene — the specific pitch, pace, or word choice that would make a character in the room flinch. Showing beats comparing.
+
+### 4. The Stacked Simile
+
+Two or three similes in the same paragraph. Each is doing decorative work. Together they stop the prose, demand that the reader stop picturing and start admiring.
+
+**Failing:**
+> She moved like water through the crowd, her laugh like a bell, her eyes bright as coins in the low light.
+
+Three similes in one sentence. The reader feels none of them. The character is now a composite of decorations rather than a person.
+
+**Rule of thumb:** At most one simile per paragraph unless each one is *doing distinct, necessary work*. When in doubt, pick the strongest and cut the others.
+
+### 5. The Over-Specific Sensation
+
+A cousin to #1. A physical sensation is compared to something so precise and strange that the reader has to stop and work out what it means, and the payoff isn't worth the pause.
+
+**Failing:**
+> His stomach dropped like a small animal the floor shouldn't have been able to do.
+
+Grammatically this doesn't even parse. Book-scoped rules in real projects have had to ban "things the floor shouldn't do" and "gone somewhere the face wasn't following" precisely because this failure mode recurs.
+
+**Working:**
+> His stomach dropped. Just that — the sudden unmistakable loss of altitude you feel before you realize you're falling.
+
+The comparison is still present ("the loss of altitude before you realize you're falling") but it describes something the reader has actually felt.
+
+### 6. The Dead Simile
+
+A comparison so worn it no longer creates an image. These are the similes readers skip without noticing.
+
+- *pale as a ghost*
+- *quiet as a mouse*
+- *quick as lightning*
+- *cold as ice*
+- *sharp as a knife*
+- *like a deer in headlights*
+- *like a kid in a candy store*
+
+If it sounds familiar, it's probably dead. Either invent a fresh comparison or drop the simile entirely.
+
+## Simile Markers — What to Scan For
+
+When a scene is drafted, walk the prose and flag every instance of these markers. Each one is a simile, and each one must survive the two-question test:
+
+- `like [noun]` — the dominant form
+- `as [adj] as [noun]` — "as cold as a morgue floor"
+- `as if [clause]` — "as if she'd heard that voice before"
+- `the way [subject] [verb]` — "the way a diver breaks the surface"
+- `moved like`, `felt like`, `sounded like`, `looked like`, `seemed like`
+- `resembled`, `reminded [him/her] of` — softer similes but still comparisons
+- `gave the impression of`, `had the air of` — formal simile-equivalents
+
+A paragraph with two or more markers is a flag even before the individual check — it's either doing heavy voice work (author's deliberate style) or drowning the prose in decoration.
+
+## Respect the Author Voice
+
+**Some authors lean on similes deliberately. The check targets quality, not quantity.**
+
+Character-driven voice authors often use grounded, everyday-life similes as a signature. These are *features*, not bugs:
+
+- *"He stood there like a mall security guard who'd just been given actual authority."* — grounded, specific, reveals character.
+- *"The apartment smelled like a Subway franchise had committed a crime in it."* — vivid, earns its place.
+
+The failure mode isn't "too many similes." It's **illogical or decorative** similes. An author whose voice includes many concrete, funny, character-grounded similes is not violating discipline. An author whose voice uses "like a celestial beacon" is.
+
+**Bias the check by profile:**
+- If the author profile explicitly documents a simile-heavy style with examples, apply the two-question test with that register as context. A grounded simile in Ethan Cole's voice may pass where the same construction in a sparser author's voice would read as decoration.
+- If the author profile is silent on similes or documents a sparse style, apply the test strictly. Default to cut-when-in-doubt.
+
+Check `~/.storyforge/authors/{slug}/profile.md` and `~/.storyforge/authors/{slug}/vocabulary.md` for any simile-style notes.
+
+## When Similes Earn Their Place
+
+A simile is pulling its weight when it does at least one of:
+
+- **Clarifies a sensation** the reader couldn't otherwise picture. (*"The cold hit him like stepping into a walk-in freezer — not pain, just the complete absence of warmth."*)
+- **Reveals character** through the comparison's frame of reference. A soldier notices combat similes; a chef notices food similes; a nurse notices body similes. The vehicle tells the reader whose mind they're inside.
+- **Lands a tonal beat** that bare description would miss. Humor, menace, grief — tone often travels in the space between tenor and vehicle.
+- **Compresses what would otherwise take a paragraph.** A single strong simile can do the work of three sentences of description.
+
+If none of those apply, the simile is decoration and should go.
+
+## The Revision Move
+
+When a simile fails the test, you have three options, in order of preference:
+
+1. **Cut it entirely.** Replace with a concrete beat — what actually happens, what is actually seen, heard, smelled. This is almost always the right move.
+2. **Replace the vehicle.** Keep the structure but swap the comparison for one that actually resembles the tenor.
+3. **Keep it.** Only if, after honest rework, the simile still does real work.
+
+Do not reach for option 3 because the sentence "sounds good." Sentences that sound good and do nothing are the specific problem this document exists to prevent.
+
+## Pre-Save Checklist
+
+Before any scene is appended to `draft.md`:
+
+- [ ] Every `like`, `as if`, `as [adj] as`, `the way [X]` construction has been inspected.
+- [ ] Each surviving simile passes both questions: *literal resemblance?* and *real work?*
+- [ ] No paragraph contains stacked decorative similes.
+- [ ] No dead similes (the familiar ones) survived.
+- [ ] Author-voice register has been considered — the check is *quality*, not *quantity*.
+- [ ] When in doubt, cut.
+
+## Related
+
+- `prose-style.md` — Metaphor and Simile: Fresh vs. Cliché, the Replacement Test.
+- `anti-ai-patterns.md` — Purple prose on demand, hollow sophistication.
+- `show-dont-tell.md` — Why concrete sensation beats decorative comparison.

--- a/skills/chapter-reviewer/SKILL.md
+++ b/skills/chapter-reviewer/SKILL.md
@@ -14,7 +14,7 @@ argument-hint: "<book-slug> <chapter-slug>"
 ## Prerequisites
 - Load author profile via MCP `get_author()`
 - Load author vocabulary from `~/.storyforge/authors/{slug}/vocabulary.md`
-- Load craft references: `dos-and-donts`, `anti-ai-patterns`, `chapter-construction`, `dialog-craft`, `show-dont-tell`
+- Load craft references: `dos-and-donts`, `anti-ai-patterns`, `chapter-construction`, `dialog-craft`, `show-dont-tell`, `simile-discipline`
 - Read the chapter draft: `{project}/chapters/{chapter}/draft.md`
 - Read the chapter outline: `{project}/chapters/{chapter}/README.md`
 - Read previous chapter draft for continuity
@@ -27,7 +27,7 @@ argument-hint: "<book-slug> <chapter-slug>"
 - Optional: If `{project}/research/manuscript-report.md` exists, read it and check whether any of THIS chapter's distinctive 5-7 word phrases already appear in earlier chapters (lightweight cross-chapter repetition check). Flag any matches in the Continuity Report section.
 - **Per-book CLAUDE.md** — MCP `get_book_claudemd(book_slug)`. Mandatory. Check the draft against every **Rule** (deduct points if violated) and verify that **Callbacks** are either honored, intentionally deferred, or not applicable to this chapter. Flag missed callbacks in the Continuity Report section.
 
-## Review Checklist — 28 Points (20 core + 5 tonal + 3 timeline)
+## Review Checklist — 28 Points + 1 sub-point (20 core + 1 sub-point + 5 tonal + 3 timeline)
 
 ### Structure (5 points)
 1. **Opening hook** — Does the first paragraph grab? Would you keep reading?
@@ -36,12 +36,14 @@ argument-hint: "<book-slug> <chapter-slug>"
 4. **Ending** — Does it compel the reader to turn the page?
 5. **Pacing** — Does the chapter breathe? Action/reflection balance?
 
-### Craft (5 points)
+### Craft (5 points + 1 sub-point)
 6. **Show don't tell** — Are emotions shown through action/body, not named?
 7. **Sensory details** — Are multiple senses engaged (not just visual)?
 8. **Specific details** — Concrete nouns and precise verbs, not generic descriptions?
 9. **Dialog quality** — Subtext present? Characters sound different? Minimal tags?
 10. **Conflict** — Is there tension in every scene? No filler?
+
+**10b. Simile discipline (craft sub-point)** — Apply the two-question test from `simile-discipline.md` to every `like`, `as if`, `as [adj] as`, `the way [X]`, `moved/felt/sounded like`, and `the kind of [noun] that [clause]` construction. For each: does the vehicle literally resemble the tenor? Does it do work a concrete beat couldn't? Flag illogical or decorative similes, stacked similes (2+ per paragraph without each doing distinct work), and dead similes (*pale as a ghost*, *quiet as a mouse*, etc.). Respect author-voice bias: if the profile documents a simile-heavy register with grounded, character-specific comparisons, apply the test with that register in mind — the check targets *quality*, not *quantity*.
 
 ### Voice (5 points)
 11. **Author consistency** — Does this sound like the defined author profile?
@@ -120,6 +122,14 @@ argument-hint: "<book-slug> <chapter-slug>"
 - Flagged words: [list]
 - Sentence length variance: [high/medium/low]
 - Generic descriptions found: [count]
+
+### Simile Report
+- Total simile markers found: [count]
+- Illogical / decorative (cut or revise): [list with quote + location]
+- Stacked (2+ per paragraph without distinct work): [list]
+- Dead similes: [list]
+- Passing similes: [count — optionally cite the strongest]
+- Author-voice register applied: [sparse / simile-heavy / as documented in profile]
 
 ### Verdict
 [PASS / NEEDS REVISION / MAJOR REVISION]

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -27,6 +27,7 @@ Before writing a SINGLE word, load ALL of these:
    - `pacing-guide` (scene vs. summary, rhythm)
    - `anti-ai-patterns` (what to avoid at ALL costs)
    - `prose-style` (word choice, rhythm, devices)
+   - `simile-discipline` (the two-question test for every comparison — mandatory for the pre-save scan in Step 6c)
 8. **Character files** — For each character appearing in this chapter, call MCP `get_character(book_slug, character_slug)`. Use the slugified name (e.g. "Jane Doe" → "jane-doe"). If the tool returns `{"error": ...}`, note it and proceed — don't fall back to direct file reads.
 9. **World files** — Read `{project}/world/setting.md` (includes the Travel Matrix). Mandatory if the chapter involves any travel or location references.
 10. **Story timeline** — Read `{project}/plot/timeline.md`. Mandatory for ALL chapters. This is the canonical day/date reference.
@@ -85,6 +86,8 @@ Target ~900 words per scene (can vary — some scenes need 600, others 1200). Th
 
 #### Step A2: Write One Scene
 For the current scene, apply ALL craft rules (Steps 3-6 from Mode B below). Write ONLY this scene — do not continue into the next scene.
+
+**Before appending, run the Step 6c Simile Discipline Scan on the scene text.** No scene goes into `draft.md` before the scan.
 
 After writing the scene:
 1. **Append the scene text directly to `{project}/chapters/{chapter}/draft.md`.** Do NOT paste the scene into chat. The user reviews in their editor and annotates with inline `` ```textile Markus: ... ``` `` comment blocks — that workflow only works if the prose is in the file. If `draft.md` does not exist yet, create it with a chapter heading (`# Chapter N: Title`) above the first scene. Separate scenes with a blank line; do not add scene headings unless the chapter outline specifies them.
@@ -171,6 +174,50 @@ Reference `chapter-construction.md` on endings:
 
 ---
 
+### Step 6c: Simile Discipline Scan (MANDATORY, both modes, pre-save)
+
+**This scan runs BEFORE any prose is appended to `draft.md` or saved.** In scene-by-scene mode (Mode A), run it per scene before Step A2's append. In full-chapter mode (Mode B), run it on the complete chapter text before Step 7.
+
+Reference: `simile-discipline.md`. The scan enforces its two-question test.
+
+**How to run the scan:**
+
+1. **Grep the scene/chapter text for simile markers.** Walk the prose and flag every instance of:
+   - `like [noun]` / `like [clause]`
+   - `as [adj] as [noun]`
+   - `as if [clause]` / `as though [clause]`
+   - `the way [subject] [verb]`
+   - `moved like`, `felt like`, `sounded like`, `looked like`, `seemed like`
+   - `resembled`, `reminded [him/her] of`
+   - `gave the impression of`, `had the air of`
+   - `the kind of [noun] that [clause]` — this construction is a frequent failure mode and must be inspected even without an explicit simile marker.
+
+2. **For each hit, answer both questions honestly:**
+   - **Literal resemblance?** Does the vehicle actually, concretely resemble the tenor? Can the reader picture the comparison?
+   - **Real work?** Does the simile clarify sensation, reveal character frame-of-reference, land a tonal beat, or compress description? Or is it decoration?
+
+3. **Apply the author-voice bias.**
+   - Check the author profile and vocabulary for simile-style notes.
+   - If the author's voice is documented as simile-heavy with grounded, character-specific comparisons (e.g. Ethan Cole's everyday-life similes), apply the test with that register as context. Many similes can pass.
+   - If the profile is silent or documents a sparse style, apply the test strictly. Default to cut-when-in-doubt.
+
+4. **Scan for stack density.** Any paragraph containing two or more simile markers is flagged. Either each one is doing distinct, necessary work, or all but the strongest are cut.
+
+5. **Scan for dead similes.** Reject the familiar ones on sight: *pale as a ghost*, *quiet as a mouse*, *quick as lightning*, *cold as ice*, *sharp as a knife*, *like a deer in headlights*, *like a kid in a candy store*. Replace or cut.
+
+6. **Revise failed similes** in order of preference:
+   - Cut entirely, replace with a concrete beat.
+   - Swap the vehicle for one that actually resembles the tenor.
+   - Keep only if, after rework, it genuinely does work.
+
+7. **Honor book-CLAUDE.md simile bans** — the per-book CLAUDE.md is already in context from Prerequisite 15. Cross-check any rule banning specific comparison patterns (e.g. "no comparisons involving things the floor shouldn't do") and cut matching similes even if the discipline check would otherwise keep them. Book rules override author-voice leniency.
+
+**Do not report the scan results in chat unless findings were significant.** For clean scenes, silence is fine. If you cut or revised similes, optionally note "Simile-Scan: N cut, M revised" in the scene metadata line alongside word count — this is a brief audit trail, not a review dump.
+
+**Do not skip the scan to save time.** The pattern recurs chapter after chapter in real projects precisely because it's easy to leave decorative similes in place. The scan is the enforcement point that the general rules in `prose-style.md` and `anti-ai-patterns.md` don't have.
+
+---
+
 ### Step 7: Save and Update (both modes)
 1. Write draft to `{project}/chapters/{chapter}/draft.md` (in scene-by-scene mode, the full draft is already assembled)
 2. Count words — report to user
@@ -191,6 +238,7 @@ Before presenting to user (in full-chapter mode) or after all scenes assembled (
 - Is there conflict in every scene?
 - Does the POV character's emotional state change?
 - Would a reader know which character is speaking without dialog tags?
+- **Simile discipline** — Confirm the Step 6c scan ran on every scene/section. No decorative or illogical comparisons survived. No stacked similes. No dead similes. `the kind of X that Y` constructions inspected.
 - **Litmus test** — If `plot/tone.md` exists, answer EVERY question from the Litmus Test section. If more than 1 answer is "no", flag it to the user and suggest specific revisions before proceeding.
 - **Time consistency** — Verify that every time reference in the chapter (explicit or relative) is consistent with the Chapter Timeline you created in Step 7.
 
@@ -202,6 +250,7 @@ Suggest: `/storyforge:chapter-reviewer` for detailed review.
 - Every scene needs conflict. No exceptions.
 - Dialog must have subtext. Characters don't say what they mean.
 - The banned word list is non-negotiable. Zero AI-tells.
+- **Simile Discipline (Step 6c) is non-negotiable.** Every scene and every full chapter must survive the two-question test before it enters `draft.md`. Decorative, illogical, stacked, or dead similes do not ship. The author-voice bias means the check targets *quality*, not *quantity* — a simile-heavy author voice is fine as long as each simile does real work. Refer to `simile-discipline.md` for the full heuristic.
 - Continuity is GLOBAL, not just local: always check `plot/timeline.md` and `world/setting.md` Travel Matrix, not just the previous chapter.
 - Never invent a travel time or distance that isn't in the Travel Matrix. Add it first, then write.
 - Never write a day-of-week or date that contradicts `plot/timeline.md`. Update timeline first if needed.

--- a/skills/manuscript-checker/SKILL.md
+++ b/skills/manuscript-checker/SKILL.md
@@ -32,6 +32,17 @@ violations of rules the author wrote into the book's CLAUDE.md.
   `voice-checker` (AI-tell gate) or `continuity-checker` (timeline/location).
   This one catches a different problem: prose drift across chapters.
 
+**Note on simile coverage.** The `simile` category in this checker is
+*cross-chapter n-gram repetition* — the same simile phrase appearing in
+multiple chapters. Per-simile *quality* (is this comparison illogical?
+decorative?) is covered by `reference/craft/simile-discipline.md` and
+enforced at write-time by `chapter-writer` (Step 6c) and at review-time by
+`chapter-reviewer`. When walking the `simile` findings in interactive fix
+mode (section 5), apply the two-question test from `simile-discipline.md`
+to each hit before deciding whether to keep or rewrite — a repeated simile
+that also fails the discipline check is a clear cut; a repeated simile that
+does real work in each location may be an intentional motif.
+
 ## Detection categories
 
 | Category | What it catches | Severity logic |
@@ -192,6 +203,12 @@ Keeps the canon log honest about what was changed during revision.
   and `blocking_tic`: default to "pick one to keep". For `structural` and
   `signature_phrase`: be more cautious — these may be intentional voice
   markers.
+- For `simile` findings specifically: apply the two-question test from
+  `reference/craft/simile-discipline.md` to each occurrence. If a repeated
+  simile also fails the discipline check (illogical, decorative, dead, or
+  stacked), cut all instances — don't just keep the "best" one. If every
+  instance does real work, the finding may be a deliberate motif worth
+  keeping — ask the user.
 - **Clichés are high severity even at a count of 1.** A cliché doesn't
   become less clichéd by being rare.
 - **Filter words are not always bad.** Internal realisations, dream logic,


### PR DESCRIPTION
## Summary
- New craft reference `reference/craft/simile-discipline.md` codifies the two-question test (literal resemblance? real work?), 6 failure modes, and author-voice bias
- `chapter-writer` Step 6c Simile Discipline Scan is now **mandatory pre-save in both writing modes** — no scene enters `draft.md` before every `like`, `as if`, `as [adj] as`, `the way X`, `the kind of X that Y`, and related markers survive the two-question test
- `chapter-reviewer` gains review point 10b + dedicated Simile Report block; `manuscript-checker` clarifies the per-chapter quality check vs. its existing cross-chapter n-gram repetition check and applies the heuristic in interactive-fix mode

Closes #31.

## Acceptance criteria (from the issue)
- [x] `chapter-writer` skill includes an explicit pre-save step to scan for simile markers and validate each
- [x] `craft/simile-discipline.md` exists and is listed in `chapter-writer`'s mandatory loads (Prerequisites item 7)
- [x] Heuristic respects author profile — simile-heavy voices (grounded, character-specific comparisons) stay intact; the check targets *quality*, not *quantity*
- [x] `chapter-reviewer` and `manuscript-checker` reuse the heuristic (not a blocker per the issue, shipped anyway)

## Scope note
The author-voice bias is enforced in two places: the craft doc has a dedicated "Respect the Author Voice" section, and Step 6c point 3 restates it operationally. An author whose profile documents a simile-heavy register ("like a mall security guard" > "like a celestial beacon") is not pushed into sparseness; the check flags illogical, decorative, stacked, and dead similes regardless of author voice.

Book-scoped simile bans (from each book's CLAUDE.md) override author-voice leniency.

## Test plan
- [ ] Open `skills/chapter-writer/SKILL.md` and confirm Step 6c sits between 6b and Step 7, and that Mode A Step A2 references it before the `draft.md` append
- [ ] Open `reference/craft/simile-discipline.md` and confirm the two-question test, failure modes, and author-voice bias read cleanly
- [ ] Run `/storyforge:chapter-writer` on a chapter of an existing book — the scan should run silently on clean scenes and report `Simile-Scan: N cut, M revised` on flagged ones
- [ ] Run `/storyforge:chapter-reviewer` on a chapter known to contain a decorative simile ("moved like a conversation" style) — confirm it surfaces in the Simile Report block with a concrete rewrite suggestion
- [ ] Run `/storyforge:manuscript-checker` on a book with repeated similes — confirm the cross-chapter repetition still fires and that interactive-fix mode applies the two-question test per hit
- [ ] Regression: chapters using an author profile with deliberately simile-heavy voice (grounded, character-specific) must not be forced into sparseness

🤖 Generated with [Claude Code](https://claude.com/claude-code)