### PR TITLE
fix(linter): banned-phrase format strictness — hook backticks-only + persistence normalization

### DIFF
--- a/hooks/validate_chapter.py
+++ b/hooks/validate_chapter.py
@@ -155,20 +155,60 @@ def _resolve_mode(file_path: Path) -> str:
 # Banned-phrase scan (book CLAUDE.md ## Rules)
 # ---------------------------------------------------------------------------
 
+# Hook-local extractor: ONLY backtick-wrapped strings count as hard-block
+# patterns. The post-draft ``manuscript-checker`` uses a looser parser that
+# also picks up ban-cued double-quoted phrases — that's tolerable for soft
+# warnings but produces too many false positives when used as a write block.
+# Backticks are the markdown convention for "this is a pattern reference",
+# so requiring them keeps the user/skill in explicit territory.
+
+_BACKTICK_PATTERN_RE = re.compile(r"`([^`\n]+)`")
+_REGEX_HINT_CHARS = set("|()[]\\^$?+*{}")
+
+
+def _extract_block_patterns_from_rule(
+    rule: str,
+) -> list[tuple[str, re.Pattern[str]]]:
+    """Extract hard-block patterns from a single rule body.
+
+    Only backtick-wrapped strings are returned. Whitespace inside the
+    backticks is preserved so the user can encode word-boundary intent
+    (e.g. `` ` thing ` ``). If the inner string contains regex
+    metacharacters it is compiled as a regex; otherwise as a literal
+    substring. Malformed regexes are skipped silently.
+    """
+    patterns: list[tuple[str, re.Pattern[str]]] = []
+    seen: set[str] = set()
+    for match in _BACKTICK_PATTERN_RE.finditer(rule):
+        raw = match.group(1)
+        inner = raw.strip()
+        if len(inner) < 2:
+            continue
+        key = raw.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        try:
+            if any(c in _REGEX_HINT_CHARS for c in inner):
+                compiled = re.compile(raw, re.IGNORECASE)
+            else:
+                compiled = re.compile(re.escape(raw), re.IGNORECASE)
+        except re.error:
+            continue
+        patterns.append((inner, compiled))
+    return patterns
+
 
 def _book_banned_patterns(book_root: Path) -> list[tuple[str, re.Pattern[str]]]:
     """Return ``(label, compiled_regex)`` patterns from the book's CLAUDE.md.
 
-    Reuses the rule-parsing logic from ``tools.analysis.manuscript_checker``
-    so the hook and the post-draft scanner agree on what counts as a
-    bannable pattern. Failure to import the helper degrades gracefully:
-    the hook still runs the AI-tell scan.
+    Reuses ``_read_book_rules`` from ``tools.analysis.manuscript_checker``
+    for the section-extraction logic, but applies the strict
+    backtick-only pattern extractor defined above. Failure to import the
+    rule reader degrades gracefully: the hook still runs the AI-tell scan.
     """
     try:
-        from tools.analysis.manuscript_checker import (
-            _extract_patterns_from_rule,
-            _read_book_rules,
-        )
+        from tools.analysis.manuscript_checker import _read_book_rules
     except Exception:
         return []
 
@@ -176,7 +216,7 @@ def _book_banned_patterns(book_root: Path) -> list[tuple[str, re.Pattern[str]]]:
     patterns: list[tuple[str, re.Pattern[str]]] = []
     seen: set[str] = set()
     for rule in rules:
-        for label, compiled in _extract_patterns_from_rule(rule):
+        for label, compiled in _extract_block_patterns_from_rule(rule):
             key = compiled.pattern.lower()
             if key in seen:
                 continue

--- a/tests/test_claudemd.py
+++ b/tests/test_claudemd.py
@@ -210,6 +210,94 @@ class TestAppendRule:
             append_rule(book_config, "my-book", "something")
 
 
