### PR TITLE
Migrate 20 skills to Claude Opus 4.7 + behavior-shift hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Nothing yet
 
 ### Changed
-- Nothing yet
+- Migrate 20 skills from `claude-opus-4-6` to `claude-opus-4-7` (#50)
+- Harden 16 skills for Claude 4.7 behavior shifts: explicit length targets as soft guidelines, Negative→Positive voice rewrites for Top-3 critical patterns per skill, `Why:` justifications for MANDATORY Loads to prevent tool-use optimization, explicit Wait gates between wizard phases (book-conceptualizer, character-creator, beta-feedback, plot-architect, series-planner)
+  - Critical (6): chapter-writer, voice-checker, book-conceptualizer, character-creator, unblock, beta-feedback
+  - Risk (10): plot-architect, chapter-reviewer, manuscript-checker, promo-writer, translator, series-planner, world-builder, create-author, study-author, sensitivity-reader
 
 ### Deprecated
 - Nothing yet

--- a/skills/beta-feedback/SKILL.md
+++ b/skills/beta-feedback/SKILL.md
@@ -82,6 +82,8 @@ Format rules:
 3. Validate: file must contain at least one `## FB-` section. If empty or malformed, report error and stop.
 4. Report to user: "Loaded X feedback items affecting Y unique chapters."
 
+**Wait for user acknowledgement before proceeding to Phase 2 (Categorize).** The user may want to add or remove items from the file first.
+
 ### Phase 2: Categorize
 
 Tag each item with one or more categories based on its content:
@@ -103,6 +105,8 @@ FB-001: Pacing drags in Ch 18-19 → pacing
 FB-002: Kael's motivation unclear → character, plot
 FB-003: Kevin scene was perfect → positive
 ```
+
+**Wait for user confirmation of the category mapping before proceeding to Phase 3.** Miscategorization at this stage cascades into wrong cross-references in Phase 3.
 
 ### Phase 3: Cross-reference
 
@@ -161,7 +165,7 @@ Output format:
 
 ### Phase 6: Execute (optional, user-triggered)
 
-**Only proceed when the user explicitly approves.** Never auto-execute.
+**Wait for explicit user approval before executing any revision.** This phase rewrites prose — auto-execution corrupts drafts.
 
 For each approved revision task:
 - **Prose/pacing fixes:** Use `/storyforge:chapter-writer` in rewrite mode for the affected scene
@@ -195,10 +199,10 @@ Generate using `templates/beta-feedback-triage.md` as scaffold.
 
 ## Rules
 - Apply Rule #14 rigorously: beta readers are LESS reliable than the author. Verify every claim before accepting.
-- NEVER auto-execute revisions. Always present the triage and wait for user approval.
+- Always present the triage and wait for user approval before executing any revision. Auto-execution is forbidden.
 - Quote specific passages from the draft when providing evidence for verdicts.
 - Quote specific entries from canon-log, arcs, tone, or callbacks when disagreeing with feedback.
-- Positive feedback is worth logging — it tells the author what's working and should NOT be changed during revision.
+- Positive feedback is worth logging — it tells the author what's working. Treat it as protected from revision changes.
 - If multiple feedback items conflict with each other, surface the conflict explicitly and let the author decide.
-- The author already pre-filtered the feedback. Respect that curation — don't second-guess which items are in the file. Only push back on the verdict (valid vs. disagree), not on inclusion.
+- The author already pre-filtered the feedback. Respect that curation — only push back on the verdict (valid vs. disagree), not on inclusion.
 - Track cascade effects rigorously. A change in one chapter that breaks another is worse than the original problem.

--- a/skills/beta-feedback/SKILL.md
+++ b/skills/beta-feedback/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Process curated beta-reader feedback — triage, cross-reference, revision plan.
   Use when: (1) User says "beta feedback", "ARC feedback", "reader feedback", "Beta-Feedback verarbeiten",
   (2) Book is in eBook/revision stage with beta-reader responses collected.
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<book-slug> [--file path/to/feedback.md]"
 ---

--- a/skills/book-conceptualizer/SKILL.md
+++ b/skills/book-conceptualizer/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Develop a book concept through 5 phases: premise, theme, conflict, structure, pitch.
   Use when: (1) User says "Konzept", "develop concept", "Buchkonzept",
   (2) After brainstorming, to deepen an idea into a workable concept.
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<book-slug>"
 ---

--- a/skills/book-conceptualizer/SKILL.md
+++ b/skills/book-conceptualizer/SKILL.md
@@ -11,11 +11,14 @@ argument-hint: "<book-slug>"
 
 # Book Conceptualizer
 
-## Prerequisites
-- Book project must exist (via `/storyforge:new-book`)
-- Load book data via MCP `get_book_full()`
-- Load genre README(s) via MCP `get_genre()` for each genre
-- Load craft references: `story-structure`, `plot-craft`, `theme-development` via MCP `get_craft_reference()`
+## Prerequisites — MANDATORY LOADS
+- Book project must exist (via `/storyforge:new-book`).
+- **Book data** via MCP `get_book_full()`. **Why:** Project state, genre selection, existing premise/theme drafts — anchors the conversation in what already exists.
+- **Genre README(s)** via MCP `get_genre()` for each genre. **Why:** Genre conventions shape premise expectations (e.g. romance HEA, thriller ticking-clock) and structural recommendations in Phase 4.
+- **Craft references** via MCP `get_craft_reference()`:
+  - `story-structure` — **Why:** Phase 4 structure selection — different concepts fit different structures (3-act vs. 5-act vs. Save-the-Cat).
+  - `plot-craft` — **Why:** Conflict-stakes-decision logic for Phase 3 conflict architecture.
+  - `theme-development` — **Why:** Theme-as-question (not theme-as-lesson) — the framing that keeps Phase 2 from going preachy.
 
 ## Workflow — 5 Phases
 
@@ -29,15 +32,19 @@ Refine into a clear **Premise** (2-3 sentences): Character + Situation + Central
 
 Write to `{project}/README.md` under "## Premise".
 
+**Wait for user response and explicit premise approval. Do not proceed to Phase 2 without input.**
+
 ### Phase 2: Theme Discovery
-Don't tell — ask:
-- "What question does this story ask?" (NOT "what lesson does it teach")
+Ask probing questions. Listen first:
+- "What question does this story ask?" (Not "what lesson does it teach")
 - "What do your protagonist and antagonist disagree about?"
 - "What's the argument your story is making — without being preachy?"
 
 Reference `theme-development.md` — theme as QUESTION, not answer.
 
 Write to `{project}/README.md` under "## Themes".
+
+**Wait for user response. Do not proceed to Phase 3 without input.**
 
 ### Phase 3: Conflict Architecture
 Using `conflict-types.md` as reference:
@@ -46,27 +53,33 @@ Using `conflict-types.md` as reference:
 - **How do they mirror each other?** The external journey should reflect the internal one.
 - **Stakes:** What happens if they fail? (Personal → Relational → Community → Existential)
 
+Target: ~200-400 Wörter Konflikt-Architektur als Output, kompakt — die Tiefe entsteht in Phase 4 + Charakter-Skill, nicht hier.
+
+**Wait for user response. Do not proceed to Phase 4 without input.**
+
 ### Phase 4: Structure Selection
 Using `story-structure.md`:
 - Recommend a structure based on genre and story type
-- Show the user 2-3 options with pros/cons
+- Show the user 2-3 options with pros/cons (max ~150 Wörter pro Option)
 - Map the concept to the chosen structure's beats
 
 Write initial outline to `{project}/plot/outline.md`.
+
+**Wait for user response and structure choice. Do not proceed to Phase 5 without input.**
 
 ### Phase 5: Pitch Creation
 Generate:
 - **Logline:** One sentence ([Character] must [action] or [stakes])
 - **Elevator pitch:** 2-3 sentences
 - **Comparable titles:** "X meets Y"
-- **Back-cover blurb:** 150-200 words (does NOT reveal ending)
+- **Back-cover blurb:** 150-200 Wörter (does NOT reveal ending)
 
 Write to `{project}/synopsis.md`.
 
 Update book status to "Concept" via MCP `update_field()`.
 
 ## Rules
-- NEVER impose a theme — discover it through questions
-- The concept must emerge from DIALOG with the user, not from AI generation alone
-- Every concept needs ALL three: premise + theme + conflict. Don't skip any.
-- Load genre conventions — they shape structural expectations
+- Discover theme through questions. Imposed themes feel preachy and AI-generated.
+- The concept must emerge from DIALOG with the user, not from AI generation alone.
+- Every concept needs ALL three: premise + theme + conflict. Skipping one ships an incomplete concept.
+- Load genre conventions — they shape structural expectations.

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Brainstorm book ideas interactively. Develop premises, explore genres, ask "what if?" questions.
   Use when: (1) User says "Idee", "brainstorm", "was könnte ich schreiben",
   (2) User wants to explore story concepts before committing.
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 ---
 

--- a/skills/chapter-reviewer/SKILL.md
+++ b/skills/chapter-reviewer/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Review and critique a chapter for craft quality, voice consistency, and AI-tells.
   Use when: (1) User says "Kapitel reviewen", "review chapter",
   (2) After chapter-writer completes a draft.
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<book-slug> <chapter-slug>"
 ---

--- a/skills/chapter-reviewer/SKILL.md
+++ b/skills/chapter-reviewer/SKILL.md
@@ -11,10 +11,16 @@ argument-hint: "<book-slug> <chapter-slug>"
 
 # Chapter Reviewer
 
-## Prerequisites
-- Load author profile via MCP `get_author()`
-- Load author vocabulary from `~/.storyforge/authors/{slug}/vocabulary.md`
-- Load craft references: `dos-and-donts`, `anti-ai-patterns`, `chapter-construction`, `dialog-craft`, `show-dont-tell`, `simile-discipline`
+## Prerequisites — MANDATORY LOADS
+- **Author profile** via MCP `get_author()`. **Why:** Voice consistency check needs the documented baseline — without it, "voice match" is gut-feel.
+- **Author vocabulary** from `~/.storyforge/authors/{slug}/vocabulary.md`. **Why:** Banned-word scan and preferred-word presence check both run against this list.
+- **Craft references** via MCP `get_craft_reference()`:
+  - `dos-and-donts` — **Why:** The general craft baseline for the Craft section (5 points).
+  - `anti-ai-patterns` — **Why:** AI-tell catalog for the Anti-AI section (5 points) — vocabulary, uniformity, generic descriptions.
+  - `chapter-construction` — **Why:** Hook/scene-sequel/ending criteria for the Structure section (5 points).
+  - `dialog-craft` — **Why:** Subtext, voice differentiation, tag discipline — for points 9 and 15.
+  - `show-dont-tell` — **Why:** Show/tell balance check for points 6 and 24.
+  - `simile-discipline` — **Why:** The two-question test sub-point 10b runs.
 - **Detect if this is Chapter 1:** Check chapter slug (starts with `01-` or `001-`) or frontmatter chapter number (`chapter: 1`). If Chapter 1: also load `openings-and-endings` craft reference.
 - Read the chapter draft: `{project}/chapters/{chapter}/draft.md`
 - Read the chapter outline: `{project}/chapters/{chapter}/README.md`
@@ -108,6 +114,8 @@ If this is Chapter 1, run this checklist BEFORE the standard review. Rate each p
 
 ## Output Format
 
+**Report target: 800-1200 Wörter total.** Critical findings first, then Recommended, Minor only if a pattern emerges (3+ instances). Skip empty sections — if there are zero AI-tells, the AI-Tell Report is one line ("Flagged words: none. Variance high. Generic descriptions: 0."), not a full table.
+
 ```markdown
 ## Chapter Review: {Chapter Title}
 
@@ -189,8 +197,8 @@ If this is Chapter 1, run this checklist BEFORE the standard review. Rate each p
 
 ## Rules
 - Be BRUTALLY honest. The user asked for honesty in their global instructions.
-- Praise what's genuinely good — don't just list problems.
+- Pair every critical finding with a specific strength — the report is signal, not just complaint.
 - Quote specific lines when flagging issues.
 - Suggest concrete rewrites, not just "make this better."
-- The AI-tell check is the most important section. Zero tolerance.
+- The AI-tell check runs as a hard gate — if banned words appear, flag the chapter as NEEDS REVISION regardless of other scores.
 - When the user flags an issue: VERIFY before accepting. Re-read the passage, check context from earlier chapters, and push back if the user misunderstood (especially English nuances). The user explicitly wants to be challenged, not blindly agreed with.

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Write a chapter in the author's voice, guided by craft knowledge and genre conventions.
   THE core creative skill. Use when: (1) User says "Kapitel schreiben", "write chapter",
   (2) Book is in Drafting status with chapters outlined.
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<book-slug> <chapter-number>"
 ---

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -14,24 +14,24 @@ argument-hint: "<book-slug> <chapter-number>"
 ## Prerequisites — MANDATORY LOADS
 Before writing a SINGLE word, load ALL of these:
 
-1. **Author profile** — MCP `get_author()`. This drives EVERYTHING: tone, vocabulary, rhythm, voice.
-2. **Author vocabulary** — Read `~/.storyforge/authors/{slug}/vocabulary.md` for preferred/banned words.
-3. **Book data** — MCP `get_book_full()` for genres, characters, plot context.
-4. **Chapter outline** — Read `{project}/chapters/{chapter}/README.md` for beats and purpose.
-5. **Previous chapter** — Read `{project}/chapters/{prev}/draft.md` for continuity, voice consistency.
-6. **Genre README(s)** — MCP `get_genre()` for each genre. Respect conventions.
+1. **Author profile** — MCP `get_author()`. **Why:** Drives EVERYTHING — tone, vocabulary, rhythm, voice. Without it, prose defaults to generic AI register.
+2. **Author vocabulary** — Read `~/.storyforge/authors/{slug}/vocabulary.md`. **Why:** Preferred/banned words list — the enforcement layer for voice authenticity at the word level.
+3. **Book data** — MCP `get_book_full()`. **Why:** Genres, characters, plot context — the chapter must fit this frame.
+4. **Chapter outline** — Read `{project}/chapters/{chapter}/README.md`. **Why:** Beats and purpose define what this chapter must deliver.
+5. **Previous chapter** — Read `{project}/chapters/{prev}/draft.md`. **Why:** Continuity (last sentence → next opening), voice consistency drift check.
+6. **Genre README(s)** — MCP `get_genre()` for each genre. **Why:** Genre conventions — readers expect specific patterns; violating them needs to be a deliberate choice, not an accident.
 7. **Craft references** — MCP `get_craft_reference()`:
-   - `chapter-construction` (hooks, scene-sequel, endings)
-   - `dialog-craft` (subtext, beats, voice)
-   - `show-dont-tell` (techniques, five senses)
-   - `pacing-guide` (scene vs. summary, rhythm)
-   - `anti-ai-patterns` (what to avoid at ALL costs)
-   - `prose-style` (word choice, rhythm, devices)
-   - `simile-discipline` (the two-question test for every comparison — mandatory for the pre-save scan in Step 6c)
-8. **Character files** — For each character appearing in this chapter, call MCP `get_character(book_slug, character_slug)`. Use the slugified name (e.g. "Jane Doe" → "jane-doe"). If the tool returns `{"error": ...}`, note it and proceed — don't fall back to direct file reads.
-9. **World files** — Read `{project}/world/setting.md` (includes the Travel Matrix). Mandatory if the chapter involves any travel or location references.
-10. **Story timeline** — Read `{project}/plot/timeline.md`. Mandatory for ALL chapters. This is the canonical day/date reference.
-11. **Canon log** — Read `{project}/plot/canon-log.md`. Mandatory for ALL chapters. This tracks established facts and revision changes. Pay special attention to facts marked `CHANGED` — never reference the old version.
+   - `chapter-construction` — **Why:** Hooks, scene-sequel, endings — the structural skeleton of every chapter.
+   - `dialog-craft` — **Why:** Subtext, beats, voice differentiation — the most common AI-tell is dialogue that sounds like everyone is the same person.
+   - `show-dont-tell` — **Why:** Techniques and five senses — telling collapses prose into report-mode.
+   - `pacing-guide` — **Why:** Scene vs. summary, rhythm — wrong pacing is what makes drafts feel flat.
+   - `anti-ai-patterns` — **Why:** The negative-space catalog — what to NOT do at ALL costs.
+   - `prose-style` — **Why:** Word choice, rhythm, devices — sentence-level craft.
+   - `simile-discipline` — **Why:** The two-question test for every comparison — mandatory for the pre-save scan in Step 6c.
+8. **Character files** — For each character appearing in this chapter, call MCP `get_character(book_slug, character_slug)`. **Why:** Voice differentiation, motivation accuracy, physical/emotional consistency. Use the slugified name (e.g. "Jane Doe" → "jane-doe"). If the tool returns `{"error": ...}`, note it and proceed — direct file reads are not the fallback.
+9. **World files** — Read `{project}/world/setting.md` (includes the Travel Matrix). **Why:** Travel times, distances, location facts — invented travel times break continuity. Mandatory if the chapter involves any travel or location references.
+10. **Story timeline** — Read `{project}/plot/timeline.md`. **Why:** The canonical day/date reference — every relative time reference ("an hour ago") is checked against this. Mandatory for ALL chapters.
+11. **Canon log** — Read `{project}/plot/canon-log.md`. **Why:** Tracks established facts and revision changes. Mandatory for ALL chapters. Pay special attention to facts marked `CHANGED` — reference only the new version.
 12. **Series canon** — If part of a series, read `{series}/world/canon.md`.
 13. **Tonal document** — Read `{project}/plot/tone.md` if it exists. This defines book-specific tonal rules, warning signs, and the litmus test for this chapter's position in the tonal arc. Older books may not have this file — proceed without it, but recommend creating one.
 14. **Previous chapter timeline** — Read the `## Chapter Timeline` section from `{project}/chapters/{prev}/README.md`. This tells you what time of day the previous chapter ended, which determines when this chapter starts. Critical for time references like "an hour ago" or "that morning."
@@ -54,8 +54,8 @@ Read the chapter README.md outline:
 ### Step 2: Choose Writing Mode
 Ask the user how they want to write this chapter (use AskUserQuestion):
 
-- **Scene-by-scene (Recommended)** — Write one scene at a time (~900 words). User reviews and corrects each scene before the next one is written. After all scenes are complete, user reads the full chapter for a final pass. This is slower per-chapter but produces higher quality with fewer full rewrites.
-- **Full chapter** — Write the entire chapter in one pass. Traditional approach.
+- **Scene-by-scene (Recommended)** — Write one scene at a time (~900 Wörter als Soft-Target, je nach Szenen-Bedarf — manche brauchen 600, andere 1200). User reviews and corrects each scene before the next one is written. After all scenes are complete, user reads the full chapter for a final pass. This is slower per-chapter but produces higher quality with fewer full rewrites.
+- **Full chapter** — Write the entire chapter in one pass. Target: 2500-4000 Wörter je nach Genre/Outline, als Richtwert — die Outline-Word-Count im README ist der primäre Anker. Traditional approach.
 - **Batch all chapters** — Write all remaining chapter drafts sequentially. Only for rough first drafts when speed matters more than quality.
 
 If the user has already chosen a mode in this session (e.g. during a previous chapter), remember their choice and skip the question — but still mention which mode is active.
@@ -128,7 +128,7 @@ After ALL scenes are approved and appended to draft.md:
 
 #### Step 3: Opening Hook
 Write the first paragraph with extreme care. Reference `openings-and-endings.md`:
-- Start with action, voice, or tension — NEVER with weather or waking up
+- Open with action, voice, or tension. Weather or waking-up openings start in neutral and force the reader to wait for stakes.
 - Ground the reader: who, where, when (subtly)
 - Create a micro-question that pulls the reader forward
 - Match the author's established voice from the FIRST sentence
@@ -152,7 +152,7 @@ Follow the Scene-Sequel structure from `chapter-construction.md`:
 For EVERY paragraph, check against the author profile:
 - **Tone:** Does this match the author's tone descriptors?
 - **Sentence rhythm:** Vary length per the author's style. Short. Then a longer, winding sentence that builds and breathes. Then short again.
-- **Vocabulary:** Use words from the preferred list. NEVER use words from the banned list.
+- **Vocabulary:** Use only words from the preferred list. The banned list is a hard gate — any banned word triggers a rewrite of that sentence.
 - **Dialog:** Each character sounds different. Use subtext. Minimal tags ("said" or action beats).
 - **Sensory details:** All five senses, not just visual. Smell is the most evocative.
 - **Specificity:** "A 1987 Oldsmobile with a cracked windshield" not "an old car."
@@ -273,7 +273,7 @@ If the user is blocked or struggling: redirect to `/storyforge:unblock` instead 
 - Never write a relative time reference ("an hour ago", "ten minutes later") without checking it against the Chapter Timeline. If the math doesn't work, adjust the prose, not the timeline.
 - The Chapter Timeline in README.md is MANDATORY for every chapter. No exceptions. Future chapters depend on it.
 - In full-chapter mode: Write in ONE PASS, then offer revision. Don't second-guess mid-flow.
-- In scene-by-scene mode: Write ONLY the current scene. STOP and WAIT for user feedback. NEVER proceed to the next scene without explicit approval. Each scene applies ALL craft rules (author voice, anti-AI, sensory details) — short scenes are not an excuse for lower quality.
+- In scene-by-scene mode: Write ONLY the current scene. STOP and WAIT for user feedback. **Wait for explicit user approval before writing the next scene** — silence or implicit-OK does not count. Each scene applies ALL craft rules (author voice, anti-AI, sensory details) — short scenes are not an excuse for lower quality.
 - In scene-by-scene mode: Scene text goes **into `draft.md`**, not into chat. The user's inline-review workflow (`` ```textile {review_handle}: ... ``` `` blocks inside the draft) breaks if prose sits in chat. Report only metadata in chat: scene number, word count, one-line summary.
 - **Never trust the file-change system-reminder diff for user review (GH#27).** When the user signals that `{review_handle}:` blocks are ready (keywords: "kommentiert", "gelesen", "Feedback", "lies mal", "schau dir an", or any `{review_handle}:` mention), ALWAYS call the `Read` tool on the full `draft.md` file first. The system-reminder truncates diffs for long files, which has caused comments at the end of the file to be silently dropped. After reading, explicitly count the `{review_handle}:` blocks you see and report the count to the user — if it mismatches their expectation, re-read before proceeding.
 - **One Claude Code session per chapter.** Do not span a chapter across sessions. The chapter-writer's cold-start prerequisite load (author profile, tone doc, canon log, previous chapter, book CLAUDE.md) is designed for a fresh session; scene-by-scene review cycles burn context fast. If auto-compaction fires mid-chapter it can silently drop earlier review decisions. All persistent state is on disk — finish the chapter, close the session, open a new one for the next chapter.
@@ -282,7 +282,7 @@ If the user is blocked or struggling: redirect to `/storyforge:unblock` instead 
 
 ## User Feedback Handling — CRITICAL
 
-**NEVER blindly accept user corrections.** The user may:
+**Always verify user corrections before applying them.** The user may:
 - Misunderstand a passage (especially nuanced English prose)
 - Miss context from an earlier chapter that explains the current text
 - Be wrong about a fact (e.g., thinking a character said X when they said Y)

--- a/skills/character-creator/SKILL.md
+++ b/skills/character-creator/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Develop deep, three-dimensional characters with arcs, voice, and motivation.
   Use when: (1) User says "Charakter", "character", "Figur",
   (2) After plot is outlined, to populate the story.
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<book-slug> [character-name]"
 ---

--- a/skills/character-creator/SKILL.md
+++ b/skills/character-creator/SKILL.md
@@ -11,14 +11,14 @@ argument-hint: "<book-slug> [character-name]"
 
 # Character Creator
 
-## Prerequisites
-- Load book data via MCP `get_book_full()`
-- Load craft references via MCP `get_craft_reference()`:
-  - `character-creation` (GMC, archetypes, wants vs. needs, flaws, motivation chains)
-  - `character-arcs` (positive, negative, flat arcs)
-  - `dialog-craft` (character voice differentiation)
-- Load genre README(s) for genre-specific character expectations
-- Read `{project}/plot/outline.md` and `{project}/plot/arcs.md` for story context
+## Prerequisites — MANDATORY LOADS
+- **Book data** via MCP `get_book_full()`. **Why:** Existing characters, plot, theme — the new character must fit the ensemble and serve the theme.
+- **Craft references** via MCP `get_craft_reference()`:
+  - `character-creation` — **Why:** GMC, archetypes, wants vs. needs, flaws, motivation chains — the depth-test framework Step 5 enforces.
+  - `character-arcs` — **Why:** Positive/negative/flat arc patterns — Step 12 maps the character to one of them.
+  - `dialog-craft` — **Why:** Voice differentiation — Step 11's "cover the name" test depends on the principles in this reference.
+- **Genre README(s)** for genre-specific character expectations. **Why:** Romance protagonists ≠ horror protagonists ≠ literary protagonists — genre dictates expected archetypes and arc patterns.
+- Read `{project}/plot/outline.md` and `{project}/plot/arcs.md` for story context.
 
 ## Workflow
 
@@ -55,7 +55,9 @@ Surface motivations are rarely the true ones. Work with the user to find all thr
 - **Deeper:** Why that actually matters (the emotional engine — ask "why does that matter to them?")
 - **Deepest:** The core wound-driven need (ask "why?" again — this is what the story is really about for this character)
 
-*Don't accept "she wants to prove herself" as the deepest layer. Keep digging: prove herself to whom? Why does that matter? What would happen if she didn't? The deepest layer is usually about survival, love, worth, or meaning.*
+**Always ask "why?" twice.** Surface motivations alone fail the depth test. The third layer connects to survival, love, worth, or meaning — if you stop at layer two, the character reads as a thin archetype. Push the user past "she wants to prove herself": prove herself to whom? Why does that matter? What would happen if she didn't?
+
+**Wait for user confirmation that the deepest layer is the right one before moving to Step 6.** Step 6 (The Ghost) builds directly on this — a wrong layer-three answer cascades.
 
 ### Step 6: The Ghost — The Wound That Made Them
 This is the most important backstory step. Ask the user:
@@ -142,11 +144,11 @@ Update `{project}/characters/INDEX.md` with the new character.
 After all major characters are created, update book status to "Characters Created".
 
 ## Rules
-- NEVER create a "perfect" character — flaws drive stories
-- Antagonists must believe they're RIGHT — no mustache-twirling villains
-- Every character needs their own voice — do the "cover the name" test
-- Backstory informs behavior but is NOT exposition — it lives below the surface
-- Physical appearance should be SPECIFIC ("a scar running through his left eyebrow"), not generic ("tall, dark, handsome")
-- If you can describe the character in one word, they're not deep enough
-- The Ghost must connect to the Lie, which must connect to the Flaw — if the chain breaks, the character psychology is not coherent
-- Contradictions are not inconsistencies — they are the mark of a real human being
+- Build characters with flaws — flaws drive stories. A "perfect" character has no engine.
+- Antagonists must believe they're RIGHT — no mustache-twirling villains.
+- Every character needs their own voice — run the "cover the name" test on Step 11 sample dialogue.
+- Backstory informs behavior. Keep it below the surface — exposition kills mystery.
+- Physical appearance should be SPECIFIC ("a scar running through his left eyebrow"), not generic ("tall, dark, handsome").
+- If you can describe the character in one word, dig further — the character is not deep enough yet.
+- The Ghost must connect to the Lie, which must connect to the Flaw — if the chain breaks, the character psychology is not coherent.
+- Contradictions are not inconsistencies — they are the mark of a real human being.

--- a/skills/cover-artist/SKILL.md
+++ b/skills/cover-artist/SKILL.md
@@ -3,7 +3,7 @@ name: cover-artist
 description: |
   Generate cover art prompts for DALL-E or Midjourney based on genre and story.
   Use when: (1) User says "Cover", "Buchcover", (2) Book needs a cover.
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<book-slug>"
 ---

--- a/skills/create-author/SKILL.md
+++ b/skills/create-author/SKILL.md
@@ -53,7 +53,7 @@ Ask open-ended questions:
 Ask: "Do you have PDFs or text files from authors whose style you want to channel? → `/storyforge:study-author`"
 
 ## Rules
-- EVERY profile must have the "avoid" list pre-populated with AI-tell words from anti-ai-patterns.md
-- Tone descriptors should be SPECIFIC, not generic
-- Influences should be REAL authors the user has actually read
-- The profile is a living document — it evolves as the author writes
+- **MANDATORY:** Every profile must have the "avoid" list pre-populated with AI-tell words from `anti-ai-patterns.md`. **Why:** AI-tell words are the most frequent authenticity-killers — without a per-author banlist, the chapter-writer falls back to generic AI register and the author profile becomes decorative.
+- Tone descriptors should be SPECIFIC, not generic ("sardonic with rural cadence" beats "edgy").
+- Influences should be REAL authors the user has actually read.
+- The profile is a living document — it evolves as the author writes.

--- a/skills/create-author/SKILL.md
+++ b/skills/create-author/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Create a new author profile with writing style, voice, and preferences.
   Use when: (1) User says "Autor anlegen", "create author", "Autorenprofil",
   (2) Before starting a first book project.
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<author-name>"
 ---

--- a/skills/genre-creator/SKILL.md
+++ b/skills/genre-creator/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Create new genre definitions or genre-mix combinations.
   Use when: (1) User says "neues Genre", "genre-mix", "genre creator",
   (2) User needs a genre combination that doesn't exist yet (e.g., "lgbtq-supernatural").
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<genre-name>"
 ---

--- a/skills/manuscript-checker/SKILL.md
+++ b/skills/manuscript-checker/SKILL.md
@@ -11,7 +11,7 @@ description: |
   check", "Wiederholungen prüfen", "prose tics", "Buch prüfen",
   (2) Book status transitions from Drafting to Revision, (3) Full-manuscript
   revision pass, (4) User wants a craft-level health check before export.
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<book-slug> [--interactive]"
 ---

--- a/skills/manuscript-checker/SKILL.md
+++ b/skills/manuscript-checker/SKILL.md
@@ -104,11 +104,10 @@ finding.
 
 ### 4. Present a focused summary
 
-Don't dump the whole report into chat. Instead:
+**Chat summary target: max ~300 Wörter.** The full report is on disk — chat is the headline, not the whole story.
 
 1. State chapters scanned + total findings + high-severity count by category.
-2. Show the top 5 highest-severity findings across *all* categories (book
-   rules first, then clichés, then the rest).
+2. Show the top 5 highest-severity findings across *all* categories (book rules first, then clichés, then the rest).
 3. Tell the user the report path so they can open it.
 4. Offer the next step (see section 5).
 
@@ -191,11 +190,8 @@ Keeps the canon log honest about what was changed during revision.
 
 ## Rules
 
-- Never auto-fix without user confirmation. The detector finds candidates;
-  the human picks the keepers.
-- **Book-rule violations are the user's own rules.** Treat them as
-  authoritative. If the user's prose violates a rule they wrote, that's the
-  most important fix — more important than any generic craft finding.
+- Always wait for user confirmation before applying fixes. The detector finds candidates; the human picks the keepers.
+- **Book-rule violations are the user's own rules.** Treat them as authoritative. If the user's prose violates a rule they wrote, that's the most important fix — more important than any generic craft finding.
 - A repeated phrase isn't always a bug. Some are deliberate motifs
   ("for a hundred and fifty years" might be a thematic refrain). When in
   doubt, ask.

--- a/skills/plot-architect/SKILL.md
+++ b/skills/plot-architect/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Structure the plot with acts, beats, turning points, and character arcs.
   Use when: (1) User says "Plot", "Handlung", "Struktur", "outline",
   (2) After concept is developed, before character creation.
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<book-slug>"
 ---

--- a/skills/plot-architect/SKILL.md
+++ b/skills/plot-architect/SKILL.md
@@ -11,15 +11,15 @@ argument-hint: "<book-slug>"
 
 # Plot Architect
 
-## Prerequisites
-- Load book data via MCP `get_book_full()`
-- Load author profile via MCP `get_author()` if assigned
-- Load genre README(s) via MCP `get_genre()`
-- Load craft references via MCP `get_craft_reference()`:
-  - `story-structure` (structures and when to use them)
-  - `plot-craft` (beats, foreshadowing, cause-effect)
-  - `tension-and-suspense` (stakes, cliffhangers, pacing)
-  - `conflict-types` (escalation, moral dilemmas)
+## Prerequisites — MANDATORY LOADS
+- **Book data** via MCP `get_book_full()`. **Why:** Existing premise, theme, characters, writing-mode — Step 0 branches on `effective_author_writing_mode` and Step 1 builds on existing concept output.
+- **Author profile** via MCP `get_author()` if assigned. **Why:** The author profile may carry structural preferences (e.g. "always uses 5-act tragic arcs") that bias the recommendation in Step 2.
+- **Genre README(s)** via MCP `get_genre()`. **Why:** Genre dictates expected structures (romance = 3-Act + HEA, thriller = Fichtean) and beat conventions.
+- **Craft references** via MCP `get_craft_reference()`:
+  - `story-structure` — **Why:** The structure catalog Step 2 picks from — without it, recommendations default to generic 3-Act.
+  - `plot-craft` — **Why:** Beats, foreshadowing, cause-effect logic — Step 3 (beat mapping) and Step 5 (foreshadowing map) are built on this.
+  - `tension-and-suspense` — **Why:** Stakes, cliffhangers, pacing — what makes the chapter-by-chapter plan in Step 7 actually keep readers turning pages.
+  - `conflict-types` — **Why:** Escalation patterns and moral dilemma structures — Step 4 subplot architecture depends on knowing how conflicts compound.
 
 ## Workflow
 
@@ -40,7 +40,9 @@ Load the book via MCP `get_book_full(slug)` and read `effective_author_writing_m
 - Read `{project}/characters/` if characters exist already
 
 ### Step 2: Choose Structure
-Based on genre and story type, recommend a structure. Use AskUserQuestion:
+Based on genre and story type, recommend a structure. Use AskUserQuestion.
+
+**Wait for the user's structure choice before proceeding to Step 3.** Each downstream step builds on the chosen structure — guessing here cascades.
 - **3-Act** — Most versatile. Best for: thriller, romance, mystery, contemporary.
 - **Hero's Journey** — Quest narratives. Best for: fantasy, sci-fi, adventure.
 - **Save the Cat** — Detailed beats. Best for: commercial fiction, thriller, romance.
@@ -70,6 +72,8 @@ For the chosen structure, work through each beat WITH the user:
 - Approximate chapter position
 
 Write to `{project}/plot/acts.md`.
+
+**Wait for user approval of the beat map before proceeding to Step 4.** Subplot architecture (Step 4) and foreshadowing (Step 5) depend on locked main-plot beats.
 
 ### Step 4: Subplot Architecture
 For each subplot:
@@ -261,8 +265,8 @@ Also create the tonal document (original Step 9 of the standard workflow) at thi
 ---
 
 ## Rules
-- Structure serves story — never force a story into a structure that doesn't fit
-- Every beat must have emotional PURPOSE, not just plot function
-- The "Therefore/But" test: every event must cause the next, not "and then"
-- Midpoint is NOT halfway through the events — it's the REVERSAL that changes everything
-- Foreshadowing map is mandatory — no deus ex machina allowed
+- Structure serves story — pick the structure that fits, not the structure on the bestseller list.
+- Every beat must have emotional PURPOSE, not just plot function.
+- The "Therefore/But" test: every event must cause the next. "And then" sequencing means the plot is just a list.
+- Midpoint is NOT halfway through the events — it's the REVERSAL that changes everything.
+- Foreshadowing map is mandatory — every climax payoff needs a prior plant. Deus ex machina is a craft failure.

--- a/skills/promo-writer/SKILL.md
+++ b/skills/promo-writer/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Create social media promotional content for books across all platforms.
   Use when: (1) User says "Promo", "Social Media", "Marketing", "bewerben",
   (2) Book is near completion or published, (3) User wants teasers, announcements, or campaigns.
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<book-slug> [platform]"
 ---

--- a/skills/promo-writer/SKILL.md
+++ b/skills/promo-writer/SKILL.md
@@ -46,7 +46,7 @@ The book blurb is the single most important marketing text — it must exist bef
 
 **Output:** Save to `{project}/export/blurb.md` using `templates/blurb.md` as scaffold.
 
-**Gate:** Ask the user to approve the blurb before proceeding. If rejected, revise until approved.
+**Gate (HARD):** Blurb approval is a hard gate. Step 2 (Campaign Strategy) requires explicit user sign-off on the blurb. Wait for explicit approval — implicit "looks fine" does not count. If rejected, revise and re-present until the user types approval.
 
 ---
 
@@ -116,11 +116,11 @@ Suggest a posting schedule:
 Write to `{project}/promo/calendar.md`.
 
 ## Rules
-- NEVER spoil the ending or major twists
-- Promo voice should feel AUTHENTIC, not salesy — especially on TikTok/BookTok
-- Each platform gets NATIVE content — don't cross-post identical text
+- Keep endings and major twists out of all promo. Spoilers kill conversion.
+- Promo voice should feel AUTHENTIC, not salesy — especially on TikTok/BookTok.
+- Each platform gets NATIVE content — write per-platform, not cross-post.
 - Emotional hooks > plot summaries. Readers buy FEELINGS, not summaries.
-- Every post needs a clear CTA (call to action) — but make it natural
-- Quote cards must be genuinely compelling lines, not random passages
-- Hashtags: research current trending ones, don't guess
-- For series: emphasize "start here" — make entry point clear
+- Every post needs a clear CTA (call to action) — keep it natural, not pushy.
+- Quote cards must be genuinely compelling lines, not random passages.
+- Hashtags: research current trending ones — guessed hashtags read as inauthentic.
+- For series: emphasize "start here" — make the entry point unambiguous.

--- a/skills/researcher/SKILL.md
+++ b/skills/researcher/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Research topics for story authenticity via web search.
   Use when: (1) User says "Recherche", "research", "find out about",
   (2) Story requires factual accuracy (historical periods, locations, professions, etc.).
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<topic> [book-slug]"
 ---

--- a/skills/sensitivity-reader/SKILL.md
+++ b/skills/sensitivity-reader/SKILL.md
@@ -11,10 +11,10 @@ argument-hint: "<book-slug> [chapter-slug]"
 
 # Sensitivity Reader
 
-## Prerequisites
-- Load `lgbtq-craft` reference if LGBTQ+ characters present
-- Read relevant chapter drafts or full book
-- Load character files for representation context
+## Prerequisites — MANDATORY LOADS
+- **`lgbtq-craft` reference** via MCP `get_craft_reference()` if LGBTQ+ characters are present. **Why:** Identity-representation evaluation framework — distinguishes authentic representation from token/trope patterns. Without it, the LGBTQ+ section of the report is generic.
+- **Relevant chapter drafts or full book.** **Why:** Sensitivity findings must be grounded in specific passages with line references — abstract concerns are not actionable.
+- **Character files** via MCP. **Why:** Representation context — knowing whether a character is positioned as protagonist/love-interest/sidekick/antagonist changes how tropes register (e.g. "Bury Your Gays" only triggers on actual queer characters with on-page death).
 
 ## Check Categories
 
@@ -46,10 +46,13 @@ argument-hint: "<book-slug> [chapter-slug]"
 - Are toxic dynamics romanticized or examined?
 
 ## Output
+
+**Report target: max ~800 Wörter total. 3-5 Bullets pro Kategorie als Cap.** If a category has zero findings, state it in one line and move on. Severity stratification is the signal.
+
 Report findings as: CONCERN (discuss) / FLAG (reconsider) / ISSUE (revise).
-Always suggest alternatives, not just problems.
+Always pair every finding with a concrete alternative — "this is problematic" without an alternative is not actionable.
 
 ## Rules
 - This is advisory, not censorship. The author makes the final call.
-- Sensitivity ≠ sanitizing. Dark themes are valid if handled with care.
-- Flag genuine concerns, don't overcorrect.
+- Sensitivity ≠ sanitizing. Dark themes are valid when handled with care.
+- Flag genuine concerns; calibrate severity rather than overcorrecting on every edge case.

--- a/skills/sensitivity-reader/SKILL.md
+++ b/skills/sensitivity-reader/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Check for problematic representations, stereotypes, and harmful tropes.
   Use when: (1) User says "sensitivity", "problematisch?",
   (2) Story involves marginalized groups, trauma, or controversial themes.
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<book-slug> [chapter-slug]"
 ---

--- a/skills/series-planner/SKILL.md
+++ b/skills/series-planner/SKILL.md
@@ -24,6 +24,8 @@ Ask the user:
   - **Duology/Trilogy:** Tight arc across 2-3 books
   - **Episodic:** Same characters, standalone plots per book (mystery series)
 
+**Wait for user input on all four points before proceeding to Step 2.** Series type changes everything downstream — guessing here forces a rewrite at Step 3.
+
 ### Step 2: Create Series
 Use MCP `create_series()` with collected info.
 
@@ -36,6 +38,8 @@ For sequential/trilogy series — plan the OVERARCHING arc:
 
 Write to `{series}/series-arc.md`.
 
+**Wait for user approval of the series arc before proceeding to Step 4.** Per-book planning depends on a locked overarching arc.
+
 ### Step 4: Book Planning
 For each planned book:
 - Working title
@@ -43,6 +47,8 @@ For each planned book:
 - Where it sits in the overarching arc
 - New characters introduced
 - Plot threads carried from previous books
+
+**Wait for user approval of the book plan before proceeding to Step 5 (Canon Management).** Canon facts are derived from book plans — building canon before plans exist creates orphan facts.
 
 ### Step 5: Canon Management
 Set up `{series}/world/canon.md`:
@@ -59,7 +65,7 @@ Set up `{series}/characters/`:
 As books are created, link them via MCP `add_book_to_series()`.
 
 ## Rules
-- Canon.md is sacred — once established, it's permanent
-- Each book must work as a standalone reading experience (even in a trilogy)
-- Series-level foreshadowing needs a PLANT & PAYOFF map across books
-- Track what each character KNOWS at each point in the series — avoid info inconsistencies
+- Canon.md is sacred — once established, treat it as permanent. Changes require a series-level revision pass.
+- Each book must work as a standalone reading experience (even in a trilogy).
+- Series-level foreshadowing needs a PLANT & PAYOFF map across books.
+- Track what each character KNOWS at each point in the series — info inconsistencies are the most common series-level failure.

--- a/skills/series-planner/SKILL.md
+++ b/skills/series-planner/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Plan a book series: overarching arc, book connections, canon management.
   Use when: (1) User says "Serie planen", "series", "book series",
   (2) User wants to write multiple connected books.
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<series-name>"
 ---

--- a/skills/study-author/SKILL.md
+++ b/skills/study-author/SKILL.md
@@ -56,6 +56,13 @@ Analyze the text for these concrete patterns:
 - Adverb frequency
 - Filter word frequency ("she saw", "he felt")
 
+### Phase 2.5: Pre-Phase-3 Gate
+
+Before writing analysis to disk, ask: **"Has this author profile already had an initial profile generated via `/storyforge:create-author`? (Yes/No)"**
+
+- **If No:** Stop here. Direct the user to `/storyforge:create-author` first. Style-extraction is meant to *refine* an existing profile, not to bootstrap one — bootstrapping from a single studied work risks copying that author's signature too closely. Wait for explicit confirmation that the base profile exists before continuing.
+- **If Yes:** Proceed to Phase 3.
+
 ### Phase 3: Write Analysis
 Save analysis as `~/.storyforge/authors/{slug}/studied-works/analysis-{title}.md`
 
@@ -98,7 +105,6 @@ Update the author's `profile.md` and `vocabulary.md` based on findings:
 Show the user a summary of what was learned and what changed in the profile.
 
 ## Rules
-- NEVER copy verbatim text from studied works into the profile
-- Extract PATTERNS, not content
-- Multiple studied works refine the profile further — don't overwrite, merge
-- Flag any conflicts between studied works (e.g., one book uses first person, another uses third)
+- Extract PATTERNS only — verbatim text from studied works belongs nowhere in the profile. Verbatim copy is plagiarism risk and AI-tell.
+- Multiple studied works refine the profile further — merge, don't overwrite. Each studied work is evidence; the profile is the synthesis.
+- Flag any conflicts between studied works (e.g., one book uses first person, another uses third) — surface to the user before merging.

--- a/skills/study-author/SKILL.md
+++ b/skills/study-author/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Analyze PDFs or text files to extract writing style and update an author profile.
   Use when: (1) User says "Buch studieren", "study this PDF", "Stil analysieren",
   (2) User wants to feed reference material to an author profile.
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<file-path> [author-slug]"
 ---

--- a/skills/translator/SKILL.md
+++ b/skills/translator/SKILL.md
@@ -29,6 +29,9 @@ Before translating any chapter, build a glossary:
 Ask the user for preferences on names/terms.
 
 ### Step 3: Chapter-by-Chapter Translation
+
+**Sequencing gate: Translate one chapter, update the glossary, then wait for user review before starting the next chapter.** Batch-translation produces glossary drift and silent voice errors that compound — by the time the user reads chapter 5, chapters 1-4 have already accumulated mistranslated terms.
+
 For each chapter:
 1. Read the original draft
 2. Translate maintaining:
@@ -39,6 +42,7 @@ For each chapter:
    - Sensory details (find equivalent sensory language in target culture)
 3. Save to `{project}/translations/{lang}/chapters/{chapter-slug}.md`
 4. Update glossary with any new terms encountered
+5. **Wait for user review of this chapter and any glossary updates before starting the next chapter.**
 
 ### Step 4: Review
 After all chapters:
@@ -47,8 +51,8 @@ After all chapters:
 - Offer to export translated version via `/storyforge:export-engineer`
 
 ## Rules
-- Translation is NOT word-for-word — it's VOICE-for-voice
-- Maintain the author's rhythm and style in the target language
-- Cultural adaptation > literal accuracy
-- The glossary is the single source of truth for term consistency
-- Translate chapter by chapter, not the entire book at once (quality control)
+- Translation is voice-for-voice, not word-for-word.
+- Maintain the author's rhythm and style in the target language.
+- Cultural adaptation > literal accuracy.
+- The glossary is the single source of truth for term consistency.
+- Translate chapter by chapter, with user review between chapters. Batch translation skips quality control and accumulates glossary drift.

--- a/skills/translator/SKILL.md
+++ b/skills/translator/SKILL.md
@@ -3,7 +3,7 @@ name: translator
 description: |
   Translate a book chapter by chapter into another language.
   Use when: (1) User says "Übersetzen", "translate", (2) Book is complete or near-complete.
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<book-slug> <target-language>"
 ---

--- a/skills/unblock/SKILL.md
+++ b/skills/unblock/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Diagnose and resolve writer's block with targeted, book-context-aware interventions.
   Use when: User says "I'm stuck", "Ich komme nicht weiter", "blocked", "can't write",
   "keine Motivation", "keine Lust", "Schreibblockade", or similar signals of creative resistance.
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 ---
 

--- a/skills/unblock/SKILL.md
+++ b/skills/unblock/SKILL.md
@@ -11,7 +11,7 @@ user-invocable: true
 # Unblock
 
 Writer's block is not one thing. It has 4 distinct root causes, each requiring a different fix.
-Diagnose first. Intervene precisely. Never give generic "just write!" advice.
+**Identify the root cause first. Provide intervention only after diagnosis is complete.** Generic "just write!" advice fails — it skips the diagnostic step.
 
 ## Workflow
 
@@ -71,7 +71,7 @@ Each cause gets a specific, actionable response. No overlap, no hedging.
 **Reframe:** Perfectionism is drafting mode and editing mode running simultaneously. They are incompatible. You cannot drive forward while constantly braking.
 
 **The two-mode rule:**
-- **Draft mode:** Write forward. No deleting. No rereading. Ugly sentences are allowed. Ugly sentences are expected. A bad sentence that exists is infinitely better than a perfect sentence that doesn't.
+- **Draft mode:** Write forward. Skip deleting and rereading. Ugly sentences are allowed. Ugly sentences are expected. A bad sentence that exists is infinitely better than a perfect sentence that doesn't.
 - **Edit mode:** Separate session. Cold read. After the full draft is done.
 
 **Intervention:**
@@ -150,7 +150,7 @@ Use AskUserQuestion:
 
 ## Notes
 
-- Never lecture. Keep interventions direct, specific, and warm.
-- Never suggest "just push through it" without a concrete technique.
+- Keep interventions direct, specific, and warm. Lecturing breaks trust and reinforces the block.
+- Pair every "push through" suggestion with a concrete technique — bare exhortation is generic AI advice.
 - Always use real book context for the warmup — generic prompts break trust.
 - If the user's block is ongoing (they mention it's been weeks), suggest `/storyforge:next-step` first — sometimes the block is caused by an unclear path, not psychology.

--- a/skills/voice-checker/SKILL.md
+++ b/skills/voice-checker/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Check if written text sounds AI-generated. Compare against author profile for authenticity.
   Use when: (1) User says "voice check", "klingt das nach AI?",
   (2) After drafting, as a final authenticity gate.
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<book-slug> [chapter-slug]"
 ---

--- a/skills/voice-checker/SKILL.md
+++ b/skills/voice-checker/SKILL.md
@@ -11,12 +11,14 @@ argument-hint: "<book-slug> [chapter-slug]"
 
 # Voice Checker — Anti-AI Authenticity Gate
 
-## Prerequisites
-- Load `anti-ai-patterns` reference via MCP `get_craft_reference()`
-- Load `prose-style` and `dos-and-donts` references
-- Load author profile via MCP `get_author()`
-- Load author vocabulary from `~/.storyforge/authors/{slug}/vocabulary.md`
-- Read the text to check (chapter draft or entire book)
+## Prerequisites — MANDATORY LOADS
+
+- **`anti-ai-patterns` reference** via MCP `get_craft_reference()`. **Why:** The flag-list — provides the catalog of AI-tells (vocabulary, structures, emotional patterns) the scan grades against. Without it, "AI-like" is a vibe, not a metric.
+- **`prose-style` reference** via MCP. **Why:** Defines what good sentence-level craft looks like — the positive counterpart to the anti-pattern list, used for scoring specificity and rhythm.
+- **`dos-and-donts` reference** via MCP. **Why:** The craft-rule baseline — many "AI-tells" are also general bad-craft tells; this reference distinguishes "AI-bad" from "fiction-bad."
+- **Author profile** via MCP `get_author()`. **Why:** "AI-like" is relative to the author's documented voice — a sparse-prose author and a maximalist author cannot be graded by the same baseline.
+- **Author vocabulary** from `~/.storyforge/authors/{slug}/vocabulary.md`. **Why:** Preferred/banned word list — the per-author enforcement layer that overrides the generic AI-tell list when in conflict.
+- Read the text to check (chapter draft or entire book).
 
 ## Analysis — 7 Dimensions
 
@@ -86,24 +88,24 @@ Compare against the defined author profile:
 | Author Match | X/100 | [Strong / Partial / Weak] |
 
 ### Flagged Words
-[List with line numbers]
+[List with line numbers — max ~150 words, group by category if many]
 
 ### Most AI-Like Passages
-[Quote 3-5 passages that read most "AI" with explanations]
+[Quote 3-5 passages that read most "AI" with explanations — max ~150 words per passage incl. explanation]
 
 ### Most Human-Like Passages
-[Quote 3-5 passages that feel most authentic]
+[Quote 3-5 passages that feel most authentic — max ~100 words per passage]
 
 ### Recommendations
-[Specific rewrites for the worst offenders]
+[Specific rewrites for the worst offenders — max 5 entries, before/after pairs]
 
 ### Verdict
 [AUTHENTIC / NEEDS WORK / REWRITE RECOMMENDED]
 ```
 
 ## Rules
-- This is the FINAL quality gate before a chapter is marked "Polished"
-- A score below 70 means revision is needed
-- Below 50 means significant rewriting
-- The vocabulary scan is non-negotiable — zero AI-tell words in final text
-- Be specific with line numbers and quotes — don't just say "it sounds AI"
+- Run this as the gate before marking a chapter "Polished" — voice-check is the last thing between draft and shipped prose.
+- A score below 70 means revision is needed.
+- Below 50 means significant rewriting.
+- Run the vocabulary scan as a hard gate before proceeding. If AI-tell words are found, STOP and request a rewrite of the affected sentences before re-scoring.
+- Be specific with line numbers and quotes — generic "it sounds AI" is not actionable; quote the offending text.

--- a/skills/world-builder/SKILL.md
+++ b/skills/world-builder/SKILL.md
@@ -11,11 +11,15 @@ argument-hint: "<book-slug>"
 
 # World Builder
 
-## Prerequisites
-- Load book data via MCP `get_book_full()`
-- Load craft reference `world-building` via MCP `get_craft_reference()`
-- Load genre README(s) — world-building depth varies by genre
-- Read existing world files: `{project}/world/`
+## Iceberg Principle (Core Operating Mode)
+
+**Show ~10% of the world in-story. Keep the other 90% in `{project}/world/` for consistency checks.** The world files are the author's reference, not the reader's experience. Avoid info-dumps in prose — exposition disguised as world-building is the most common AI-tell in fantasy/sci-fi drafts. Every world fact you generate here either pays off in conflict, character, or atmosphere — or it stays below the surface as continuity ballast.
+
+## Prerequisites — MANDATORY LOADS
+- **Book data** via MCP `get_book_full()`. **Why:** Genre, premise, characters — world-building must serve the story, not exist in parallel to it.
+- **`world-building` craft reference** via MCP `get_craft_reference()`. **Why:** Sanderson's Laws, iceberg principle, conflict-driven culture — the framework Steps 3-5 apply.
+- **Genre README(s)**. **Why:** Fantasy needs full world rules, contemporary needs almost none — depth scales with genre.
+- Read existing world files: `{project}/world/`.
 
 ## When World-Building Matters
 - **Essential:** Fantasy, Sci-Fi, Supernatural, Historical, Dark Fantasy
@@ -73,8 +77,10 @@ For `{project}/world/setting.md`:
 For `{project}/world/history.md`:
 - Key events that shaped the current world
 - Wars, revolutions, discoveries, disasters
-- ONLY what's relevant to the story — resist the urge to write an encyclopedia
+- Include only what's relevant to the story. Encyclopedia mode produces dead world-building.
 - How the past explains present tensions
+
+Target: ~500-1000 Wörter total für die History-Sektion, als Richtwert. Wenn die Story eine 5000-jährige Imperien-Geschichte braucht, darf es mehr werden — aber dann mit klarer Verbindung zu Plot-Konflikten.
 
 ### Step 6: Glossary
 For `{project}/world/glossary.md`:
@@ -93,8 +99,8 @@ Create a consistency checklist in `{project}/world/rules.md`:
 Update book status to "World Built" via MCP `update_field()`.
 
 ## Rules
-- ICEBERG PRINCIPLE: Know 100%, show 10%. The reader discovers; the author doesn't lecture.
-- World-building through STORY, not through exposition chapters
-- Every rule you create is a promise — you must keep it
+- ICEBERG PRINCIPLE: Know 100%, show ~10% in-story. The reader discovers through scene; the author keeps the rest as reference.
+- World-building lands through STORY — character action, dialogue, sensory detail. Exposition chapters break the spell.
+- Every rule you create is a promise — keep it. Magic systems that bend mid-book signal authorial cheating.
 - Consistency > realism. A consistent fantasy world feels more real than an inconsistent realistic one.
-- If you can't explain how a cultural element creates conflict, cut it
+- If you can't explain how a cultural element creates conflict, cut it from the story (keep it in setting.md only if it's load-bearing for continuity).

--- a/skills/world-builder/SKILL.md
+++ b/skills/world-builder/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Build settings, magic systems, societies, and history for the story world.
   Use when: (1) User says "Welt", "world", "Setting", "Magic System",
   (2) For fantasy, sci-fi, supernatural, or historical genres.
-model: claude-opus-4-6
+model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<book-slug>"
 ---


### PR DESCRIPTION
## Summary

- Migrates 20 Skills von `claude-opus-4-6` auf `claude-opus-4-7` (Frontmatter-Bump)
- Hardened 16 Skills für 4.7 Default-Shifts (Verbosity, Negative→Positive Voice, Tool-Use Why-Begründungen, Multi-Turn-Gates)
- 4 Skills behalten ihr Frontmatter ohne Body-Änderung (brainstorm, cover-artist, genre-creator + die Sonnet/Haiku-Skills)

Closes #50

## Approach (deviates from issue plan)

Statt des im Issue vorgeschlagenen prophylaktischen Acceptance-Plans wurde **evidence-driven** vorgegangen:

1. **Frontmatter-Bump** (commit `6b42789`) — 20 Skills via `/mm-dev-toolkit:skill-model-updater update`
2. **Statische 4.7-Diagnostik** der 20 Skills mit Subagent-Klassifikation (Critical / Risk / OK)
3. **Re-Diagnostik der OK-7** mit schärferen Heuristiken — fand 4 weitere Risk-Skills + 1 neues Critical (voice-checker)
4. **Body-Hardening** (commit `6181a5f`) — 16 Skills, 44 Edits

## Klassifikation

**🔴 Critical (6):** chapter-writer, voice-checker, book-conceptualizer, character-creator, unblock, beta-feedback
**⚠️ Risk (10):** plot-architect, chapter-reviewer, manuscript-checker, promo-writer, translator, series-planner, world-builder, create-author, study-author, sensitivity-reader
**✅ OK (3):** brainstorm, cover-artist, genre-creator

## Hardening-Patterns

- **Verbosity:** Length-Targets als Soft-Guidelines (z.B. `~900 Wörter, je nach Szenen-Bedarf`)
- **Negative→Positive Voice:** Top-3 critical Patterns pro Skill umformuliert (`NEVER X` → `Do Y. X breaks Z.`)
- **Tool-Use:** `**Why:**` Justifications für MANDATORY Loads in 7 Skills (chapter-writer, voice-checker, book-conceptualizer, character-creator, plot-architect, chapter-reviewer, sensitivity-reader, world-builder)
- **Multi-Turn-Gates:** Explizite Wait-Statements zwischen Wizard-Phasen (book-conceptualizer, character-creator, beta-feedback, plot-architect, series-planner)

## Memory-Compliance

- *Word-Count-Targets sind Richtlinien*: alle Targets als Soft-Guideline
- *Scene-by-scene preferred*: ~900W/Szene erhalten
- *Challenge Corrections*: User-Verifikation-Logik proaktiv formuliert (chapter-writer Rule)

## Test plan

- [x] Frontmatter-Verifikation: `grep -rln "claude-opus-4-6" skills/` → 0 Treffer
- [x] Test-Baseline: 269/269 pytest passing nach jedem Commit
- [ ] **Manueller Smoke-Test (User):** chapter-writer scene write, voice-checker auf 4.6-Kapitel, book-conceptualizer Phase-Loop, manuscript-checker Report-Länge
- [ ] **Latenz/Qualität-Eindruck (Max-Plan):** Beim ersten Kapitel-Schreiben subjektiv prüfen — Voice-Match, Längen-Treffer, Tool-Use vollständig, gefühlte Latenz. (Token-Cost-Hinweis aus Issue #50 trifft nur API-User; bei Max-Plan irrelevant.)

## Out of Scope (gem. Issue)

- Sonnet/Haiku-Migration (separate Aufgabe falls nötig)
- CLAUDE.md-Hardening (4 NEVER-Patterns in Rules — könnte separater Issue werden)
- Performance-Benchmarking
