### PR TITLE
feat: add dedicated blurb-writing step to promo-writer workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ Use MCP tools for ALL state operations. Never parse project files directly in sk
 | "Übersetzen" / "Translate" | `/storyforge:translator` |
 | "Cover" / "Buchcover" | `/storyforge:cover-artist` |
 | "Promo" / "Social Media" / "Marketing" / "bewerben" | `/storyforge:promo-writer` |
+| "Klappentext" / "Blurb" / "Back cover" / "Back-cover copy" | `/storyforge:promo-writer` (starts at blurb step) |
 | "Neues Genre" / "Genre-Mix" | `/storyforge:genre-creator` |
 | `Regel:` / `Workflow:` / `Callback:` prefix, "merke dir" | `/storyforge:register-callback` |
 | "Hilfe" / "Help" | `/storyforge:help` |
@@ -171,6 +172,7 @@ Skills MUST load relevant craft references before generating creative content:
 - `character-creator` → loads: character-creation, character-arcs
 - `world-builder` → loads: world-building
 - `voice-checker` → loads: anti-ai-patterns, prose-style, dos-and-donts
+- `promo-writer` → loads: genre README(s) for blurb tone guidance
 
 ## Important Rules
 

--- a/skills/promo-writer/SKILL.md
+++ b/skills/promo-writer/SKILL.md
@@ -20,7 +20,36 @@ argument-hint: "<book-slug> [platform]"
 
 ## Workflow
 
-### Step 1: Campaign Strategy
+### Step 1: Write the Blurb
+
+The book blurb is the single most important marketing text — it must exist before any platform content is written. Do this first, always.
+
+**Load:**
+- `{project}/synopsis.md` — Short Synopsis section is the raw material
+- Genre README(s) — tone guidance for the blurb voice
+
+**Walk through the 5-element structure:**
+
+1. **Hook** — Opening line that captures the core premise. One sentence, written to grab a skimming reader.
+2. **Character Introduction** — Protagonist name + one defining characteristic. Enough to care, nothing more.
+3. **Conflict & Stakes** — What's at stake and what happens if they fail. The "or else" that creates urgency.
+4. **Tone Alignment** — Verify the blurb voice matches genre expectations:
+   - Thriller: tension, urgency, menace
+   - Romance: warmth, anticipation, emotional pull
+   - Horror: dread, wrongness, the unknown
+   - Fantasy: wonder, scale, stakes
+   - Literary Fiction: interiority, ambiguity, weight
+5. **Comp Titles** (optional) — "_X_ meets _Y_" format. Only include if the comparison is strong and both titles are recognizable.
+
+**Target:** 150–200 words. Rigorously edited. No spoilers. No ending revealed.
+
+**Output:** Save to `{project}/export/blurb.md` using `templates/blurb.md` as scaffold.
+
+**Gate:** Ask the user to approve the blurb before proceeding. If rejected, revise until approved.
+
+---
+
+### Step 2: Campaign Strategy
 Ask the user:
 - **Phase:** Pre-launch (teasers), Launch (announcement), Post-launch (sustained)
 - **Platforms:** Which ones? (or all)
@@ -35,7 +64,7 @@ Ask the user:
   - Series announcement
   - Giveaway posts
 
-### Step 2: Generate Platform-Specific Content
+### Step 3: Generate Platform-Specific Content
 
 Create `{project}/promo/` directory with per-platform files.
 
@@ -232,7 +261,7 @@ Body: [Deleted scene or character backstory + review request]
 
 ---
 
-### Step 3: Quote Cards
+### Step 4: Quote Cards
 Extract 5-10 compelling quotes from the book for visual content:
 - **Criteria:** Punchy, evocative, standalone (no context needed)
 - **Length:** 1-3 sentences max
@@ -241,7 +270,7 @@ Extract 5-10 compelling quotes from the book for visual content:
 
 Write to `{project}/promo/quotes.md`.
 
-### Step 4: Hashtag Strategy
+### Step 5: Hashtag Strategy
 Research and compile genre-specific hashtags:
 - **Broad:** #bookstagram, #booktok, #readersofinstagram, #bookish
 - **Genre:** #horrorbooks, #fantasyreads, #romancebooks, etc.
@@ -251,7 +280,7 @@ Research and compile genre-specific hashtags:
 
 Write to `{project}/promo/hashtags.md`.
 
-### Step 5: Content Calendar
+### Step 6: Content Calendar
 Suggest a posting schedule:
 
 | Day | Platform | Content Type |

--- a/templates/blurb.md
+++ b/templates/blurb.md
@@ -1,0 +1,33 @@
+---
+status: "Draft"
+word_count: 0
+approved: false
+---
+
+# {{title}} — Back-Cover Blurb
+
+## Hook
+
+*Opening line that captures the core premise immediately. One sentence — must grab readers who are skimming.*
+
+## Character Introduction
+
+*[Name] + one defining characteristic. What do we need to know about them to care?*
+
+## Conflict & Stakes
+
+*What's at stake. What happens if they fail. The "or else" that makes this urgent.*
+
+## Tone Alignment
+
+*Note: Does the blurb voice match the genre? (Thriller = tension; Romance = warmth + anticipation; Horror = dread; Fantasy = wonder + danger)*
+
+## Comp Titles (optional)
+
+*"[Title] meets [Title]" — only if the comparison is strong and both books are recognizable.*
+
+---
+
+## Final Blurb (150–200 words)
+
+*The polished, ready-to-publish version. Written in third person, present tense. No spoilers. No ending.*


### PR DESCRIPTION
Closes #39

## Summary

- Inserts a structured blurb-writing step as **Step 1** of `promo-writer` — before any platform content is generated
- Blurb follows the 5-element Reedsy structure: Hook → Character Introduction → Conflict & Stakes → Tone Alignment → Comp Titles
- Genre-aware: loads genre README(s) for tone guidance
- Gated on user approval before proceeding to social media steps
- Output saved to `{project}/export/blurb.md`
- Existing steps renumbered 2–6, no logic changed

## Files changed

| File | Change |
|------|--------|
| `skills/promo-writer/SKILL.md` | New Step 1 added; Steps 2–6 renumbered |
| `templates/blurb.md` | New scaffold with 5-element structure |
| `CLAUDE.md` | Routing for "Klappentext" / "Blurb" / "Back cover" added; `promo-writer` craft-references entry added |

## Test plan

- [ ] Trigger `promo-writer` — verify blurb step appears first
- [ ] Trigger with keyword "Klappentext" — verify routing hits `promo-writer`
- [ ] Verify blurb output lands in `export/blurb.md` with correct template structure
- [ ] Verify approval gate blocks Step 2 until user confirms
- [ ] Verify existing social media steps (Steps 2–6) are unchanged

🤖 Generated with [Claude Code](https://claude.ai/claude-code)