+class TestAppendRuleNormalization:
+    """Verify that rules persisted via ``append_rule`` get their primary
+    ban-cued double-quoted phrase converted to backtick form, so the
+    PostToolUse hook (which only blocks on backtick patterns) can pick
+    them up automatically.
+    """
+
+    def test_avoid_quoted_phrase_becomes_backticks(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        append_rule(book_config, "my-book", 'Avoid "clocked" as a verb')
+        content = get_claudemd(book_config, "my-book")
+        assert "Avoid `clocked` as a verb" in content
+        assert 'Avoid "clocked"' not in content
+
+    def test_do_not_use_quoted_phrase(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        append_rule(
+            book_config, "my-book", 'Do not use "began to" as a verb opener'
+        )
+        content = get_claudemd(book_config, "my-book")
+        assert "Do not use `began to`" in content
+
+    def test_dont_use_smart_apostrophe(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        append_rule(book_config, "my-book", 'Don’t use "really" too often')
+        content = get_claudemd(book_config, "my-book")
+        assert "`really`" in content
+
+    def test_limit_with_qualifier(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        append_rule(
+            book_config,
+            "my-book",
+            'Limit the "specific kind of X that Y" construction',
+        )
+        content = get_claudemd(book_config, "my-book")
+        assert "Limit the `specific kind of X that Y` construction" in content
+
+    def test_only_first_quoted_phrase_converted(self, book_config):
+        """Replacement examples that come *after* the banned phrase stay
+        in double quotes — they're advice, not patterns to block."""
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        append_rule(
+            book_config,
+            "my-book",
+            'Avoid "clocked" — replace with "noticed" or "registered"',
+        )
+        content = get_claudemd(book_config, "my-book")
+        assert "Avoid `clocked`" in content
+        # The replacement examples remain quoted (they're not block patterns).
+        assert '"noticed"' in content
+        assert '"registered"' in content
+
+    def test_no_ban_cue_leaves_quotes_intact(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        append_rule(
+            book_config, "my-book", 'Use "felt like" sparingly in dialog'
+        )
+        content = get_claudemd(book_config, "my-book")
+        assert '"felt like"' in content
+        assert "`felt like`" not in content
+
+    def test_already_backticked_unchanged(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        append_rule(book_config, "my-book", "Avoid `clocked` as a verb")
+        content = get_claudemd(book_config, "my-book")
+        assert "Avoid `clocked` as a verb" in content
+        assert "``clocked``" not in content  # no double-wrapping
+
+    def test_workflow_not_normalized(self, book_config):
+        """Normalization only applies to rules, not workflows."""
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        append_workflow(
+            book_config, "my-book", 'Avoid "branching" in commit names'
+        )
+        content = get_claudemd(book_config, "my-book")
+        assert '"branching"' in content
+        assert "`branching`" not in content
+
+    def test_callback_not_normalized(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        append_callback(
+            book_config, "my-book", 'Avoid "Gary" as a name in next book'
+        )
+        content = get_claudemd(book_config, "my-book")
+        assert '"Gary"' in content
+
+
 class TestAppendWorkflow:
     def test_appends_to_workflow_section(self, book_config):
         init_claudemd(book_config, PLUGIN_ROOT, "my-book")

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -142,6 +142,79 @@ class TestValidateChapter:
         blocking = [f for f in findings if f.severity == vc.SEVERITY_BLOCK]
         assert blocking == []
 
+    def test_double_quoted_phrases_do_not_trigger_block(self, tmp_path):
+        """Hook only honors backtick patterns. Double-quoted phrases in
+        rules are advisory text only — typically positive examples or
+        replacement suggestions — and must not produce hard-block
+        findings (see #87)."""
+        book = _make_book(
+            tmp_path,
+            claudemd_body=(
+                "# Book\n\n"
+                "## Rules\n"
+                "- Avoid \"clocked\" as a verb. Replace with "
+                "\"noticed\" or \"registered\".\n"
+            ),
+        )
+        draft = _write_draft(
+            book,
+            "# Chapter 1\n\n"
+            + (
+                "Theo clocked the room and let his shoulders drop. "
+                "The bag slid off the bench. He counted three breaths "
+                "before he turned to face the door. " * 5
+            ),
+        )
+        findings = vc.validate_chapter(str(draft))
+        blocking = [f for f in findings if f.severity == vc.SEVERITY_BLOCK]
+        # Quoted phrases are not block patterns — only backticks are.
+        assert blocking == []
+
+    def test_backtick_regex_pattern_with_alternation(self, tmp_path):
+        """Backticks containing regex metacharacters compile as regex."""
+        book = _make_book(
+            tmp_path,
+            claudemd_body=(
+                "# Book\n\n"
+                "## Rules\n"
+                "- Avoid `the (specific|particular|certain) [a-z]+ that` "
+                "as filler.\n"
+            ),
+        )
+        draft = _write_draft(
+            book,
+            "# Chapter 1\n\n"
+            + (
+                "She noticed the specific quietude that follows a slammed "
+                "door. The room held its breath. " * 5
+            ),
+        )
+        findings = vc.validate_chapter(str(draft))
+        blocking = [f for f in findings if f.severity == vc.SEVERITY_BLOCK]
+        assert len(blocking) >= 1
+
+    def test_backtick_regex_does_not_match_unrelated_text(self, tmp_path):
+        book = _make_book(
+            tmp_path,
+            claudemd_body=(
+                "# Book\n\n"
+                "## Rules\n"
+                "- Avoid `the (specific|particular|certain) [a-z]+ that` "
+                "as filler.\n"
+            ),
+        )
+        draft = _write_draft(
+            book,
+            "# Chapter 1\n\n"
+            + (
+                "The door slammed. She held her breath, counted to four, "
+                "then exhaled into the fabric of her sleeve. " * 5
+            ),
+        )
+        findings = vc.validate_chapter(str(draft))
+        blocking = [f for f in findings if f.severity == vc.SEVERITY_BLOCK]
+        assert blocking == []
+
 
 # ---------------------------------------------------------------------------
 # Mode resolution (strict vs warn)

--- a/tests/test_migrate_to_backticks.py
+++ b/tests/test_migrate_to_backticks.py
@@ -1,0 +1,164 @@
+"""Tests for the CLAUDE.md migration script.
+
+Covers the in-process functions of ``tools.claudemd.migrate_to_backticks``
+plus an end-to-end CLI smoke test in dry-run mode.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from tools.claudemd.migrate_to_backticks import _migrate_text, main
+
+
+SAMPLE_CLAUDEMD = """# Sample Book
+
+## Rules
+
+<!-- RULES:START -->
+- Avoid "clocked" as a verb — reader edited it out twice.
+- Do not use "began to" as an opener.
+- Use "felt like" sparingly (no ban cue, advisory only).
+- Avoid `pulsed` already in backticks — should not be touched.
+- Limit the "specific kind of X that Y" construction.
+<!-- RULES:END -->
+"""
+
+
+class TestMigrateText:
+    def test_converts_avoid_quoted_phrase(self):
+        new, changes = _migrate_text(SAMPLE_CLAUDEMD)
+        assert "Avoid `clocked` as a verb" in new
+        assert "Avoid \"clocked\"" not in new
+        assert any("clocked" in after for _, _, after in changes)
+
+    def test_converts_do_not_use(self):
+        new, _ = _migrate_text(SAMPLE_CLAUDEMD)
+        assert "Do not use `began to`" in new
+
+    def test_advisory_quotes_stay(self):
+        new, _ = _migrate_text(SAMPLE_CLAUDEMD)
+        # No ban cue → should remain quoted.
+        assert "Use \"felt like\" sparingly" in new
+
+    def test_already_backticked_unchanged(self):
+        new, _ = _migrate_text(SAMPLE_CLAUDEMD)
+        assert "Avoid `pulsed` already in backticks" in new
+        # No accidental double-wrapping.
+        assert "``pulsed``" not in new
+
+    def test_limit_with_qualifier(self):
+        new, _ = _migrate_text(SAMPLE_CLAUDEMD)
+        assert "Limit the `specific kind of X that Y` construction" in new
+
+    def test_changes_count_matches_expectation(self):
+        _, changes = _migrate_text(SAMPLE_CLAUDEMD)
+        # Three rules should change: clocked, began to, specific kind of X that Y.
+        assert len(changes) == 3
+
+    def test_empty_input(self):
+        new, changes = _migrate_text("")
+        assert new == ""
+        assert changes == []
+
+    def test_preserves_trailing_newline(self):
+        text_with = "- Avoid \"x\" please.\n"
+        new, _ = _migrate_text(text_with)
+        assert new.endswith("\n")
+
+        text_without = "- Avoid \"x\" please."
+        new_wo, _ = _migrate_text(text_without)
+        assert not new_wo.endswith("\n")
+
+    def test_non_bullet_lines_untouched(self):
+        text = (
+            "Some narrative paragraph mentioning \"clocked\" and avoid it.\n"
+            "- Avoid \"clocked\" as a verb.\n"
+        )
+        new, changes = _migrate_text(text)
+        assert "narrative paragraph mentioning \"clocked\"" in new
+        assert "Avoid `clocked`" in new
+        assert len(changes) == 1
+
+
+class TestMigrateCLI:
+    def _write_book(self, tmp_path: Path, body: str) -> Path:
+        book = tmp_path / "sample-book"
+        book.mkdir()
+        (book / "CLAUDE.md").write_text(body, encoding="utf-8")
+        return book
+
+    def test_missing_claudemd_returns_error(self, tmp_path, capsys):
+        book = tmp_path / "no-such-book"
+        book.mkdir()
+        rc = main([str(book)])
+        assert rc == 1
+        assert "not found" in capsys.readouterr().err
+
+    def test_dry_run_shows_diff_without_writing(self, tmp_path, capsys):
+        book = self._write_book(tmp_path, SAMPLE_CLAUDEMD)
+        original = (book / "CLAUDE.md").read_text(encoding="utf-8")
+
+        rc = main([str(book)])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "would change" in captured.out
+        # File unchanged.
+        assert (book / "CLAUDE.md").read_text(encoding="utf-8") == original
+
+    def test_no_changes_needed(self, tmp_path, capsys):
+        body = "## Rules\n- Avoid `clocked` as a verb.\n"
+        book = self._write_book(tmp_path, body)
+        rc = main([str(book)])
+        assert rc == 0
+        assert "No changes needed" in capsys.readouterr().out
+
+    def test_apply_writes_with_yes_confirmation(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        book = self._write_book(tmp_path, SAMPLE_CLAUDEMD)
+        monkeypatch.setattr("builtins.input", lambda _: "y")
+        rc = main([str(book), "--apply"])
+        assert rc == 0
+        new = (book / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "Avoid `clocked` as a verb" in new
+
+    def test_apply_aborts_on_no(self, tmp_path, capsys, monkeypatch):
+        book = self._write_book(tmp_path, SAMPLE_CLAUDEMD)
+        original = (book / "CLAUDE.md").read_text(encoding="utf-8")
+        monkeypatch.setattr("builtins.input", lambda _: "n")
+        rc = main([str(book), "--apply"])
+        assert rc == 0
+        assert "Aborted" in capsys.readouterr().out
+        assert (book / "CLAUDE.md").read_text(encoding="utf-8") == original
+
+
+class TestMigrateSubprocess:
+    """Smoke test the script as a subprocess (CLI invocation path)."""
+
+    def test_dry_run_subprocess(self, tmp_path):
+        book = tmp_path / "sample-book"
+        book.mkdir()
+        (book / "CLAUDE.md").write_text(SAMPLE_CLAUDEMD, encoding="utf-8")
+
+        repo_root = Path(__file__).resolve().parent.parent
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "tools.claudemd.migrate_to_backticks",
+                str(book),
+            ],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "Avoid `clocked`" in result.stdout
+        # File unchanged in dry-run.
+        assert "Avoid \"clocked\"" in (book / "CLAUDE.md").read_text(
+            encoding="utf-8"
+        )

--- a/tools/claudemd/manager.py
+++ b/tools/claudemd/manager.py
@@ -88,6 +88,41 @@ def _insert_before_marker(content: str, marker_end: str, new_line: str) -> str:
     return content.replace(marker_end, replacement, 1)
 
 
+# Match a ban-cue followed by an optional 0-2-word qualifier and a
+# double-quoted phrase. Tuned to recognize the simple shapes that Claude or
+# the user typically produces ("Avoid X", "Do not use X", "Limit the X")
+# without grabbing every quoted string on the line. Quotes that come later
+# in the bullet (typically examples or replacements) are deliberately left
+# untouched.
+_BAN_CUE_QUOTE_RE = re.compile(
+    r"\b(?P<cue>banned|avoid|never|do(?:\s+not|n[’']?t)\s+use|"
+    r"never\s+use|limit|stop\s+using)"
+    r"(?P<between>(?:[\s:]+[\w-]+){0,2}[\s:]+)"
+    r'"(?P<phrase>[^"\n]{2,})"',
+    re.IGNORECASE,
+)
+
+
+def _normalize_banned_phrase(text: str) -> str:
+    """Convert the *first* ban-cued double-quoted phrase to backticks.
+
+    Rules with ban-cue + quoted phrase ("Avoid \"clocked\" as a verb") get
+    rewritten to backtick form ("Avoid ``clocked`` as a verb") so the
+    PostToolUse hook (which only honors backticks for hard-block
+    patterns) can enforce them. Conservative by design — only the first
+    matching phrase per text is converted; later quoted strings (typically
+    examples or replacements) stay double-quoted.
+    """
+    match = _BAN_CUE_QUOTE_RE.search(text)
+    if not match:
+        return text
+    cue = match.group("cue")
+    between = match.group("between")
+    phrase = match.group("phrase")
+    replacement = f"{cue}{between}`{phrase}`"
+    return text[: match.start()] + replacement + text[match.end():]
+
+
 def _append_entry(
     config: dict[str, Any],
     book_slug: str,
@@ -98,6 +133,9 @@ def _append_entry(
     text = text.strip()
     if not text:
         raise ValueError("Entry text must not be empty")
+
+    if kind == "rule":
+        text = _normalize_banned_phrase(text)
 
     path = resolve_claudemd_path(config, book_slug)
     if not path.exists():

--- a/tools/claudemd/migrate_to_backticks.py
+++ b/tools/claudemd/migrate_to_backticks.py
@@ -1,0 +1,120 @@
+"""One-shot migration: convert ban-cued double-quoted phrases in a book's
+``CLAUDE.md`` to backtick form so the PostToolUse hook (issue #70) can
+hard-block them.
+
+The validate_chapter hook only honors backtick-wrapped patterns as
+hard-block triggers (see ``hooks/validate_chapter.py``). Existing rules
+that were persisted before the strictness change use double quotes; this
+script rewrites them in-place under the same heuristic that
+``tools.claudemd.manager._normalize_banned_phrase`` applies on append, so
+new and old rules agree on format.
+
+Usage::
+
+    python -m tools.claudemd.migrate_to_backticks <book_path>           # dry-run
+    python -m tools.claudemd.migrate_to_backticks <book_path> --apply   # interactive write
+
+Without ``--apply`` the script prints a unified diff and exits. With
+``--apply`` it asks for confirmation before writing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import sys
+from pathlib import Path
+
+# Make the project root importable when run as a script.
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from tools.claudemd.manager import _normalize_banned_phrase
+
+
+def _migrate_text(original: str) -> tuple[str, list[tuple[int, str, str]]]:
+    """Apply normalization line-by-line.
+
+    Returns ``(new_content, changes)`` where ``changes`` is a list of
+    ``(line_number, before, after)`` tuples for changed lines only.
+    """
+    new_lines: list[str] = []
+    changes: list[tuple[int, str, str]] = []
+    for lineno, line in enumerate(original.splitlines(), start=1):
+        # Only consider markdown bullets — rules / callbacks / workflows.
+        stripped = line.lstrip()
+        if stripped.startswith("- "):
+            new_line = _normalize_banned_phrase(line)
+        else:
+            new_line = line
+        if new_line != line:
+            changes.append((lineno, line, new_line))
+        new_lines.append(new_line)
+
+    new_content = "\n".join(new_lines)
+    if original.endswith("\n"):
+        new_content += "\n"
+    return new_content, changes
+
+
+def _print_diff(original: str, new_content: str, path: Path) -> None:
+    diff = difflib.unified_diff(
+        original.splitlines(keepends=True),
+        new_content.splitlines(keepends=True),
+        fromfile=str(path),
+        tofile=f"{path} (migrated)",
+    )
+    sys.stdout.writelines(diff)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert ban-cued double-quoted phrases in a book's CLAUDE.md "
+            "to backtick form."
+        ),
+    )
+    parser.add_argument(
+        "book_path",
+        type=Path,
+        help="Path to the book directory (the one containing CLAUDE.md).",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Prompt for confirmation, then write changes back to disk.",
+    )
+    args = parser.parse_args(argv)
+
+    claudemd = args.book_path / "CLAUDE.md"
+    if not claudemd.is_file():
+        print(f"Error: {claudemd} not found.", file=sys.stderr)
+        return 1
+
+    original = claudemd.read_text(encoding="utf-8")
+    new_content, changes = _migrate_text(original)
+
+    if not changes:
+        print("No changes needed — CLAUDE.md is already in backtick format.")
+        return 0
+
+    _print_diff(original, new_content, claudemd)
+    print()
+    print(f"{len(changes)} line(s) would change.")
+
+    if not args.apply:
+        print("Re-run with --apply to write.")
+        return 0
+
+    response = input("Apply these changes? [y/N] ").strip().lower()
+    if response != "y":
+        print("Aborted. No changes written.")
+        return 0
+
+    claudemd.write_text(new_content, encoding="utf-8")
+    print(f"Wrote {claudemd} ({len(changes)} line(s) changed).")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover — CLI entry point
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Follow-up bug-fix for #70. After the PostToolUse hook went live, real-world testing against `blood-and-binary-firelight/CLAUDE.md` surfaced a ~50% false-positive rate. The hook was inheriting `manuscript_checker.py`'s rule parser, which is tuned for soft post-draft warnings (user reviews each finding) — too aggressive for hard-block enforcement.

This PR tightens the hook and normalizes the persistence pipeline so future Claude-generated rules land in the right format automatically.

## Changes

- **Hook (`hooks/validate_chapter.py`)** — replaces the imported `_extract_patterns_from_rule` with a local `_extract_block_patterns_from_rule` that **only** honors backtick-wrapped patterns. Double-quoted phrases in rules stay advisory text. The post-draft `manuscript-checker` is unchanged.
- **Persistence (`tools/claudemd/manager.py`)** — `_normalize_banned_phrase` runs in `_append_entry` for `kind=\"rule\"`. When a rule body has a ban-cue (`avoid`, `never`, `do not use`, `don't use`, `limit`, `stop using`) followed by a double-quoted phrase, the **first** quoted phrase gets converted to backtick form. Later quoted strings (replacement examples, advisory text) stay double-quoted. Conservative — false-conversion is worse than no-conversion.
- **Migration (`tools/claudemd/migrate_to_backticks.py`)** — new CLI: `python -m tools.claudemd.migrate_to_backticks <book>`. Dry-run by default, requires `--apply` + interactive y/N to write.

## False positives that are now gone

After this fix, on Blood & Binary, the hook stops blocking on:
- `\"a second coffee in a diner\"` (positive simile example)
- `\"clutching the book against his ribs\"` (replacement suggestion)
- `\"Bedroom's that way\"` (positive humor example)
- `\"family emergency\"`, `\"Kael's sister\"`, `\"I'm fine\"` (in-voice register)
- `\"like\"`, `\"as if\"`, `\"felt like\"` (heuristic markers)
- `\"earlier\"`, `\"weeks ago\"` (softened forms — what user wants)

Patterns that **continue** to block (after migration adds backticks): `clocked`, `the floor was doing something the floor shouldn't do`, `specific kind of X that Y`.

## Test plan

- [x] `pytest` — 312 passed (was 285; +27 new tests)
- [x] `ruff check hooks/ tests/ tools/` — clean
- [x] Dry-run migration on `blood-and-binary-firelight` produces a 4-line diff with the expected conversions
- [ ] **Manual confirmation needed**: review the migration diff per book and decide which `--apply` calls are safe (see caveats below)

## Migration caveats — read before applying

The auto-normalization in step 2 is conservative. The CLI migration applies the same rule and has two known limitations on real books:

1. **Single-word patterns can be too generic.** Example from Blood & Binary: rule 3 (`Avoid vague-noun \"thing\"`) would become `` `thing` `` — which would then block every occurrence of \"thing\" in the prose, including the dialog exception the rule itself documents. Recommendation: skip `--apply` for rules where the converted pattern is a single common word, or manually edit the CLAUDE.md afterward to widen the pattern (e.g. `` ` thing ` `` with surrounding spaces, or a regex).

2. **Quotes far from the ban cue are not picked up.** Example: rule 5 (`\"opened his mouth. Closed it...\" has become a tic across chapters. Banned as a default reach.`) — the cue (`Banned`) sits *after* the quote, so the regex misses it. Same for rule 10 (`Avoid definitive durations (\"Eight hours older\", ...)`) — three words between cue and quote. These need a manual edit to backticks.

The migration script is intentionally simple and shows you the diff first; complex cases stay in the user's hands.

## Files

- `hooks/validate_chapter.py` — local backtick-only extractor
- `tools/claudemd/manager.py` — `_normalize_banned_phrase` + integration into `_append_entry`
- `tools/claudemd/migrate_to_backticks.py` — NEW CLI script
- `tests/test_hooks.py` — backtick-only assertion + double-quote-ignored test + regex-pattern test
- `tests/test_claudemd.py` — 9 normalization tests (avoid / do not use / smart-apostrophe / limit-with-qualifier / first-only / no-cue / already-backticked / workflow-not-normalized / callback-not-normalized)
- `tests/test_migrate_to_backticks.py` — NEW (14 tests covering text-level + CLI + subprocess)

Closes #87
Refs #69, #70