### PR TITLE
feat: add author_writing_mode for outliner/plantser/discovery workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Use MCP tools for ALL state operations. Never parse project files directly in sk
 | "Klappentext" / "Blurb" / "Back cover" / "Back-cover copy" | `/storyforge:promo-writer` (starts at blurb step) |
 | "Neues Genre" / "Genre-Mix" | `/storyforge:genre-creator` |
 | "I'm stuck" / "Ich komme nicht weiter" / "blockiert" / "kann nicht schreiben" / "keine Motivation" / "Schreibblockade" / "keine Lust" | `/storyforge:unblock` |
+| "Rolling planner" / "Next scene" / "Was kommt als nächstes?" / "Nächste Szene planen" / "Discovery writer" | `/storyforge:rolling-planner` |
 | `Regel:` / `Workflow:` / `Callback:` prefix, "merke dir" | `/storyforge:register-callback` |
 | "Hilfe" / "Help" | `/storyforge:help` |
 | "Setup" / "Einrichten" | `/storyforge:setup` |
@@ -66,14 +67,30 @@ Use MCP tools for ALL state operations. Never parse project files directly in sk
 5. Revision → Export → Translation (optional)
 ```
 
-### Standard Workflow
-1. `/storyforge:create-author` — Define writing style
+### Standard Workflow (Outliner)
+1. `/storyforge:create-author` — Define writing style (incl. `author_writing_mode`)
 2. `/storyforge:study-author` — (Optional) Analyze PDFs for style extraction
-3. `/storyforge:new-book` — Create project scaffold
+3. `/storyforge:new-book` — Create project scaffold + resolve writing mode
 4. `/storyforge:book-conceptualizer` — Develop concept in 5 phases
 5. `/storyforge:plot-architect` — Structure plot with acts, beats, arcs + tonal document
 6. `/storyforge:character-creator` — Build characters with depth
 7. `/storyforge:world-builder` — Setting, rules, history
+
+### Discovery Writer Workflow (Pantser)
+1. `/storyforge:create-author` — Define writing style (`author_writing_mode: discovery`)
+2. `/storyforge:new-book` — Create project scaffold (skips `plot-architect` suggestion)
+3. `/storyforge:book-conceptualizer` — Concept only (premise + protagonist + core tension)
+4. `/storyforge:character-creator` — Core characters (no arc planning required)
+5. `/storyforge:rolling-planner` — Before each writing session: scene recipe (Goal / Conflict / Consequence)
+6. (repeat 5 → chapter-writer for each chapter)
+
+### Plantser Workflow (Hybrid)
+1. `/storyforge:create-author` — Define writing style (`author_writing_mode: plantser`)
+2. `/storyforge:new-book` — Create project scaffold
+3. `/storyforge:book-conceptualizer` — Concept in 5 phases
+4. `/storyforge:plot-architect` — Minimal Viable Outline only (6 key beats, no full chapter plan)
+5. `/storyforge:character-creator` — Core characters
+6. `/storyforge:rolling-planner` — Scene-by-scene planning buffer (3-5 scenes ahead)
 8. `/storyforge:chapter-writer` — Write chapters in author's voice (loads timeline + travel matrix + tonal document + chapter timeline)
 9. `/storyforge:continuity-checker` — (Optional, after several chapters) Validate timeline and location consistency
 9. `/storyforge:chapter-reviewer` — Review each chapter

--- a/servers/storyforge-server/server.py
+++ b/servers/storyforge-server/server.py
@@ -83,11 +83,22 @@ def find_book(query: str) -> str:
 
 @mcp.tool()
 def get_book_full(slug: str) -> str:
-    """Get complete book data including all chapters and characters."""
+    """Get complete book data including all chapters and characters.
+
+    Returns effective_author_writing_mode: book-level override takes precedence
+    over the author profile value; falls back to "outliner" if neither is set.
+    """
     state = _cache.get()
     book = state.get("books", {}).get(slug)
     if not book:
         return json.dumps({"error": f"Book '{slug}' not found"})
+
+    author_slug = book.get("author", "")
+    author = state.get("authors", {}).get(author_slug, {})
+    book_override = book.get("author_writing_mode", "")
+    effective = book_override or author.get("author_writing_mode", "outliner")
+    book = {**book, "effective_author_writing_mode": effective}
+
     return json.dumps(book)
 
 

--- a/skills/configure/SKILL.md
+++ b/skills/configure/SKILL.md
@@ -41,3 +41,19 @@ user-invocable: true
 | Export format | `export.default_format` | epub, pdf, mobi |
 | PDF engine | `export.pdf_engine` | xelatex, pdflatex, wkhtmltopdf |
 | Cover platform | `cover.platform` | midjourney, dall-e |
+
+## Author Profile Settings
+
+These settings live in the author's `profile.md` frontmatter, not in `config.yaml`.
+Use MCP `update_author(slug, field, value)` to apply changes.
+
+| Setting | Field | Options |
+|---------|-------|---------|
+| Writing process mode | `author_writing_mode` | `outliner` \| `plantser` \| `discovery` |
+
+**To change an author's writing mode:**
+1. Ask which author profile to edit via MCP `list_authors()`
+2. Show current value via MCP `get_author(slug)`
+3. Ask for new value with AskUserQuestion (Outliner / Plantser / Discovery)
+4. Apply via MCP `update_author(slug, "author_writing_mode", value)`
+5. Confirm the change

--- a/skills/create-author/SKILL.md
+++ b/skills/create-author/SKILL.md
@@ -32,6 +32,10 @@ Guide the user through voice choices (use AskUserQuestion):
 5. **Vocabulary level:** simple, moderate, advanced, archaic
 6. **Dialog style:** naturalistic, stylized, minimal, heavy
 7. **Pacing:** slow-burn, tension-driven, breakneck, literary
+8. **Writing process (author_writing_mode):** How does this author approach planning?
+   - **Outliner** — Plans everything before writing (beats, chapter outlines, full plot map)
+   - **Plantser (Hybrid)** — Knows the key story beats, discovers the rest scene by scene
+   - **Discovery Writer (Pantser)** — Finds the story as they write; no outline before drafting
 
 ### Phase 3: Deeper Character
 Ask open-ended questions:
@@ -40,7 +44,7 @@ Ask open-ended questions:
 - "What's this author's signature move?" (e.g., unreliable narrators, gut-punch endings, dry wit in dark moments)
 
 ### Phase 4: Create Profile
-1. Use MCP `create_author()` with collected data
+1. Use MCP `create_author()` with collected data, then immediately call MCP `update_author(slug, "author_writing_mode", value)` to persist the writing mode
 2. Load the generated `profile.md` and `vocabulary.md`
 3. Review the banned words list (AI tells) — ask if user wants to add/remove any
 4. Show the complete profile to the user

--- a/skills/new-book/SKILL.md
+++ b/skills/new-book/SKILL.md
@@ -33,20 +33,38 @@ argument-hint: "[title]"
      - Novel: 80,000
      - Epic: 120,000
 
-2. **Create project** — Use MCP `create_book_structure()` with collected info
+2. **Resolve writing mode** — Load the author profile via MCP `get_author(slug)`:
 
-3. **Create CLAUDE.md** — Use MCP `init_book_claudemd(book_slug, book_title, pov, tense, genre, writing_mode)` to scaffold the per-book context file. Ask the user for `writing_mode` if not obvious: `scene-by-scene` (default), `chapter`, or `book`. Per-chapter progress is NOT stored here — it lives in `update_session()`.
+   **a) Lazy migration** — If `author_writing_mode` is missing or empty in the returned data:
+   - Ask once: *"How do you approach writing? — Outliner (plan everything) / Plantser (key beats + discovery) / Discovery Writer (no outline)"*
+   - Write back via MCP `update_author(slug, "author_writing_mode", value)`
+   - This is a one-time migration; it never asks again once set.
 
-4. **Update session** — Use MCP `update_session()` with the new book as active
+   **b) Per-book override** — Show the author's default and ask:
+   *"Your default writing style is [mode]. Same for this book, or override?"*
+   - If override: store in book README frontmatter via MCP `update_field(book_readme_path, "author_writing_mode", value)`
+   - If same: leave book `author_writing_mode` empty (inherits from author)
 
-5. **Load genre README(s)** — Use MCP `get_genre()` for each selected genre. Show key conventions to the user.
+   **c) Route based on effective mode:**
+   - `outliner` → suggest `/storyforge:plot-architect` for full outline
+   - `plantser` → suggest `/storyforge:plot-architect` (user will choose minimal outline or Snowflake there)
+   - `discovery` → suggest `/storyforge:rolling-planner` instead of `plot-architect`
 
-6. **Suggest next steps** — Based on the genre and book type:
-   - "Start with `/storyforge:book-conceptualizer` to develop your concept"
-   - "Or jump to `/storyforge:plot-architect` if you already know the story"
-   - "Need characters first? Try `/storyforge:character-creator`"
+3. **Create project** — Use MCP `create_book_structure()` with collected info
+
+4. **Create CLAUDE.md** — Use MCP `init_book_claudemd(book_slug, book_title, pov, tense, genre, writing_mode)` to scaffold the per-book context file. Ask the user for `writing_mode` if not obvious: `scene-by-scene` (default), `chapter`, or `book`. Note: this `writing_mode` controls how Claude composes chapters — it is different from `author_writing_mode` which controls the planning workflow.
+
+5. **Update session** — Use MCP `update_session()` with the new book as active
+
+6. **Load genre README(s)** — Use MCP `get_genre()` for each selected genre. Show key conventions to the user.
+
+7. **Suggest next steps** — Based on effective `author_writing_mode`:
+   - **Outliner:** "Start with `/storyforge:book-conceptualizer` → then `/storyforge:plot-architect` for the full outline"
+   - **Plantser:** "Start with `/storyforge:book-conceptualizer` → then `/storyforge:plot-architect` (choose minimal outline or Snowflake)"
+   - **Discovery:** "Start with `/storyforge:book-conceptualizer` (concept only, no plot) → then `/storyforge:rolling-planner` before each writing session"
 
 ## Rules
 - ALWAYS create the author profile BEFORE the book if none exists
 - NEVER skip genre selection — it drives the entire writing process
 - If the user provides a title as argument, use it directly
+- Lazy migration in step 2a is idempotent — only ask if `author_writing_mode` is truly missing/empty

--- a/skills/plot-architect/SKILL.md
+++ b/skills/plot-architect/SKILL.md
@@ -23,6 +23,17 @@ argument-hint: "<book-slug>"
 
 ## Workflow
 
+### Step 0: Check Writing Mode
+Load the book via MCP `get_book_full(slug)` and read `effective_author_writing_mode`.
+
+- **`discovery`** — Stop here. Discovery writers skip `plot-architect` entirely.
+  Tell the user: *"Your writing mode is Discovery — you don't need a full outline. Use `/storyforge:rolling-planner` before each writing session instead."*
+  Do not proceed unless the user explicitly overrides this.
+
+- **`plantser`** — Proceed, but flag at Step 2 that the goal is a **Minimal Viable Outline only** (6 sentences), not a full beat sheet. Skip Steps 4–6 unless the user asks for them. Suggest Snowflake or 3-Act (minimal) as the default structure.
+
+- **`outliner`** — Proceed with the full workflow below.
+
 ### Step 1: Read Existing Work
 - Read `{project}/README.md` for premise, themes, concept
 - Read `{project}/plot/outline.md` for any existing outline

--- a/skills/rolling-planner/SKILL.md
+++ b/skills/rolling-planner/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: rolling-planner
+description: |
+  Scene-by-scene planning for discovery writers and plantsers.
+  Use when: (1) User says "rolling planner", "next scene", "was kommt als nächstes",
+  (2) author_writing_mode is "discovery" and user is about to write a chapter,
+  (3) Plantser needs to plan the next 3-5 scenes before chapter-writer runs.
+model: claude-sonnet-4-6
+user-invocable: true
+argument-hint: "[book-slug]"
+---
+
+# Rolling Planner
+
+Purpose: Replace full upfront outlining with a lightweight, just-in-time scene recipe
+written *before* `chapter-writer` runs. Discovery writers and plantsers use this
+instead of `plot-architect`.
+
+## Prerequisites
+- Load book via MCP `get_book_full(book_slug)`
+- Load author profile via MCP `get_author(author_slug)`
+- Load existing chapter summaries to understand story so far
+
+## Workflow
+
+### Step 1: Orient — What Has Happened
+Read chapter READMEs (in order) via MCP to build a quick "story so far" summary:
+- Who is where, and what do they want right now?
+- What was the last thing that happened (last chapter's consequence)?
+- What loose threads are active (unresolved conflicts, open questions)?
+
+Present a 3-sentence "previously on" to the user and ask: *"Does this match your sense of where we are?"*
+
+### Step 2: Define What Needs to Happen Next
+Ask the user (use AskUserQuestion or conversational flow):
+- **What does the protagonist want in the next scene?** (concrete goal, not theme)
+- **What stands in their way?** (person, situation, internal resistance)
+- **What should change by the end of this scene?** (something must shift — status, knowledge, relationship, plan)
+
+If the user doesn't know the answer to any of these, that's fine — help them discover it:
+- "What would feel wrong if it *didn't* happen soon?"
+- "What does the antagonist/situation need from this moment?"
+- "What would surprise you as a reader?"
+
+### Step 3: Write the Scene Recipe
+Compose a 3-part scene recipe (one line each):
+
+```
+Goal:        [What the POV character is trying to achieve]
+Conflict:    [What blocks or complicates that goal]
+Consequence: [What changes — resolution or disaster that opens the next scene]
+```
+
+Ask the user to confirm or adjust. This is the contract the chapter-writer will fulfill.
+
+### Step 4: Optional — 3-Sentence Scene Outline
+For scenes with higher complexity (multiple characters, reveals, action), offer a brief
+expansion:
+1. Opening beat — how the scene starts, who is present
+2. Complication — the moment the goal gets harder or changes
+3. Exit beat — how the scene ends and what it leaves unresolved
+
+This is optional. Skip for straightforward scenes.
+
+### Step 5: Save to Chapter README
+Write the scene recipe (and optional outline) to the next chapter's README via
+MCP `update_field(chapter_readme_path, "scene_recipe", value)`.
+
+If the chapter directory doesn't exist yet, create it via MCP `create_chapter(book_slug, number, title)`.
+
+### Step 6: Look Ahead (Optional)
+Ask: *"Want to sketch the next 2-3 scenes as well, or start writing now?"*
+
+If yes: repeat Steps 2-4 for each additional scene, writing them to their chapter READMEs.
+This builds a rolling 3-5 scene buffer — enough to write without planning the whole book.
+
+## Rules
+- Scene recipes are planning tools, not outlines — they can and should change during drafting
+- NEVER ask the user to plan more than 5 scenes ahead; that defeats the purpose
+- If the user already knows what happens, skip Steps 1-2 and go straight to writing the recipe
+- After saving the recipe, always suggest: "Ready to write? → `/storyforge:chapter-writer`"
+- Plantser users: this skill complements the minimal outline from `plot-architect` — it adds
+  scene-level detail only when needed, not upfront

--- a/templates/author-profile.md
+++ b/templates/author-profile.md
@@ -14,6 +14,7 @@ pacing: "tension-driven"
 themes: []
 influences: []
 avoid: ["purple-prose", "info-dumps", "deus-ex-machina"]
+author_writing_mode: "outliner"  # outliner | plantser | discovery
 ---
 
 # {{name}}

--- a/templates/book.md
+++ b/templates/book.md
@@ -10,6 +10,7 @@ target_word_count: {{target_word_count}}
 series: ""
 series_number: 0
 description: ""
+author_writing_mode: ""  # override author default: outliner | plantser | discovery (empty = inherit)
 created: "{{date}}"
 updated: "{{date}}"
 ---

--- a/tests/test_author_writing_mode.py
+++ b/tests/test_author_writing_mode.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from tools.state.parsers import parse_author_profile, parse_book_readme
 
 

--- a/tests/test_author_writing_mode.py
+++ b/tests/test_author_writing_mode.py
@@ -1,0 +1,113 @@
+"""Tests for author_writing_mode support in parse_author_profile.
+
+Issue #34: StoryForge now tracks how an author plans their writing process
+(outliner | plantser | discovery). This is stored as author_writing_mode in
+the author profile frontmatter — distinct from the book-level writing_mode
+(scene-by-scene | chapter | book) which controls how Claude composes chapters.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.state.parsers import parse_author_profile, parse_book_readme
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_profile(tmp_path: Path, extra_frontmatter: str = "") -> Path:
+    author_dir = tmp_path / "test-author"
+    author_dir.mkdir()
+    profile = author_dir / "profile.md"
+    profile.write_text(
+        f'---\nname: "Test Author"\nslug: "test-author"\n'
+        f'narrative_voice: "third-limited"\ntense: "past"\n'
+        f'{extra_frontmatter}'
+        f'---\n\n# Test Author\n',
+        encoding="utf-8",
+    )
+    return profile
+
+
+# ---------------------------------------------------------------------------
+# author_writing_mode field
+# ---------------------------------------------------------------------------
+
+
+class TestAuthorWritingMode:
+    def test_returns_outliner_as_default_when_field_missing(self, tmp_path):
+        profile = _make_profile(tmp_path)
+        result = parse_author_profile(profile)
+        assert result["author_writing_mode"] == "outliner"
+
+    def test_reads_outliner_value(self, tmp_path):
+        profile = _make_profile(tmp_path, 'author_writing_mode: "outliner"\n')
+        result = parse_author_profile(profile)
+        assert result["author_writing_mode"] == "outliner"
+
+    def test_reads_plantser_value(self, tmp_path):
+        profile = _make_profile(tmp_path, 'author_writing_mode: "plantser"\n')
+        result = parse_author_profile(profile)
+        assert result["author_writing_mode"] == "plantser"
+
+    def test_reads_discovery_value(self, tmp_path):
+        profile = _make_profile(tmp_path, 'author_writing_mode: "discovery"\n')
+        result = parse_author_profile(profile)
+        assert result["author_writing_mode"] == "discovery"
+
+    def test_does_not_conflict_with_existing_fields(self, tmp_path):
+        """author_writing_mode must not overwrite or corrupt other profile fields."""
+        profile = _make_profile(tmp_path, 'author_writing_mode: "plantser"\n')
+        result = parse_author_profile(profile)
+        assert result["narrative_voice"] == "third-limited"
+        assert result["tense"] == "past"
+        assert result["slug"] == "test-author"
+        assert result["name"] == "Test Author"
+
+    def test_field_present_in_returned_dict(self, tmp_path):
+        """Regression: author_writing_mode must always be present, never silently absent."""
+        profile = _make_profile(tmp_path)
+        result = parse_author_profile(profile)
+        assert "author_writing_mode" in result
+
+
+# ---------------------------------------------------------------------------
+# Book-level author_writing_mode override (stored in book README frontmatter)
+# ---------------------------------------------------------------------------
+
+
+def _make_book_readme(tmp_path: Path, extra_frontmatter: str = "") -> Path:
+    book_dir = tmp_path / "my-book"
+    book_dir.mkdir()
+    readme = book_dir / "README.md"
+    readme.write_text(
+        f'---\ntitle: "My Book"\nauthor: "test-author"\n'
+        f'genres: ["horror"]\nbook_type: "novel"\nstatus: "Idea"\n'
+        f'{extra_frontmatter}'
+        f'---\n\n# My Book\n',
+        encoding="utf-8",
+    )
+    return readme
+
+
+class TestBookAuthorWritingModeOverride:
+    def test_defaults_to_empty_string_when_not_set(self, tmp_path):
+        """Empty string signals 'inherit from author profile' — not a mode value."""
+        readme = _make_book_readme(tmp_path)
+        result = parse_book_readme(readme)
+        assert result["author_writing_mode"] == ""
+
+    def test_reads_override_when_set(self, tmp_path):
+        readme = _make_book_readme(tmp_path, 'author_writing_mode: "discovery"\n')
+        result = parse_book_readme(readme)
+        assert result["author_writing_mode"] == "discovery"
+
+    def test_field_present_in_returned_dict(self, tmp_path):
+        readme = _make_book_readme(tmp_path)
+        result = parse_book_readme(readme)
+        assert "author_writing_mode" in result

--- a/tools/state/parsers.py
+++ b/tools/state/parsers.py
@@ -47,6 +47,7 @@ def parse_book_readme(path: Path) -> dict[str, Any]:
         "series": meta.get("series", ""),
         "series_number": meta.get("series_number", 0),
         "description": meta.get("description", ""),
+        "author_writing_mode": meta.get("author_writing_mode", ""),
         "created": str(meta.get("created", "")),
         "updated": str(meta.get("updated", "")),
     }
@@ -125,6 +126,7 @@ def parse_author_profile(path: Path) -> dict[str, Any]:
         "themes": meta.get("themes", []),
         "influences": meta.get("influences", []),
         "avoid": meta.get("avoid", []),
+        "author_writing_mode": meta.get("author_writing_mode", "outliner"),
         "created": str(meta.get("created", "")),
         "updated": str(meta.get("updated", "")),
     }


### PR DESCRIPTION
## Summary

- Introduces `author_writing_mode` (`outliner` | `plantser` | `discovery`) as a first-class field on author profiles and per-book override
- Discovery writers (~40-50% of authors) are no longer forced through the full `plot-architect` pipeline
- Adds new `/storyforge:rolling-planner` skill for scene-by-scene just-in-time planning

## Changes

**Python / MCP Server**
- `parse_author_profile()` returns `author_writing_mode` (default: `"outliner"`)
- `parse_book_readme()` returns `author_writing_mode` override (default: `""` = inherit from author)
- `get_book_full()` now includes `effective_author_writing_mode` (book override > author default)

**Templates**
- `author-profile.md` — new `author_writing_mode` field
- `book.md` — new `author_writing_mode` override field (empty = inherit)

**Skills**
- `create-author` — Phase 2 now asks for writing mode, persists via `update_author()`
- `configure` — exposes `author_writing_mode` as editable author profile setting
- `new-book` — lazy migration for existing authors + per-book override + mode-based routing
- `plot-architect` — new Step 0: blocks discovery writers, flags plantsers for minimal outline
- `rolling-planner` — **new skill** for scene-by-scene planning (Goal / Conflict / Consequence)
- `CLAUDE.md` — routing table updated, three workflow pipelines documented

## Note on naming

The existing `writing_mode` in `init_book_claudemd()` controls how Claude *composes* chapters (`scene-by-scene` | `chapter` | `book`). The new field is named `author_writing_mode` to avoid any ambiguity.

## Test plan

- [x] 9 new tests covering `parse_author_profile()` and `parse_book_readme()` for `author_writing_mode`
- [x] All 269 tests pass
- [ ] Manual: create new author → writing mode is asked and saved
- [ ] Manual: existing author without `author_writing_mode` → lazy migration fires in `new-book`
- [ ] Manual: discovery writer → `plot-architect` redirects to `rolling-planner`
- [ ] Manual: `rolling-planner` produces scene recipe and saves to chapter README

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)