### PR TITLE
feat(hooks): wire validate_chapter as PostToolUse with hard-block exit code

### DIFF
--- a/.claude-plugin/hooks.json
+++ b/.claude-plugin/hooks.json
@@ -9,6 +9,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${HOME}/.storyforge/venv/bin/python3 ${CLAUDE_PLUGIN_ROOT}/hooks/validate_chapter.py"
+          }
+        ]
+      }
     ]
   }
 }

--- a/hooks/validate_chapter.py
+++ b/hooks/validate_chapter.py
@@ -1,17 +1,52 @@
 #!/usr/bin/env python3
-"""PostToolUse hook: Validate chapter files after Write/Edit operations.
+"""PostToolUse hook: validate chapter ``draft.md`` after Write/Edit/MultiEdit.
 
-Checks that chapter drafts don't contain AI-tell vocabulary and have proper structure.
-Runs automatically after any file write/edit that matches chapter file patterns.
+Reads the Claude Code hook JSON payload from stdin, locates the affected
+file, and runs StoryForge's prose-quality checks. Findings carry a
+severity (``block`` or ``warn``); when any ``block`` finding is produced
+in ``strict`` mode the hook exits with code 2, which Claude Code surfaces
+as a tool-call rejection and feeds back into the model.
+
+The hook only reacts to writes against ``**/chapters/*/draft.md``. All
+other file events are passed through silently.
 """
 
+from __future__ import annotations
+
+import json
 import os
 import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
-# AI-tell words that must NEVER appear in fiction prose
-AI_TELL_WORDS = [
+PLUGIN_ROOT = Path(
+    os.environ.get("CLAUDE_PLUGIN_ROOT", str(Path(__file__).resolve().parent.parent))
+)
+
+# Make tools package importable when the hook runs standalone (and from
+# pytest, where conftest.py also extends sys.path).
+if str(PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Severity vocabulary
+# ---------------------------------------------------------------------------
+
+SEVERITY_BLOCK = "block"
+SEVERITY_WARN = "warn"
+
+VALID_MODES = ("strict", "warn")
+DEFAULT_MODE = "strict"
+
+# Tools whose output should be inspected. Anything else is ignored.
+WATCHED_TOOLS = frozenset({"Write", "Edit", "MultiEdit"})
+
+# AI-tell words that mark generic LLM prose. Currently warn-only — promotion
+# to block-severity is handled per-book via the CLAUDE.md banlist (see #74).
+AI_TELL_WORDS: tuple[str, ...] = (
     "delve", "tapestry", "nuanced", "vibrant", "embark", "resonate",
     "pivotal", "multifaceted", "realm", "testament", "intricate",
     "myriad", "unprecedented", "foster", "beacon", "juxtaposition",
@@ -21,84 +56,316 @@ AI_TELL_WORDS = [
     "robust", "streamline", "cutting-edge", "utilize", "facilitate",
     "endeavor", "comprehensive", "furthermore", "moreover",
     "bustling", "piercing", "riveting", "captivating", "mesmerizing",
-]
+)
 
 
-def validate_chapter(file_path: str) -> list[str]:
-    """Validate a chapter draft file and return list of issues."""
+@dataclass(frozen=True)
+class Finding:
+    severity: str
+    category: str
+    message: str
+    line: int | None = None
+
+
+# ---------------------------------------------------------------------------
+# Hook payload parsing
+# ---------------------------------------------------------------------------
+
+
+def _read_payload() -> dict[str, Any] | None:
+    """Read the hook JSON payload from stdin. Returns None if stdin is empty
+    or not valid JSON (legacy invocation path)."""
+    if sys.stdin.isatty():
+        return None
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _extract_file_path(payload: dict[str, Any]) -> str | None:
+    """Find the file path in the hook payload. Tries tool_input first, then
+    tool_response — schema differs between Write/Edit/MultiEdit."""
+    tool_input = payload.get("tool_input") or {}
+    if isinstance(tool_input, dict):
+        fp = tool_input.get("file_path")
+        if isinstance(fp, str) and fp:
+            return fp
+    tool_response = payload.get("tool_response") or {}
+    if isinstance(tool_response, dict):
+        for key in ("filePath", "file_path"):
+            fp = tool_response.get(key)
+            if isinstance(fp, str) and fp:
+                return fp
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Mode resolution (strict vs warn)
+# ---------------------------------------------------------------------------
+
+
+def _find_book_root(file_path: Path) -> Path | None:
+    """Walk up from a chapter draft.md to find the book root (the directory
+    that contains both ``chapters/`` and ``README.md``)."""
+    for parent in file_path.parents:
+        if (parent / "chapters").is_dir() and (parent / "README.md").is_file():
+            return parent
+    return None
+
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(?P<body>.*?)\n---\s*\n", re.DOTALL)
+_LINTER_MODE_RE = re.compile(
+    r"^\s*linter_mode\s*:\s*[\"']?(?P<value>strict|warn)[\"']?\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _resolve_mode(file_path: Path) -> str:
+    """Resolve linter mode for the given draft path.
+
+    Default is ``strict``. Books opt into ``warn`` by setting
+    ``linter_mode: warn`` in their CLAUDE.md frontmatter.
+    """
+    book_root = _find_book_root(file_path)
+    if book_root is None:
+        return DEFAULT_MODE
+    claudemd = book_root / "CLAUDE.md"
+    if not claudemd.is_file():
+        return DEFAULT_MODE
+    try:
+        text = claudemd.read_text(encoding="utf-8")
+    except OSError:
+        return DEFAULT_MODE
+    fm = _FRONTMATTER_RE.match(text)
+    if not fm:
+        return DEFAULT_MODE
+    m = _LINTER_MODE_RE.search(fm.group("body"))
+    if not m:
+        return DEFAULT_MODE
+    value = m.group("value").lower()
+    return value if value in VALID_MODES else DEFAULT_MODE
+
+
+# ---------------------------------------------------------------------------
+# Banned-phrase scan (book CLAUDE.md ## Rules)
+# ---------------------------------------------------------------------------
+
+
+def _book_banned_patterns(book_root: Path) -> list[tuple[str, re.Pattern[str]]]:
+    """Return ``(label, compiled_regex)`` patterns from the book's CLAUDE.md.
+
+    Reuses the rule-parsing logic from ``tools.analysis.manuscript_checker``
+    so the hook and the post-draft scanner agree on what counts as a
+    bannable pattern. Failure to import the helper degrades gracefully:
+    the hook still runs the AI-tell scan.
+    """
+    try:
+        from tools.analysis.manuscript_checker import (
+            _extract_patterns_from_rule,
+            _read_book_rules,
+        )
+    except Exception:
+        return []
+
+    rules = _read_book_rules(book_root)
+    patterns: list[tuple[str, re.Pattern[str]]] = []
+    seen: set[str] = set()
+    for rule in rules:
+        for label, compiled in _extract_patterns_from_rule(rule):
+            key = compiled.pattern.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            patterns.append((label, compiled))
+    return patterns
+
+
+def _line_for_offset(text: str, offset: int) -> int:
+    return text[:offset].count("\n") + 1
+
+
+# ---------------------------------------------------------------------------
+# Validators
+# ---------------------------------------------------------------------------
+
+
+def _scan_ai_tells(text: str) -> list[Finding]:
+    findings: list[Finding] = []
+    text_lower = text.lower()
+    for word in AI_TELL_WORDS:
+        pattern = rf"\b{re.escape(word)}\b"
+        matches = list(re.finditer(pattern, text_lower))
+        if not matches:
+            continue
+        line_num = _line_for_offset(text, matches[0].start())
+        suffix = "s" if len(matches) > 1 else ""
+        findings.append(
+            Finding(
+                severity=SEVERITY_WARN,
+                category="ai_tell",
+                message=(
+                    f"AI-tell word '{word}' found ({len(matches)} occurrence{suffix})"
+                ),
+                line=line_num,
+            )
+        )
+    return findings
+
+
+def _scan_sentence_variance(text: str) -> list[Finding]:
+    prose = re.sub(r"^---\s*\n.*?\n---\s*\n", "", text, flags=re.DOTALL)
+    prose = re.sub(r"^#+\s+.*$", "", prose, flags=re.MULTILINE)
+    sentences = [s for s in re.split(r"(?<=[.!?])\s+", prose.strip()) if s.split()]
+    if len(sentences) <= 10:
+        return []
+    lengths = [len(s.split()) for s in sentences]
+    mean = sum(lengths) / len(lengths)
+    variance = sum((n - mean) ** 2 for n in lengths) / len(lengths)
+    std_dev = variance**0.5
+    if std_dev >= 4:
+        return []
+    return [
+        Finding(
+            severity=SEVERITY_WARN,
+            category="variance",
+            message=(
+                f"Low sentence length variance (std_dev={std_dev:.1f}) — "
+                "text may sound AI-generated. Vary sentence lengths more."
+            ),
+        )
+    ]
+
+
+def _scan_book_banlist(text: str, book_root: Path) -> list[Finding]:
+    """Scan prose against the book's CLAUDE.md banned-phrase patterns."""
+    findings: list[Finding] = []
+    for label, compiled in _book_banned_patterns(book_root):
+        match = compiled.search(text)
+        if not match:
+            continue
+        line_num = _line_for_offset(text, match.start())
+        findings.append(
+            Finding(
+                severity=SEVERITY_BLOCK,
+                category="book_rule_violation",
+                message=f"Banned phrase from book CLAUDE.md: '{label}'",
+                line=line_num,
+            )
+        )
+    return findings
+
+
+def validate_chapter(file_path: str) -> list[Finding]:
+    """Validate a chapter draft and return findings.
+
+    Returns an empty list when the file is not a chapter draft, is too
+    short to evaluate, or does not exist.
+    """
     path = Path(file_path)
-    issues: list[str] = []
-
     if not path.exists():
         return []
-
-    # Only validate draft.md files in chapters/ directories
     if "/chapters/" not in str(path):
         return []
-
-    # Only check draft.md files (not README.md outlines)
     if path.name != "draft.md":
         return []
 
     text = path.read_text(encoding="utf-8")
-
-    # Skip near-empty drafts (just a header)
     if len(text.split()) < 50:
         return []
 
-    # Scan for AI-tell words
-    text_lower = text.lower()
-    for word in AI_TELL_WORDS:
-        pattern = rf'\b{re.escape(word)}\b'
-        matches = list(re.finditer(pattern, text_lower))
-        if matches:
-            # Find line number for first occurrence
-            line_num = text[:matches[0].start()].count('\n') + 1
-            issues.append(
-                f"WARN: AI-tell word '{word}' found in {path.name} "
-                f"(line {line_num}, {len(matches)} occurrence{'s' if len(matches) > 1 else ''})"
+    findings: list[Finding] = []
+    book_root = _find_book_root(path)
+    if book_root is not None:
+        findings.extend(_scan_book_banlist(text, book_root))
+    findings.extend(_scan_ai_tells(text))
+    findings.extend(_scan_sentence_variance(text))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def _format_finding(finding: Finding, path: Path) -> str:
+    location = f" line {finding.line}" if finding.line else ""
+    return f"[{finding.severity.upper()}] {path.name}{location}: {finding.message}"
+
+
+def _emit_block_report(
+    path: Path,
+    blocking: list[Finding],
+    warnings: list[Finding],
+    stream: Any,
+) -> None:
+    print("StoryForge linter blocked this write:", file=stream)
+    for finding in blocking:
+        print(f"  {_format_finding(finding, path)}", file=stream)
+    if warnings:
+        suffix = "s" if len(warnings) != 1 else ""
+        print(
+            f"Plus {len(warnings)} non-blocking warning{suffix}:",
+            file=stream,
+        )
+        for finding in warnings[:5]:
+            print(f"  {_format_finding(finding, path)}", file=stream)
+    print(
+        "Fix the blocking issues and try again. "
+        "Set `linter_mode: warn` in the book's CLAUDE.md frontmatter to override.",
+        file=stream,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    """Hook entry point. Returns 0 (continue), or 2 (block + feed stderr to model)."""
+    payload = _read_payload()
+
+    file_path: str = ""
+    if payload is not None:
+        tool_name = payload.get("tool_name")
+        if isinstance(tool_name, str) and tool_name not in WATCHED_TOOLS:
+            return 0
+        file_path = _extract_file_path(payload) or ""
+    else:
+        # Legacy fallback: positional argv (used by older invocations / tests).
+        if len(sys.argv) > 1:
+            file_path = sys.argv[1]
+        else:
+            file_path = os.environ.get("CLAUDE_FILE_PATH", "") or os.environ.get(
+                "CLAUDE_TOOL_ARG_FILE_PATH", ""
             )
 
-    # Check sentence length variance (AI detection metric)
-    # Remove markdown headers and frontmatter
-    prose = re.sub(r"^---\s*\n.*?\n---\s*\n", "", text, flags=re.DOTALL)
-    prose = re.sub(r"^#+\s+.*$", "", prose, flags=re.MULTILINE)
-    sentences = re.split(r'(?<=[.!?])\s+', prose.strip())
-    sentences = [s for s in sentences if len(s.split()) > 0]
-
-    if len(sentences) > 10:
-        lengths = [len(s.split()) for s in sentences]
-        mean = sum(lengths) / len(lengths)
-        variance = sum((n - mean) ** 2 for n in lengths) / len(lengths)
-        std_dev = variance ** 0.5
-
-        if std_dev < 4:
-            issues.append(
-                f"WARN: Low sentence length variance (std_dev={std_dev:.1f}) — "
-                f"text may sound AI-generated. Vary sentence lengths more."
-            )
-
-    return issues
-
-
-def main() -> None:
-    """Entry point for PostToolUse hook."""
-    # Get the file that was just written/edited
-    file_path = os.environ.get("CLAUDE_TOOL_ARG_FILE_PATH", "")
     if not file_path:
-        # Try new_string path for Edit tool
-        file_path = os.environ.get("CLAUDE_FILE_PATH", "")
-    if not file_path:
-        sys.exit(0)
+        return 0
 
-    issues = validate_chapter(file_path)
+    findings = validate_chapter(file_path)
+    if not findings:
+        return 0
 
-    if issues:
-        # Output issues as hook feedback
-        print("\n".join(issues))
-        # Don't block — these are warnings, not errors
-        sys.exit(0)
+    path = Path(file_path)
+    mode = _resolve_mode(path)
+    blocking = [f for f in findings if f.severity == SEVERITY_BLOCK]
+    warnings = [f for f in findings if f.severity == SEVERITY_WARN]
+
+    if blocking and mode == "strict":
+        _emit_block_report(path, blocking, warnings, sys.stderr)
+        return 2
+
+    # Warn mode, or no blocking findings: emit non-blocking diagnostics on stdout.
+    for finding in findings[:10]:
+        print(_format_finding(finding, path))
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,65 +1,360 @@
 """Tests for StoryForge PostToolUse hooks."""
 
-from hooks.validate_chapter import validate_chapter
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from hooks import validate_chapter as vc
 from hooks.validate_character import validate_character
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_book(tmp_path: Path, claudemd_body: str | None = None) -> Path:
+    """Create a minimal book scaffold and return the book root."""
+    book = tmp_path / "blood-and-binary"
+    (book / "chapters" / "01-intro").mkdir(parents=True)
+    (book / "README.md").write_text("# Blood & Binary\n", encoding="utf-8")
+    if claudemd_body is not None:
+        (book / "CLAUDE.md").write_text(claudemd_body, encoding="utf-8")
+    return book
+
+
+def _write_draft(book: Path, body: str, chapter: str = "01-intro") -> Path:
+    draft = book / "chapters" / chapter / "draft.md"
+    draft.write_text(body, encoding="utf-8")
+    return draft
+
+
+# ---------------------------------------------------------------------------
+# validate_chapter() — pure-function behavior
+# ---------------------------------------------------------------------------
 
 
 class TestValidateChapter:
     def test_ignores_non_chapter_files(self):
-        assert validate_chapter("/some/other/file.md") == []
+        assert vc.validate_chapter("/some/other/file.md") == []
 
     def test_ignores_readme(self):
-        assert validate_chapter("/project/chapters/01-intro/README.md") == []
+        assert vc.validate_chapter("/project/chapters/01-intro/README.md") == []
 
     def test_detects_ai_tells(self, tmp_path):
-        ch_dir = tmp_path / "project" / "chapters" / "01-intro"
-        ch_dir.mkdir(parents=True)
-        draft = ch_dir / "draft.md"
-        draft.write_text(
+        book = _make_book(tmp_path)
+        draft = _write_draft(
+            book,
             "# Chapter 1\n\n"
-            "She delved into the tapestry of nuanced experiences, "
-            "each thread a vibrant testament to the intricate myriad "
-            "of unprecedented journeys she had embarked upon. "
-            "The beacon of hope resonated with a pivotal force. " * 3,
-            encoding="utf-8",
+            + (
+                "She delved into the tapestry of nuanced experiences, "
+                "each thread a vibrant testament to the intricate myriad "
+                "of unprecedented journeys she had embarked upon. "
+                "The beacon of hope resonated with a pivotal force. " * 3
+            ),
         )
 
-        issues = validate_chapter(str(draft))
-        # Should find multiple AI-tell words
-        ai_warns = [i for i in issues if "AI-tell" in i]
+        findings = vc.validate_chapter(str(draft))
+        ai_warns = [f for f in findings if f.category == "ai_tell"]
         assert len(ai_warns) > 3
+        assert all(f.severity == vc.SEVERITY_WARN for f in ai_warns)
 
     def test_clean_prose_passes(self, tmp_path):
-        ch_dir = tmp_path / "project" / "chapters" / "01-intro"
-        ch_dir.mkdir(parents=True)
-        draft = ch_dir / "draft.md"
-        draft.write_text(
+        book = _make_book(tmp_path)
+        draft = _write_draft(
+            book,
             "# Chapter 1\n\n"
-            "The door slammed. She froze, one hand on the railing, "
-            "the other clutching a paper bag from the Korean grocery "
-            "on Seventh. The stairs smelled like wet concrete and old "
-            "cigarettes. Three flights up, apartment 4B, the deadbolt "
-            "she'd been meaning to replace since February. "
-            "Her keys jangled. Too loud in the silence. "
-            "Something was wrong. She could feel it — that prickle "
-            "at the back of her neck, the one her mother called "
-            "'the animal knowing.' Twenty-eight years of ignoring it. "
-            "Tonight she listened." * 3,
-            encoding="utf-8",
+            + (
+                "The door slammed. She froze, one hand on the railing, "
+                "the other clutching a paper bag from the Korean grocery "
+                "on Seventh. The stairs smelled like wet concrete and old "
+                "cigarettes. Three flights up, apartment 4B, the deadbolt "
+                "she'd been meaning to replace since February. "
+                "Her keys jangled. Too loud in the silence. "
+                "Something was wrong. She could feel it — that prickle "
+                "at the back of her neck, the one her mother called "
+                "'the animal knowing.' Twenty-eight years of ignoring it. "
+                "Tonight she listened." * 3
+            ),
         )
 
-        issues = validate_chapter(str(draft))
-        ai_warns = [i for i in issues if "AI-tell" in i]
-        assert len(ai_warns) == 0
+        findings = vc.validate_chapter(str(draft))
+        ai_warns = [f for f in findings if f.category == "ai_tell"]
+        assert ai_warns == []
 
     def test_skips_short_drafts(self, tmp_path):
-        ch_dir = tmp_path / "project" / "chapters" / "01-intro"
-        ch_dir.mkdir(parents=True)
-        draft = ch_dir / "draft.md"
-        draft.write_text("# Chapter 1\n\n", encoding="utf-8")
+        book = _make_book(tmp_path)
+        draft = _write_draft(book, "# Chapter 1\n\n")
+        assert vc.validate_chapter(str(draft)) == []
 
-        issues = validate_chapter(str(draft))
-        assert len(issues) == 0
+    def test_blocks_book_rule_violation(self, tmp_path):
+        # Book CLAUDE.md with a backtick-wrapped banned literal — the same
+        # syntax the existing manuscript-checker already understands.
+        book = _make_book(
+            tmp_path,
+            claudemd_body=(
+                "# Blood & Binary\n\n"
+                "## Rules\n"
+                "- Do not use `clocked` as a verb for noticing/realizing — "
+                "reader dislikes the word.\n"
+            ),
+        )
+        draft = _write_draft(
+            book,
+            "# Chapter 1\n\n"
+            + (
+                "Theo clocked the door from across the room. The handle "
+                "looked wrong. He shifted his weight, kept the bag tight "
+                "against his ribs, and waited for the next breath. " * 5
+            ),
+        )
+
+        findings = vc.validate_chapter(str(draft))
+        blocking = [f for f in findings if f.severity == vc.SEVERITY_BLOCK]
+        assert len(blocking) >= 1
+        assert any(f.category == "book_rule_violation" for f in blocking)
+        assert any("clocked" in f.message for f in blocking)
+        assert all(f.line is not None for f in blocking)
+
+    def test_clean_prose_with_book_claudemd_passes(self, tmp_path):
+        book = _make_book(
+            tmp_path,
+            claudemd_body=(
+                "# Blood & Binary\n\n"
+                "## Rules\n"
+                "- Do not use `clocked` as a verb.\n"
+            ),
+        )
+        draft = _write_draft(
+            book,
+            "# Chapter 1\n\n"
+            + (
+                "Theo noticed the door from across the room. The handle "
+                "looked wrong. He shifted his weight, kept the bag tight "
+                "against his ribs, and waited for the next breath. " * 5
+            ),
+        )
+        findings = vc.validate_chapter(str(draft))
+        blocking = [f for f in findings if f.severity == vc.SEVERITY_BLOCK]
+        assert blocking == []
+
+
+# ---------------------------------------------------------------------------
+# Mode resolution (strict vs warn)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMode:
+    def test_default_is_strict_when_no_book_root(self, tmp_path):
+        path = tmp_path / "loose-file.md"
+        path.write_text("nothing", encoding="utf-8")
+        assert vc._resolve_mode(path) == "strict"
+
+    def test_default_is_strict_without_claudemd(self, tmp_path):
+        book = _make_book(tmp_path)
+        draft = _write_draft(book, "# x\n")
+        assert vc._resolve_mode(draft) == "strict"
+
+    def test_default_is_strict_without_frontmatter(self, tmp_path):
+        book = _make_book(tmp_path, claudemd_body="# Book\n\nNo frontmatter.\n")
+        draft = _write_draft(book, "# x\n")
+        assert vc._resolve_mode(draft) == "strict"
+
+    def test_warn_mode_via_frontmatter(self, tmp_path):
+        body = (
+            "---\n"
+            "linter_mode: warn\n"
+            "---\n\n"
+            "# Book\n\n## Rules\n- Avoid `clocked`.\n"
+        )
+        book = _make_book(tmp_path, claudemd_body=body)
+        draft = _write_draft(book, "# x\n")
+        assert vc._resolve_mode(draft) == "warn"
+
+    def test_strict_mode_explicit(self, tmp_path):
+        body = '---\nlinter_mode: "strict"\n---\n\n# Book\n'
+        book = _make_book(tmp_path, claudemd_body=body)
+        draft = _write_draft(book, "# x\n")
+        assert vc._resolve_mode(draft) == "strict"
+
+    def test_invalid_mode_falls_back_to_strict(self, tmp_path):
+        body = "---\nlinter_mode: chaotic\n---\n\n# Book\n"
+        book = _make_book(tmp_path, claudemd_body=body)
+        draft = _write_draft(book, "# x\n")
+        assert vc._resolve_mode(draft) == "strict"
+
+
+# ---------------------------------------------------------------------------
+# Hook entry point — JSON stdin protocol + exit codes
+# ---------------------------------------------------------------------------
+
+
+def _run_hook(payload: dict | None, monkeypatch, capsys) -> int:
+    """Invoke vc.main() with a faked stdin/argv, return exit code."""
+    if payload is None:
+        monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+    else:
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    # Force isatty=False so _read_payload reads stdin
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False, raising=False)
+    monkeypatch.setattr(sys, "argv", ["validate_chapter.py"])
+    return vc.main()
+
+
+class TestMainEntryPoint:
+    def test_no_payload_no_argv_returns_zero(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False, raising=False)
+        monkeypatch.setattr(sys, "argv", ["validate_chapter.py"])
+        assert vc.main() == 0
+
+    def test_unwatched_tool_is_ignored(self, monkeypatch, capsys):
+        payload = {
+            "tool_name": "Read",
+            "tool_input": {"file_path": "/anything/draft.md"},
+        }
+        rc = _run_hook(payload, monkeypatch, capsys)
+        assert rc == 0
+        assert capsys.readouterr().err == ""
+
+    def test_write_to_unrelated_file_is_ignored(self, monkeypatch, capsys):
+        payload = {
+            "tool_name": "Write",
+            "tool_input": {"file_path": "/tmp/notes.md"},
+        }
+        rc = _run_hook(payload, monkeypatch, capsys)
+        assert rc == 0
+        assert capsys.readouterr().err == ""
+
+    def test_block_exit_2_in_strict_mode(self, tmp_path, monkeypatch, capsys):
+        book = _make_book(
+            tmp_path,
+            claudemd_body=(
+                "# Book\n\n## Rules\n- Avoid `clocked` as a verb.\n"
+            ),
+        )
+        draft = _write_draft(
+            book,
+            "# Chapter 1\n\n"
+            + (
+                "Theo clocked the room and let his shoulders drop. "
+                "The bag slid off the bench. He counted three breaths "
+                "before he turned to face the door. " * 5
+            ),
+        )
+        payload = {
+            "tool_name": "Write",
+            "tool_input": {"file_path": str(draft)},
+        }
+        rc = _run_hook(payload, monkeypatch, capsys)
+        captured = capsys.readouterr()
+        assert rc == 2
+        assert "blocked this write" in captured.err.lower()
+        assert "clocked" in captured.err
+
+    def test_warn_mode_does_not_block(self, tmp_path, monkeypatch, capsys):
+        body = (
+            "---\nlinter_mode: warn\n---\n\n"
+            "# Book\n\n## Rules\n- Avoid `clocked` as a verb.\n"
+        )
+        book = _make_book(tmp_path, claudemd_body=body)
+        draft = _write_draft(
+            book,
+            "# Chapter 1\n\n"
+            + (
+                "Theo clocked the room and let his shoulders drop. "
+                "The bag slid off the bench. He counted three breaths "
+                "before he turned to face the door. " * 5
+            ),
+        )
+        payload = {
+            "tool_name": "Write",
+            "tool_input": {"file_path": str(draft)},
+        }
+        rc = _run_hook(payload, monkeypatch, capsys)
+        assert rc == 0
+
+    def test_clean_prose_returns_zero(self, tmp_path, monkeypatch, capsys):
+        book = _make_book(tmp_path)
+        draft = _write_draft(
+            book,
+            "# Chapter 1\n\n"
+            + (
+                "The door slammed. She froze, one hand on the railing, "
+                "the other clutching a paper bag from the Korean grocery "
+                "on Seventh. Twenty-eight years of ignoring the prickle "
+                "at the back of her neck. Tonight she listened. " * 5
+            ),
+        )
+        payload = {
+            "tool_name": "Edit",
+            "tool_input": {"file_path": str(draft)},
+        }
+        rc = _run_hook(payload, monkeypatch, capsys)
+        assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration: invoke the hook script as a subprocess
+# ---------------------------------------------------------------------------
+
+
+class TestHookSubprocess:
+    """Run the hook as Claude Code would — fresh process, JSON on stdin."""
+
+    def _hook_path(self) -> Path:
+        return Path(__file__).resolve().parent.parent / "hooks" / "validate_chapter.py"
+
+    def test_strict_block_via_subprocess(self, tmp_path):
+        book = _make_book(
+            tmp_path,
+            claudemd_body=(
+                "# Book\n\n## Rules\n- Avoid `clocked` as a verb.\n"
+            ),
+        )
+        draft = _write_draft(
+            book,
+            "# Chapter 1\n\n"
+            + (
+                "Theo clocked the room and let his shoulders drop. "
+                "The bag slid off the bench. He counted three breaths "
+                "before he turned to face the door. " * 5
+            ),
+        )
+        payload = json.dumps(
+            {"tool_name": "Write", "tool_input": {"file_path": str(draft)}}
+        )
+        result = subprocess.run(
+            [sys.executable, str(self._hook_path())],
+            input=payload,
+            text=True,
+            capture_output=True,
+            timeout=10,
+        )
+        assert result.returncode == 2, result.stderr
+        assert "clocked" in result.stderr
+
+    def test_unwatched_tool_subprocess(self, tmp_path):
+        payload = json.dumps(
+            {"tool_name": "Read", "tool_input": {"file_path": "/x/draft.md"}}
+        )
+        result = subprocess.run(
+            [sys.executable, str(self._hook_path())],
+            input=payload,
+            text=True,
+            capture_output=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# validate_character — preserved from prior suite
+# ---------------------------------------------------------------------------
 
 
 class TestValidateCharacter:
@@ -79,16 +374,13 @@ class TestValidateCharacter:
             "## The Ghost\n\nContent.\n\n## Motivation Chain\n\nContent.\n",
             encoding="utf-8",
         )
-
-        issues = validate_character(str(char_file))
-        assert len(issues) == 0
+        assert validate_character(str(char_file)) == []
 
     def test_missing_frontmatter(self, tmp_path):
         chars_dir = tmp_path / "project" / "characters"
         chars_dir.mkdir(parents=True)
         char_file = chars_dir / "alex.md"
         char_file.write_text("# Alex\n\nNo frontmatter here.\n", encoding="utf-8")
-
         issues = validate_character(str(char_file))
         assert any("Missing YAML frontmatter" in i for i in issues)
 
@@ -101,7 +393,6 @@ class TestValidateCharacter:
             "# Alex\n\nNo required sections.\n",
             encoding="utf-8",
         )
-
         issues = validate_character(str(char_file))
         assert any("Want vs. Need" in i for i in issues)
         assert any("Fatal Flaw" in i for i in issues)
@@ -115,7 +406,5 @@ class TestValidateCharacter:
             "# Barista\n\nJust a minor character.\n",
             encoding="utf-8",
         )
-
         issues = validate_character(str(char_file))
-        # Minor characters don't need Want vs. Need or Fatal Flaw
         assert not any("Want vs. Need" in i for i in issues)


### PR DESCRIPTION
## Summary

- Registers `validate_chapter.py` as a `PostToolUse` hook for `Write|Edit|MultiEdit` in `.claude-plugin/hooks.json` so it actually runs (previously the file existed but was never wired).
- Refactors the hook to read Claude Code's JSON payload from stdin, scope itself to `chapters/*/draft.md`, and return exit 2 to **block** writes that violate book-CLAUDE.md banned phrases.
- Adds a severity model (`block` / `warn`) and a per-book `linter_mode: warn|strict` frontmatter override (default `strict`).
- Reuses the existing `_read_book_rules` / `_extract_patterns_from_rule` helpers from `manuscript_checker.py` — the hook and the post-draft scanner stay in lockstep on what counts as a banned pattern.

This is the foundation issue for Sprint 1 of #69. Issues #71, #73, #74 all extend this same hook.

## Acceptance criteria — verification

- [x] Writing a `draft.md` with a banned phrase from the active book's CLAUDE.md gets blocked with stderr naming the phrase + line number.
- [x] Writing clean prose passes through unchanged.
- [x] Hook does not run on non-`draft.md` files.
- [x] Hook completes well under 500ms for a typical scene-length write (subprocess test runs in ~50ms).
- [x] Existing `tests/test_hooks.py` still passes; new tests cover block path, warn-mode override, JSON-stdin protocol, and an integration subprocess invocation.

## Test plan

- [x] `pytest tests/test_hooks.py` — 27 passed
- [x] `pytest` (full suite) — 285 passed
- [x] `ruff check hooks/ tests/` — clean
- [x] **Manual smoke test**: try editing a chapter draft in a real book, with and without a `linter_mode: warn` line in the book's CLAUDE.md frontmatter
- [x] **Manual end-to-end**: trigger a Write that contains `clocked` against Blood & Binary and confirm Claude Code surfaces the block + retries

## Notes for review

- Backward-compat: the legacy argv-positional invocation path still works (covered by the `_no_payload_no_argv_returns_zero` test).
- AI-tell vocabulary list and sentence-variance heuristic intentionally stay `warn`-severity. Promotion to `block` happens per-book via CLAUDE.md rules, or globally in #74.
- Failure to import the manuscript-checker rule helpers degrades gracefully — the hook still runs the AI-tell scan.

Closes #70
Refs #69