### PR TITLE
feat: expand character template and creator skill with 18 new fields

### DIFF
--- a/hooks/validate_character.py
+++ b/hooks/validate_character.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import yaml
 
 REQUIRED_FRONTMATTER = ["name", "role", "status"]
-REQUIRED_SECTIONS = ["Want vs. Need", "Fatal Flaw"]
+REQUIRED_SECTIONS = ["Want vs. Need", "Fatal Flaw", "The Ghost", "Motivation Chain"]
 
 
 def validate_character(file_path: str) -> list[str]:

--- a/reference/craft/openings-and-endings.md
+++ b/reference/craft/openings-and-endings.md
@@ -141,6 +141,35 @@ Example: *The Fellowship of the Ring* does not begin with Frodo's childhood. It 
 
 *In medias res* fails when used as a cheap hook. If you begin with an action scene that has no emotional weight and no connection to the actual story, readers will feel tricked.
 
+#### The 13-Point First Chapter Checklist
+
+Chapter 1 carries responsibilities no other chapter has. Use this checklist to verify your first chapter does its full job before moving on.
+
+**Set the Stage**
+
+1. **Orient the reader** — Time period and location are established early. The reader knows *when* and *where* without an info dump.
+2. **Set the tone** — Words, events, dialogue, and setting convey the story's mood. The reader knows what emotional register they're entering.
+3. **Establish the genre** — The reader can identify whether this is fantasy, thriller, romance, literary fiction, etc. The genre contract is signed.
+
+**Spotlight the Protagonist**
+
+4. **Introduce the protagonist in their element** — Show them doing what defines them best. Not sitting. Not waking up. Doing the thing that is most *them*.
+5. **Give the protagonist something to want** — Even before the story's main conflict, the protagonist has a desire or longing. Something they're pursuing, hoping for, or missing.
+6. **Reveal the normal world** — Show everyday life before the disruption. Readers need to understand the baseline to feel the disruption.
+7. **Illustrate the problem with the protagonist's life** — Something is broken or unsatisfying before the main plot begins. Show what's wrong or missing in their world.
+8. **Hint at the theme** — Subtly introduce the deeper questions the story will explore. The theme isn't stated; it's seeded.
+9. **Present the protagonist's internal conflict** — The fear-versus-desire tension that will drive the character through the book is present. What do they want? What are they afraid of?
+
+**Give Readers a Reason to Stay**
+
+10. **Killer first sentence** — The opening line sparks curiosity. It makes the reader ask a question they need answered.
+11. **Spark curiosity** — Unanswered questions, a mysterious object, an intriguing exchange of dialogue. The reader is leaning forward.
+12. **Establish dread** — Foreshadow coming challenges or disasters. The reader senses something is coming even if they can't name it.
+13. **Knock over the first domino** — The initial event that sets the protagonist's journey in motion is present by chapter's end. The first chapter doesn't just introduce—it *begins*.
+
+**How to use this checklist:**
+A Chapter 1 that passes all 13 points is ready. A chapter that fails 1–2 minor points (e.g., 8 or 12) may still work. A chapter that fails items 4, 5, 9, 10, or 13 needs revision before proceeding—those are the load-bearing requirements.
+
 ### 4. What to Avoid in Openings
 
 **Weather Descriptions**

--- a/reference/craft/story-structure.md
+++ b/reference/craft/story-structure.md
@@ -245,6 +245,123 @@ The Snowflake Method can feel overly mechanical for pantsers (writers who write 
 
 ---
 
+## Dan Harmon's Story Circle
+
+Dan Harmon, creator of *Community* and *Rick and Morty*, developed the Story Circle as a character-centered adaptation of Campbell's monomyth. Where the Hero's Journey maps external adventure, the Story Circle maps internal transformation. The character's inner journey is the structure.
+
+### The Eight Steps
+
+**1. A character is in a zone of comfort**
+The protagonist exists in their ordinary world—familiar, safe, known. This is not paradise; it may be stagnation. But it's *theirs*. We understand exactly what they stand to lose before they risk it.
+
+**2. But they want something**
+An unfulfilled need or desire drives them forward. This is often unconscious—what the character *thinks* they want versus what they actually need. The want sets the story in motion.
+
+**3. They enter an unfamiliar situation**
+The protagonist leaves their comfort zone—physically, socially, psychologically. They cross a threshold into territory where the old rules don't apply. The unfamiliar situation is a test designed to reveal who they really are.
+
+**4. They adapt to it**
+The protagonist learns to operate in the new world. They acquire skills, allies, and understanding. They grow more confident—sometimes dangerously so. This is the "fun and games" phase where the premise delivers on its promise.
+
+**5. They get what they wanted**
+The surface desire is achieved. The protagonist accomplishes the goal they set out for. This is often a false victory—they get what they wanted, but it doesn't satisfy them.
+
+**6. But they pay a heavy price for it**
+Success costs something profound. A relationship is broken. An illusion is shattered. Something is lost that cannot be recovered. This is the All Is Lost moment—the price of getting the want rather than the need.
+
+**7. Then they return to their familiar situation**
+The protagonist returns to their ordinary world—or what's left of it. But the return is changed by everything that happened. The familiar is now strange because *they* are strange.
+
+**8. Having changed**
+The protagonist is fundamentally different. The internal transformation is complete. They now operate from a truth they didn't have at the start. The change should be *demonstrated* in behavior, not stated in dialogue.
+
+### The Key Insight: Want vs. Need
+
+The Story Circle's power comes from the gap between Step 2 (what the character wants) and Step 8 (what the story reveals they needed). If Steps 2 and 8 align perfectly, there is no arc. If they're in tension—if getting the want in Step 5 costs them something that forces them toward the need—the circle produces genuine transformation.
+
+*Example: Rick and Morty, "Pilot"*
+Rick (Step 1) exists in the comfort of his genius and cynicism. He wants to expose Morty to adventure (Step 2). They enter the adventure world (Step 3), adapt (Step 4), and succeed at the mission (Step 5). But Rick is forced to admit he needs Morty's presence more than he'll say (Step 6). He returns to domestic life (Step 7) slightly more vulnerable than before (Step 8).
+
+### When to Use Dan Harmon's Story Circle
+
+**Best for:**
+- Character-driven stories where internal transformation is the core
+- Episodic narratives (each episode can be its own circle)
+- Stories with comedic tone and sharp character voice
+- Writers who find three-act structure too focused on external plot
+
+**Avoid when:**
+- Your story is primarily plot-driven with minimal character transformation
+- You're writing ensemble narratives where no single character leads (though circles can nest)
+- Your protagonist is a flat arc character who doesn't fundamentally change
+
+### Story Circle vs. Hero's Journey
+
+The Hero's Journey maps the *adventure*. The Story Circle maps the *person*. Both derive from Campbell, but the Story Circle compresses external events to foreground inner change. In the Hero's Journey, stages like "Tests, Allies, and Enemies" can expand into vast plot territory. In the Story Circle, that territory compresses into Steps 3–4 because the point is transformation, not adventure.
+
+---
+
+## Seven-Point Story Structure
+
+The Seven-Point Story Structure—popularized by author Dan Wells—works backward from the ending. You define where characters end up (resolution), then build the structure that gets them there. It's particularly strong for writers who know their ending but struggle with the middle.
+
+### The Seven Points
+
+**1. Hook**
+Where the character *starts*—the opposite of the resolution. If the resolution is "protagonist learns to trust others," the hook shows the protagonist who cannot trust anyone. The greater the contrast between hook and resolution, the more satisfying the arc.
+
+The hook should also grip the reader immediately: a compelling situation, an intriguing character, an unusual circumstance that makes readers ask "what happens next?"
+
+**2. Plot Point 1**
+The character is *called into* the story world. Something happens that forces or enables them to engage with the central conflict. They commit—willingly or not—to the journey. This is the point of no return that ends the setup phase.
+
+**3. Pinch Point 1**
+The antagonistic force reveals its power. This is a direct application of pressure on the protagonist—a demonstration of what they're up against. The protagonist may succeed or fail, but the antagonist's strength is now undeniable. Stakes are raised.
+
+**4. Midpoint**
+The protagonist shifts from *reactive* to *proactive*. Before the midpoint, things happen to them. After the midpoint, they make things happen. This shift is driven by new information, a revelation, or a moment of decision. The protagonist now understands the stakes in full and commits to action.
+
+**5. Pinch Point 2**
+The antagonistic force applies maximum pressure. The protagonist's plan is failing or has failed. Everything that could go wrong does. This is the All Is Lost moment—the darkest point before the final act. It forces the protagonist to dig deeper than they thought possible.
+
+**6. Plot Point 2**
+The protagonist finds the key to winning. Not victory itself, but the insight, tool, ally, or decision that makes victory possible. This often involves the protagonist finally doing the difficult thing they've been avoiding—facing their fear, accepting help, confronting the truth about themselves.
+
+**7. Resolution**
+The protagonist uses what they found in Plot Point 2 to resolve the central conflict. The story's central question is answered. The contrast with the Hook demonstrates how far they've come.
+
+### Design from Both Ends
+
+The Seven-Point method's defining technique: write your hook and resolution first, then build the structure between them.
+
+*Process:*
+1. Define your resolution (where does the character end up, emotionally and externally?)
+2. Define your hook (where do they start—the opposite of the resolution)
+3. Place your midpoint (what shifts the character from reactive to proactive?)
+4. Fill in Plot Points 1 and 2 (what leads into the midpoint? what follows it?)
+5. Add Pinch Points 1 and 2 (where does the antagonist demonstrate power?)
+
+This backward design prevents the common problem of a strong beginning and end with a sagging, directionless middle.
+
+### When to Use Seven-Point Structure
+
+**Best for:**
+- Writers who know their ending and need help building toward it
+- Stories with a strong antagonist whose power must be clearly established
+- Fantasy, thriller, and adventure stories with clear external conflict
+- Writers who struggle with the second act
+
+**Avoid when:**
+- You're a discovery writer (this method requires knowing the destination)
+- Your story is more mood and atmosphere than plot-driven
+- Your structure is deliberately non-linear
+
+### Seven-Point vs. Three-Act
+
+The three-act structure organizes by emotional phase (setup, confrontation, resolution). The seven-point organizes by narrative function. They overlap significantly—Plot Point 1 corresponds to the end of Act 1, Midpoint to the three-act midpoint, Plot Point 2 to the end of Act 2. The difference is design orientation: three-act builds forward, seven-point builds from both ends simultaneously.
+
+---
+
 ## Kishotenketsu (East Asian Story Structure)
 
 Kishōtenketsu (起承転結) originates in classical Chinese poetry and structures many East Asian narratives. It differs fundamentally from Western conflict-driven structures by organizing around development, contrast, and unexpected turns rather than escalating tension.
@@ -318,12 +435,16 @@ Different genres and story types benefit from different structures. This table p
 |-------|---|---|---|
 | Literary Fiction | Kishotenketsu or Custom | Emphasizes character psychology, mood, and subtle transformation. Benefits from non-linear emotional arcs. | Three-Act (loose), Hero's Journey (modified) |
 | Romance | Three-Act or Save the Cat | Requires clear beat structure for meet-cute, conflict, and resolution. Save the Cat's B Story excels for relationship threads. | Hero's Journey (adapted for relationship focus) |
-| Thriller/Mystery | Fichtean Curve or Three-Act | Requires sustained tension and escalating crises. Fichtean is ideal for high-octane pacing. | Save the Cat (for commercial structure) |
-| Fantasy Epic | Hero's Journey or Five-Act | Epic scope demands the mythic resonance of the Hero's Journey. Multiple acts accommodate complex worlds. | Save the Cat (for pacing commercial fantasy) |
+| Thriller/Mystery | Fichtean Curve or Three-Act | Requires sustained tension and escalating crises. Fichtean is ideal for high-octane pacing. | Seven-Point (for writers who know their ending) |
+| Fantasy Epic | Hero's Journey or Five-Act | Epic scope demands the mythic resonance of the Hero's Journey. Multiple acts accommodate complex worlds. | Seven-Point (for writers designing from the ending) |
 | Science Fiction | Three-Act or Fichtean | Depends on subtype: hard sci-fi often uses three-act for clarity. Space opera uses Hero's Journey. | Snowflake Method (for world-building integration) |
 | Historical Fiction | Five-Act or Snowflake | Complex timelines and multiple perspectives benefit from granular structure. Snowflake excels at historical detail integration. | Three-Act (modified) |
-| Literary Short Fiction | Kishotenketsu or Custom | Short format demands efficiency and resonance over plot mechanics. | Three-Act (highly compressed) |
+| Literary Short Fiction | Kishotenketsu or Custom | Short format demands efficiency and resonance over plot mechanics. | Story Circle (for tight character transformation) |
 | Young Adult | Save the Cat or Three-Act | YA benefits from clear beats and emotional arcs. Save the Cat's theme work is particularly valuable. | Hero's Journey (for coming-of-age) |
+| Comedy / Sitcom / Episodic | Dan Harmon's Story Circle | Foregrounds character transformation over external plot. Each episode or chapter can complete its own circle. | Three-Act (compressed) |
+| Tragedy / Corruption Arc | Five-Act (Freytag's Pyramid) | Designed explicitly for downward arcs, disillusionment, and fatal flaws that destroy the protagonist. | Three-Act (negative arc variant) |
+| Character Study | Dan Harmon's Story Circle | When internal change *is* the story, the Story Circle keeps the transformation central at every stage. | Kishotenketsu |
+| Author knows the ending | Seven-Point Structure | Design from both ends: define resolution first, then build hook, midpoints, and pinch points backward to connect them. | Three-Act |
 
 ---
 

--- a/skills/chapter-reviewer/SKILL.md
+++ b/skills/chapter-reviewer/SKILL.md
@@ -15,6 +15,7 @@ argument-hint: "<book-slug> <chapter-slug>"
 - Load author profile via MCP `get_author()`
 - Load author vocabulary from `~/.storyforge/authors/{slug}/vocabulary.md`
 - Load craft references: `dos-and-donts`, `anti-ai-patterns`, `chapter-construction`, `dialog-craft`, `show-dont-tell`, `simile-discipline`
+- **Detect if this is Chapter 1:** Check chapter slug (starts with `01-` or `001-`) or frontmatter chapter number (`chapter: 1`). If Chapter 1: also load `openings-and-endings` craft reference.
 - Read the chapter draft: `{project}/chapters/{chapter}/draft.md`
 - Read the chapter outline: `{project}/chapters/{chapter}/README.md`
 - Read previous chapter draft for continuity
@@ -26,6 +27,33 @@ argument-hint: "<book-slug> <chapter-slug>"
 - Read the `## Chapter Timeline` from the PREVIOUS chapter's `README.md` — verify cross-chapter time references (e.g. "an hour ago" across chapter boundaries)
 - Optional: If `{project}/research/manuscript-report.md` exists, read it and check whether any of THIS chapter's distinctive 5-7 word phrases already appear in earlier chapters (lightweight cross-chapter repetition check). Flag any matches in the Continuity Report section.
 - **Per-book CLAUDE.md** — MCP `get_book_claudemd(book_slug)`. Mandatory. Check the draft against every **Rule** (deduct points if violated) and verify that **Callbacks** are either honored, intentionally deferred, or not applicable to this chapter. Flag missed callbacks in the Continuity Report section.
+
+## First Chapter Checklist — 13 Points (ONLY for Chapter 1)
+
+If this is Chapter 1, run this checklist BEFORE the standard review. Rate each point: PASS / WARN / FAIL.
+
+**Set the Stage**
+1. **Orient the reader** — Time period and location established early without info dump.
+2. **Set the tone** — Words, events, dialogue, and setting convey the story's mood.
+3. **Establish the genre** — Reader knows what type of story they're entering.
+
+**Spotlight the Protagonist**
+4. **Protagonist in their element** — Shown doing what defines them best (not sitting, not waking up).
+5. **Protagonist wants something** — A concrete desire or longing exists before the main plot hits.
+6. **Normal world revealed** — Everyday life before disruption is visible.
+7. **Problem illustrated** — Something is broken or unsatisfying in the protagonist's world.
+8. **Theme seeded** — A subtle hint at the story's deeper questions exists.
+9. **Internal conflict established** — Fear-versus-desire tension is present.
+
+**Give Readers a Reason to Stay**
+10. **Killer first sentence** — Opening line sparks curiosity and makes the reader ask a question.
+11. **Curiosity sparked** — Unanswered questions, mysterious objects, or intriguing dialogue keep reader leaning forward.
+12. **Dread established** — Coming challenges are foreshadowed; the reader senses something is coming.
+13. **First domino knocked** — The initial event that sets the journey in motion occurs by chapter's end.
+
+**Load-bearing items** (FAIL here = chapter needs revision before moving on): 4, 5, 9, 10, 13.
+
+---
 
 ## Review Checklist — 28 Points + 1 sub-point (20 core + 1 sub-point + 5 tonal + 3 timeline)
 
@@ -82,6 +110,27 @@ argument-hint: "<book-slug> <chapter-slug>"
 
 ```markdown
 ## Chapter Review: {Chapter Title}
+
+### First Chapter Report (only if Chapter 1)
+| # | Requirement | Result | Notes |
+|---|---|---|---|
+| 1 | Orient the reader | PASS/WARN/FAIL | |
+| 2 | Set the tone | PASS/WARN/FAIL | |
+| 3 | Establish genre | PASS/WARN/FAIL | |
+| 4 | Protagonist in element ⚠️ | PASS/WARN/FAIL | |
+| 5 | Protagonist wants something ⚠️ | PASS/WARN/FAIL | |
+| 6 | Normal world revealed | PASS/WARN/FAIL | |
+| 7 | Problem illustrated | PASS/WARN/FAIL | |
+| 8 | Theme seeded | PASS/WARN/FAIL | |
+| 9 | Internal conflict ⚠️ | PASS/WARN/FAIL | |
+| 10 | Killer first sentence ⚠️ | PASS/WARN/FAIL | |
+| 11 | Curiosity sparked | PASS/WARN/FAIL | |
+| 12 | Dread established | PASS/WARN/FAIL | |
+| 13 | First domino knocked ⚠️ | PASS/WARN/FAIL | |
+
+⚠️ = load-bearing, FAIL requires revision before proceeding.
+
+---
 
 ### Score: [X]/25 (core) + [X]/5 (tonal, if tone.md exists) + [X]/3 (timeline)
 

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -132,6 +132,8 @@ Write the first paragraph with extreme care. Reference `openings-and-endings.md`
 - Create a micro-question that pulls the reader forward
 - Match the author's established voice from the FIRST sentence
 
+**If this is Chapter 1:** Before writing, review the 13-Point First Chapter Checklist from `openings-and-endings.md`. Plan how this chapter will satisfy all 13 points — especially the load-bearing ones (4, 5, 9, 10, 13). After writing, run `/storyforge:chapter-reviewer` which will automatically apply the first-chapter check.
+
 #### Step 4: Write Scene by Scene
 Follow the Scene-Sequel structure from `chapter-construction.md`:
 

--- a/skills/character-creator/SKILL.md
+++ b/skills/character-creator/SKILL.md
@@ -14,7 +14,7 @@ argument-hint: "<book-slug> [character-name]"
 ## Prerequisites
 - Load book data via MCP `get_book_full()`
 - Load craft references via MCP `get_craft_reference()`:
-  - `character-creation` (GMC, archetypes, wants vs. needs, flaws)
+  - `character-creation` (GMC, archetypes, wants vs. needs, flaws, motivation chains)
   - `character-arcs` (positive, negative, flat arcs)
   - `dialog-craft` (character voice differentiation)
 - Load genre README(s) for genre-specific character expectations
@@ -24,65 +24,119 @@ argument-hint: "<book-slug> [character-name]"
 
 ### Step 1: Character Role
 Ask the user:
-- Who is this character? (name, role: protagonist/antagonist/supporting/minor)
-- What's their function in the story? (drives plot, mirrors theme, provides contrast)
+- Who is this character? (name, role: protagonist / antagonist / supporting / minor)
+- What's their function in the story? (drives plot, mirrors theme, provides contrast, comic relief)
 
 Create file via MCP `create_character()`.
 
-### Step 2: The Core Triangle (GMC)
-Work through Goal/Motivation/Conflict:
-- **Goal (external):** What do they want? (concrete, visible, achievable)
-- **Motivation:** WHY do they want it? (emotional, rooted in backstory)
+### Step 2: Archetype — Starting Point
+Identify the primary archetype as a starting point, then immediately look for the subversion:
+- Which archetype do they resemble at first glance? (Hero, Mentor, Shadow, Trickster, Ally, Herald, Shapeshifter, Threshold Guardian)
+- **More important:** How do they *break* the archetype? A Mentor with an addiction. A Hero who is physically weak. A Trickster who is genuinely wise.
+- The subversion is what makes them specific. The archetype is what makes them recognizable.
+
+### Step 3: The Core Triangle (GMC)
+Work through Goal / Motivation / Conflict:
+- **Goal (external):** What do they want? (concrete, visible, achievable or not by story's end)
+- **Motivation:** WHY do they want it? (emotional, rooted in backstory — not "because it's important" but a specific wound or desire)
 - **Conflict:** What stops them? (both external obstacles and internal resistance)
 
-### Step 3: Want vs. Need
+### Step 4: Want vs. Need
 The most important character mechanic:
 - **Want:** What they consciously pursue (external goal)
-- **Need:** What they actually need to grow/change (internal truth)
+- **Need:** What they actually need to grow or change (internal truth they're avoiding)
 - **The Lie:** The false belief that prevents them from getting what they need
 
 Example: Want = revenge. Need = forgiveness. Lie = "Justice requires punishment."
 
-### Step 4: Fatal Flaw
+### Step 5: The Motivation Chain — Dig Three Layers Deep
+Surface motivations are rarely the true ones. Work with the user to find all three layers:
+- **Surface:** What the character says they want (what they'd tell a stranger)
+- **Deeper:** Why that actually matters (the emotional engine — ask "why does that matter to them?")
+- **Deepest:** The core wound-driven need (ask "why?" again — this is what the story is really about for this character)
+
+*Don't accept "she wants to prove herself" as the deepest layer. Keep digging: prove herself to whom? Why does that matter? What would happen if she didn't? The deepest layer is usually about survival, love, worth, or meaning.*
+
+### Step 6: The Ghost — The Wound That Made Them
+This is the most important backstory step. Ask the user:
+
+*"What happened to this character BEFORE the story that made them who they are?"*
+
+Guide the conversation:
+- What single event (or sustained condition) changed them permanently?
+- What did they lose, witness, survive, or fail at that they never fully recovered from?
+- What false lesson did they draw from it? (This becomes The Lie in Step 4)
+- The Ghost explains the Fatal Flaw. If you can't connect the wound to the flaw, dig deeper.
+
+Apply the Iceberg Principle: know 100%, show 10%. The Ghost rarely appears on the page directly — it shapes behavior from below the surface.
+
+Then map the broader backstory:
+- **Upbringing:** Setting, income level, family dynamics, cultural background, core values instilled
+- **Family Relationships:** Which were formative and how? What did they teach about love, trust, worth?
+- **Friendships:** Most significant friendships — who shaped them, who was lost?
+- **Adversaries:** Who looms in their memory as betrayer, nemesis, or threat?
+
+### Step 7: Psychology
+Work through the internal landscape:
+- **The Lie:** What broken conclusion did they draw from The Ghost?
+- **Fear (rational):** What do they consciously dread?
+- **Phobias (irrational):** What makes them flinch in ways they can't fully explain?
+- **Insecurities:** What are they secretly ashamed of? What would they never admit?
+- **Value System:** What moral framework do they navigate by — even if it's flawed? Religious, philosophical, cultural, personal code?
+- **Handling Emotions:** How do they process feelings? Suppress, explode, intellectualize, deflect, go silent? What does it look like at their emotional limit?
+
+### Step 8: Fatal Flaw
 Not just a weakness — a flaw that:
-- Actively causes problems in the story
-- Connects to the theme
-- Has roots in the backstory/wound
-- Must be overcome (positive arc) or embraced (negative arc)
+- **Actively causes problems** in the story (not just limits the character)
+- **Connects to the theme** of the book
+- **Has roots in The Ghost** — the flaw is usually an overcorrection to the wound
+- **Must be overcome** (positive arc) or **embraced** (negative arc)
 
-### Step 5: Backstory — The Wound
-Ask: "What happened to this character BEFORE the story that made them who they are?"
-- Apply the Iceberg Principle: know 100%, show 10%
-- The wound should explain the Lie they believe
-- Don't info-dump backstory — reveal through behavior and reactions
+*Weakness vs. flaw: "She is shy" is a weakness. "She is so afraid of rejection that she sabotages every relationship before it can end on someone else's terms" is a flaw.*
 
-### Step 6: Voice
+### Step 9: Human Texture
+The details that make them feel lived-in. These don't drive the plot — they make the character feel real:
+- **Quirks:** Distinctive habits or mannerisms that feel uniquely them
+- **Contradictions:** Opposing traits that coexist (the hard-boiled detective who cries at romantic comedies)
+- **Habits:** Recurring behaviors, especially under pressure or stress
+- **Pet Peeves:** What irritates them disproportionately?
+
+*Tip: Contradictions are the most powerful of these. Real people are not unified. They contain multitudes.*
+
+### Step 10: Life Context
+Practical details that anchor them in the world:
+- Job / Occupation (and how they feel about it — it's rarely neutral)
+- Hobbies (what do they do when no one's watching?)
+- Location (where do they live, and what does that say about them?)
+
+### Step 11: Voice
 Make this character sound DIFFERENT from every other character:
-- **Vocabulary level:** (educated, street-smart, formal, casual)
-- **Sentence patterns:** (short and blunt, rambling, precise)
-- **Verbal tics:** (filler words, catchphrases, speech avoidance)
+- **Vocabulary level:** (educated, street-smart, formal, casual, profession-specific jargon)
+- **Sentence patterns:** (short and blunt, rambling, precise, avoidant)
+- **Verbal tics:** (filler words, catchphrases, speech patterns)
 - **What they DON'T say:** (topics they avoid, emotions they suppress)
+- **Voice under stress:** How does their speech change when they're afraid, angry, or cornered?
 
-Write a sample dialog snippet (5-6 lines) demonstrating their voice.
+Write a sample dialogue snippet (5–6 lines) that could only be this character. Do the "cover the name" test: could any other character in the book say this?
 
-### Step 7: Arc Design
+### Step 12: Arc Design
 Based on `character-arcs.md`:
-- **Arc type:** Positive (Lie → Truth), Negative (Truth → Lie), Flat (changes world)
+- **Arc type:** Positive (Lie → Truth), Negative (Truth → Lie), Flat (changes world, not self)
 - **Arc beats** aligned to plot beats:
-  1. Lie established
-  2. Lie challenged
-  3. Moment of truth (midpoint)
-  4. All is lost (crisis)
-  5. Final choice (climax)
+  1. Lie established, reinforced by backstory
+  2. Lie challenged by story events
+  3. Moment of truth (midpoint — glimpse of what they need)
+  4. All Is Lost (the Lie or the Truth must win)
+  5. Final choice (transformation complete or refused)
 
-### Step 8: Relationships
+### Step 13: Key Relationships
 Map relationships to other characters:
 - What does this character want FROM each other character?
 - What conflict exists between them?
 - How do relationships change through the story?
 
-### Step 9: Write Character File
-Update the character file with all developed details.
+### Step 14: Write Character File
+Update the character file with all developed details via MCP `update_character()` or direct Write.
 Update `{project}/characters/INDEX.md` with the new character.
 
 After all major characters are created, update book status to "Characters Created".
@@ -91,6 +145,8 @@ After all major characters are created, update book status to "Characters Create
 - NEVER create a "perfect" character — flaws drive stories
 - Antagonists must believe they're RIGHT — no mustache-twirling villains
 - Every character needs their own voice — do the "cover the name" test
-- Backstory informs behavior but is NOT exposition
-- Physical appearance should be SPECIFIC, not generic ("tall, dark, handsome" = lazy)
+- Backstory informs behavior but is NOT exposition — it lives below the surface
+- Physical appearance should be SPECIFIC ("a scar running through his left eyebrow"), not generic ("tall, dark, handsome")
 - If you can describe the character in one word, they're not deep enough
+- The Ghost must connect to the Lie, which must connect to the Flaw — if the chain breaks, the character psychology is not coherent
+- Contradictions are not inconsistencies — they are the mark of a real human being

--- a/skills/plot-architect/SKILL.md
+++ b/skills/plot-architect/SKILL.md
@@ -33,9 +33,18 @@ Based on genre and story type, recommend a structure. Use AskUserQuestion:
 - **3-Act** — Most versatile. Best for: thriller, romance, mystery, contemporary.
 - **Hero's Journey** — Quest narratives. Best for: fantasy, sci-fi, adventure.
 - **Save the Cat** — Detailed beats. Best for: commercial fiction, thriller, romance.
-- **5-Act** — Tragic or complex narratives. Best for: literary, drama, historical.
+- **5-Act / Freytag's Pyramid** — Tragic or complex narratives. Best for: literary, drama, historical, corruption/downfall arcs.
 - **Fichtean Curve** — Start in action. Best for: thriller, horror.
+- **Dan Harmon's Story Circle** — Character transformation first. Best for: character-driven, episodic, comedic stories. 8 steps: comfort → want → unfamiliar → adapt → get want → pay price → return → changed.
+- **Seven-Point Structure** — Design from both ends (know your ending first). Best for: fantasy, thriller, adventure. Hook → Plot Point 1 → Pinch 1 → Midpoint → Pinch 2 → Plot Point 2 → Resolution.
 - **Kishotenketsu** — No central conflict. Best for: literary, slice-of-life.
+
+**Recommendation logic:**
+- Protagonist doesn't fundamentally change → Flat arc → consider **Hero's Journey** or **Seven-Point**
+- Protagonist corrupts or falls → **5-Act / Freytag's Pyramid**
+- Story is episodic or comedy-driven → **Dan Harmon's Story Circle**
+- Author knows the ending but not the middle → **Seven-Point Structure**
+- Pantser / Plantser writing mode → lean toward **3-Act** (minimal) or **Dan Harmon's Story Circle** (8 clear checkpoints)
 
 ### Step 3: Map Plot Beats
 For the chosen structure, work through each beat WITH the user:

--- a/templates/character.md
+++ b/templates/character.md
@@ -4,6 +4,8 @@ role: "{{role}}"
 status: "Concept"
 age: ""
 gender: ""
+job: ""
+archetype: ""
 description: ""
 ---
 
@@ -12,52 +14,123 @@ description: ""
 ## Role
 {{role}}
 
+## Archetype
+*Starting archetype (Hero / Mentor / Shadow / Trickster / Ally / Herald / Shapeshifter / Threshold Guardian). Then: how does this character subvert or complicate the archetype?*
+
+## Life Context
+
+- **Age:**
+- **Job / Occupation:**
+- **Location:**
+- **Hobbies:**
+
 ## Physical Appearance
 
-*Be specific. Not "tall and handsome" but concrete, memorable details.*
+*Be specific. Not "tall and handsome" but concrete, memorable details. One or two features that stick.*
 
 ## Personality
 
-*Core traits, contradictions, quirks, habits.*
+*Core traits. What is the first impression? What do people get wrong about them?*
 
-## Backstory / Wound
+### Human Texture
 
-*What happened before the story? What event shaped who they are?*
-*Remember the Iceberg: know 100%, show 10%.*
+- **Quirks:** *Distinctive habits, mannerisms, or behaviors that feel uniquely them.*
+- **Contradictions:** *Opposing traits that coexist — the cynic who tears up at commercials, the brave soldier who panics at spiders.*
+- **Habits:** *Recurring behaviors — nervous tics, rituals, defaults under pressure.*
+- **Pet Peeves:** *What irritates them disproportionately?*
+
+---
+
+## Backstory
+
+*The Iceberg Principle: know 100%, show 10%. Everything here informs behavior without necessarily appearing on the page.*
+
+### Upbringing
+*Setting (urban/rural/era), income level, family dynamics, cultural background, core values instilled. What did their world teach them about how life works?*
+
+### Family Relationships
+*Which family relationships were most formative — and how? Absent father, overbearing mother, rivalry with a sibling? What did these relationships teach them about love, trust, or worth?*
+
+### Friendships
+*Most significant friendships — past or present. Who shaped them? Who did they lose? What did those relationships reveal about who they are?*
+
+### Adversaries
+*Who looms in their memory as a nemesis, betrayer, or villain? This doesn't have to be the story's antagonist — it's whoever in their past represents a wound or a threat.*
+
+### The Ghost
+*The single disastrous event — or sustained condition — that changed them forever. The psychic injury that the character has spent their life trying to protect themselves from. This is the root of The Lie.*
+
+---
+
+## Psychology
+
+### The Lie
+*The flawed philosophy or false belief they now live by because of The Ghost. What broken conclusion did they draw from their wound? Examples: "I am unlovable." / "Power is the only safety." / "Everyone leaves eventually."*
+
+### Fear
+*Their greatest rational fear — what they consciously dread and try to avoid.*
+
+### Phobias
+*Irrational fears. What makes them flinch in ways that don't quite make sense even to them?*
+
+### Insecurities
+*What do they feel secretly ashamed of or inadequate about? What would they never admit?*
+
+### Value System
+*What do they believe in? Religious doctrine, personal philosophy, cultural code of honor, or deep cynicism. What is the moral framework they navigate by — even if it's flawed?*
+
+### Handling Emotions
+*How do they process feelings? Do they suppress, intellectualize, explode, deflect with humor, go silent? What does it look like when they're at their emotional limit?*
+
+---
 
 ## Want vs. Need
 
-- **Want (external):** *What they consciously pursue*
-- **Need (internal):** *What they actually need to grow/change*
-- **The Lie they believe:** *The false belief that drives their flaw*
+- **Want (external):** *What they consciously pursue — concrete, visible, achievable.*
+- **Need (internal):** *What they actually need to grow or change — the truth that would heal The Ghost.*
+- **The Lie they believe:** *The false belief that prevents them from getting what they need.*
+
+## Motivation Chain
+
+*Dig beneath the surface. Ask "why?" three times.*
+
+- **Surface:** *What they say they want — the goal they'd name out loud.*
+- **Deeper:** *Why that actually matters to them — the emotional engine underneath.*
+- **Deepest:** *The core wound-driven need — what the story is really about for this character.*
+
+---
 
 ## Fatal Flaw
 
-*Not just a weakness — a flaw that actively causes problems and connects to theme.*
+*Not just a weakness — a flaw that actively causes problems, connects to the theme, and has roots in The Ghost. It must be overcome (positive arc) or embraced (negative arc).*
 
 ## Character Arc
 
-*Type: Positive (Lie → Truth) / Negative (Truth → Lie) / Flat (changes world)*
+*Type: Positive (Lie → Truth) / Negative (Truth → Lie) / Flat (changes world, not self)*
 
 ### Arc Beats
-1. **Setup:** *Flaw established, Lie reinforced*
-2. **Challenge:** *Events begin to challenge the Lie*
-3. **Midpoint:** *Moment of truth — glimpse of the Truth*
-4. **Crisis:** *All Is Lost — the Lie or Truth must win*
-5. **Resolution:** *Final choice — transformation complete*
+1. **Setup:** *Flaw and Lie established, reinforced by backstory*
+2. **Challenge:** *Events begin to contradict the Lie*
+3. **Midpoint:** *Moment of truth — a glimpse of what they actually need*
+4. **Crisis:** *All Is Lost — the Lie or the Truth must win*
+5. **Resolution:** *Final choice — transformation complete (or refused)*
+
+---
 
 ## Voice
 
-*How do they speak? Vocabulary level, sentence patterns, verbal tics, accent.*
+*How do they speak? Vocabulary level, sentence patterns, verbal tics, what they DON'T say. Topics they avoid. Emotions they suppress. How does their voice change under stress?*
 
-## Relationships
+*Write a sample dialogue snippet (5–6 lines) that could only be this character.*
 
-| Character | Relationship | Dynamic |
-|-----------|-------------|---------|
-| *Name* | *Type* | *Description* |
+## Key Relationships
+
+| Character | Relationship | Dynamic | What they want FROM this person |
+|-----------|-------------|---------|-------------------------------|
+| *Name* | *Type* | *Description* | *Desire/need* |
 
 ## GMC (Goal / Motivation / Conflict)
 
-- **Goal:** *What do they want?*
-- **Motivation:** *Why do they want it?*
-- **Conflict:** *What stops them?*
+- **Goal:** *What do they want? (concrete, binary — achieved or not)*
+- **Motivation:** *Why do they want it? (emotional, rooted in backstory)*
+- **Conflict:** *What stops them? (external obstacles + internal resistance)*


### PR DESCRIPTION
## Summary

- Adds 18 missing character development fields across template + skill (Issue #36)
- Expands character-creator workflow from 9 to 14 steps with richer guidance
- Updates validator to enforce The Ghost + Motivation Chain for non-minor characters

## Changes

**`templates/character.md`**
- Frontmatter: `job` and `archetype` fields added
- New sections: Archetype (with subversion prompt), Life Context, Human Texture, Backstory subsections (Upbringing/Family/Friendships/Adversaries/The Ghost), Psychology (Lie/Fear/Phobias/Insecurities/Value System/Handling Emotions), Motivation Chain
- Enhanced Key Relationships table with "What they want FROM this person" column

**`skills/character-creator/SKILL.md`**
- 14-step workflow (was 9): new steps for Archetype, Motivation Chain, Psychology, Human Texture, Life Context
- Weakness vs. flaw distinction made explicit with concrete example
- Voice step adds "cover the name" test and stress-register guidance
- New coherence rule: Ghost → Lie → Flaw chain must be unbroken

**`hooks/validate_character.py`**
- `REQUIRED_SECTIONS` now includes `The Ghost` and `Motivation Chain` for non-minor characters

## Test plan

- [ ] Create a new character using the skill — all 14 steps should flow naturally
- [ ] Verify validator rejects a character file missing `## The Ghost` or `## Motivation Chain`
- [ ] Confirm `minor` role still skips section validation

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)