### PR TITLE
feat(linter): per-scene counter for structural tics with chapter-cap limits

### DIFF
--- a/hooks/validate_chapter.py
+++ b/hooks/validate_chapter.py
@@ -14,6 +14,7 @@ other file events are passed through silently.
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 import sys
@@ -199,13 +200,44 @@ def _extract_block_patterns_from_rule(
     return patterns
 
 
-def _book_banned_patterns(book_root: Path) -> list[tuple[str, re.Pattern[str]]]:
-    """Return ``(label, compiled_regex)`` patterns from the book's CLAUDE.md.
+# Matches "max N per chapter", "maximum N per chapter", "max N-M per chapter"
+# (range — upper bound is taken), "limit to N per chapter". Numeric value
+# applies per chapter; a per-scene limit is then derived by scaling against
+# the chapter's word-count target (see ``_scan_book_banlist``).
+_CHAPTER_LIMIT_RE = re.compile(
+    r"\b(?:max(?:imum)?|limit\s+to)\s+(?:of\s+)?"
+    r"(?P<low>\d+)(?:\s*[-–]\s*(?P<high>\d+))?"
+    r"\s+per\s+(?:chapter|kapitel)\b",
+    re.IGNORECASE,
+)
 
-    Reuses ``_read_book_rules`` from ``tools.analysis.manuscript_checker``
-    for the section-extraction logic, but applies the strict
-    backtick-only pattern extractor defined above. Failure to import the
-    rule reader degrades gracefully: the hook still runs the AI-tell scan.
+
+def _extract_chapter_limit(rule: str) -> int:
+    """Parse ``max N per chapter`` / ``max N-M per chapter`` from a rule body.
+
+    Returns the integer limit (upper bound for ranges), or ``0`` when the
+    rule does not declare a per-chapter cap. ``0`` means "block on first
+    hit" — the existing default behavior.
+    """
+    match = _CHAPTER_LIMIT_RE.search(rule)
+    if not match:
+        return 0
+    upper = match.group("high") or match.group("low")
+    try:
+        return int(upper)
+    except ValueError:
+        return 0
+
+
+def _book_banned_patterns(
+    book_root: Path,
+) -> list[tuple[str, re.Pattern[str], int]]:
+    """Return ``(label, compiled_regex, chapter_limit)`` patterns.
+
+    ``chapter_limit`` is ``0`` when the source rule has no
+    ``max N per chapter`` declaration (block on first hit). When > 0 the
+    scanner applies a scaled per-scene limit instead (see
+    ``_scan_book_banlist``).
     """
     try:
         from tools.analysis.manuscript_checker import _read_book_rules
@@ -213,16 +245,78 @@ def _book_banned_patterns(book_root: Path) -> list[tuple[str, re.Pattern[str]]]:
         return []
 
     rules = _read_book_rules(book_root)
-    patterns: list[tuple[str, re.Pattern[str]]] = []
+    patterns: list[tuple[str, re.Pattern[str], int]] = []
     seen: set[str] = set()
     for rule in rules:
+        limit = _extract_chapter_limit(rule)
         for label, compiled in _extract_block_patterns_from_rule(rule):
             key = compiled.pattern.lower()
             if key in seen:
                 continue
             seen.add(key)
-            patterns.append((label, compiled))
+            patterns.append((label, compiled, limit))
     return patterns
+
+
+# ---------------------------------------------------------------------------
+# Chapter target word-count (for per-scene limit scaling)
+# ---------------------------------------------------------------------------
+
+# Matches a "Target Words" cell in the chapter README's overview table.
+# Examples it accepts: "| Target Words | ~3,200 |", "| Target Words | 2500 |"
+_TARGET_WORDS_RE = re.compile(
+    r"\|\s*Target\s+Words?\s*\|\s*~?\s*"
+    r"(?P<value>\d{1,3}(?:[,\.]\d{3})*|\d+)\s*\|",
+    re.IGNORECASE,
+)
+
+# Used when no chapter README or no parseable target is available. Picked to
+# match the typical scene-by-scene chapter size users have been writing.
+DEFAULT_CHAPTER_TARGET_WORDS = 3000
+
+
+def _chapter_target_words(draft_path: Path) -> int:
+    """Return the chapter's target word count.
+
+    Looks at ``README.md`` next to the draft, parses the
+    "Target Words" overview cell, and returns the integer. Falls back to
+    ``DEFAULT_CHAPTER_TARGET_WORDS`` if the README is missing or has no
+    parseable target.
+    """
+    readme = draft_path.parent / "README.md"
+    if not readme.is_file():
+        return DEFAULT_CHAPTER_TARGET_WORDS
+    try:
+        text = readme.read_text(encoding="utf-8")
+    except OSError:
+        return DEFAULT_CHAPTER_TARGET_WORDS
+    match = _TARGET_WORDS_RE.search(text)
+    if not match:
+        return DEFAULT_CHAPTER_TARGET_WORDS
+    raw = match.group("value").replace(",", "").replace(".", "")
+    try:
+        target = int(raw)
+    except ValueError:
+        return DEFAULT_CHAPTER_TARGET_WORDS
+    return target if target > 0 else DEFAULT_CHAPTER_TARGET_WORDS
+
+
+def _scaled_scene_limit(
+    chapter_limit: int, current_words: int, target_words: int
+) -> int:
+    """Compute per-scene limit from a per-chapter cap, prorated by progress.
+
+    A 900-word draft toward a 3200-word chapter target is "about a third
+    of the way through", so the scene budget is one third of the chapter
+    cap (rounded up, floored at 1, never exceeding the chapter cap — going
+    over the word target should not unlock more banned-phrase budget).
+    """
+    if chapter_limit <= 0:
+        return 0
+    if target_words <= 0:
+        return chapter_limit
+    ratio = current_words / target_words
+    return max(1, min(chapter_limit, math.ceil(chapter_limit * ratio)))
 
 
 # ---------------------------------------------------------------------------
@@ -392,22 +486,75 @@ def _scan_sentence_variance(text: str) -> list[Finding]:
     ]
 
 
-def _scan_book_banlist(text: str, book_root: Path) -> list[Finding]:
-    """Scan prose against the book's CLAUDE.md banned-phrase patterns."""
+def _format_occurrences(
+    text: str, matches: list[re.Match[str]], cap: int = 5
+) -> str:
+    """Format up to ``cap`` match locations as a compact list for stderr."""
+    parts: list[str] = []
+    for match in matches[:cap]:
+        line = _line_for_offset(text, match.start())
+        start = max(0, match.start() - 25)
+        end = min(len(text), match.end() + 25)
+        snippet = text[start:end].replace("\n", " ").strip()
+        parts.append(f"line {line}: …{snippet}…")
+    if len(matches) > cap:
+        parts.append(f"…and {len(matches) - cap} more")
+    return "; ".join(parts)
+
+
+def _scan_book_banlist(
+    text: str, book_root: Path, draft_path: Path
+) -> list[Finding]:
+    """Scan prose against the book's CLAUDE.md banned-phrase patterns.
+
+    Patterns without a per-chapter limit (the default) block on the first
+    hit. Patterns whose source rule declares ``max N per chapter`` get a
+    scaled per-scene budget instead — a 900-word draft toward a 3200-word
+    chapter target gets ``ceil(N * 900/3200)`` allowed hits, floored at 1.
+    Only counts above the budget produce a finding.
+    """
     findings: list[Finding] = []
-    for label, compiled in _book_banned_patterns(book_root):
-        match = compiled.search(text)
-        if not match:
+    target_words = _chapter_target_words(draft_path)
+    current_words = max(len(text.split()), 1)
+
+    for label, compiled, chapter_limit in _book_banned_patterns(book_root):
+        matches = list(compiled.finditer(text))
+        if not matches:
             continue
-        line_num = _line_for_offset(text, match.start())
-        findings.append(
-            Finding(
-                severity=SEVERITY_BLOCK,
-                category="book_rule_violation",
-                message=f"Banned phrase from book CLAUDE.md: '{label}'",
-                line=line_num,
+
+        if chapter_limit > 0:
+            scene_limit = _scaled_scene_limit(
+                chapter_limit, current_words, target_words
             )
-        )
+            if len(matches) <= scene_limit:
+                continue
+            line_num = _line_for_offset(text, matches[0].start())
+            occurrences = _format_occurrences(text, matches)
+            findings.append(
+                Finding(
+                    severity=SEVERITY_BLOCK,
+                    category="book_rule_violation",
+                    message=(
+                        f"phrase '{label}' appears {len(matches)} times "
+                        f"(scaled scene limit: {scene_limit}; chapter cap: "
+                        f"{chapter_limit}; current draft: {current_words}w "
+                        f"of {target_words}w target). Cut at least "
+                        f"{len(matches) - scene_limit}. {occurrences}"
+                    ),
+                    line=line_num,
+                )
+            )
+        else:
+            match = matches[0]
+            line_num = _line_for_offset(text, match.start())
+            findings.append(
+                Finding(
+                    severity=SEVERITY_BLOCK,
+                    category="book_rule_violation",
+                    message=f"Banned phrase from book CLAUDE.md: '{label}'",
+                    line=line_num,
+                )
+            )
     return findings
 
 
@@ -432,7 +579,7 @@ def validate_chapter(file_path: str) -> list[Finding]:
     findings: list[Finding] = []
     book_root = _find_book_root(path)
     if book_root is not None:
-        findings.extend(_scan_book_banlist(text, book_root))
+        findings.extend(_scan_book_banlist(text, book_root, path))
     findings.extend(_scan_meta_narrative(text))
     findings.extend(_scan_ai_tells(text))
     findings.extend(_scan_sentence_variance(text))

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -33,6 +33,25 @@ def _write_draft(book: Path, body: str, chapter: str = "01-intro") -> Path:
     return draft
 
 
+def _write_chapter_readme(
+    book: Path,
+    target_words: int | str,
+    chapter: str = "01-intro",
+) -> Path:
+    """Write a chapter README with a Target Words cell. Accepts int (3200)
+    or string ("~3,200") to test parser tolerance."""
+    readme = book / "chapters" / chapter / "README.md"
+    body = (
+        f"# Chapter\n\n"
+        f"## Overview\n"
+        f"| Field | Value |\n"
+        f"|-------|-------|\n"
+        f"| Target Words | {target_words} |\n"
+    )
+    readme.write_text(body, encoding="utf-8")
+    return readme
+
+
 # ---------------------------------------------------------------------------
 # validate_chapter() — pure-function behavior
 # ---------------------------------------------------------------------------
@@ -360,6 +379,264 @@ class TestValidateChapter:
         findings = vc.validate_chapter(str(draft))
         blocking = [f for f in findings if f.severity == vc.SEVERITY_BLOCK]
         assert blocking == []
+
+
+# ---------------------------------------------------------------------------
+# Per-chapter limit parsing
+# ---------------------------------------------------------------------------
+
+
+class TestExtractChapterLimit:
+    def test_no_limit_returns_zero(self):
+        assert vc._extract_chapter_limit("Avoid `clocked` as a verb") == 0
+
+    def test_max_n_per_chapter(self):
+        rule = "Limit `kind of X that Y` — max 3 per chapter."
+        assert vc._extract_chapter_limit(rule) == 3
+
+    def test_max_n_per_chapter_german(self):
+        rule = "Limit `kind of X that Y` — max 3 per kapitel."
+        assert vc._extract_chapter_limit(rule) == 3
+
+    def test_max_range_takes_upper_bound(self):
+        rule = (
+            "Limit the `specific kind of X that Y` construction — "
+            "max 2-3 per chapter."
+        )
+        assert vc._extract_chapter_limit(rule) == 3
+
+    def test_maximum_word(self):
+        rule = "Use `felt like` sparingly — maximum 2 per chapter."
+        assert vc._extract_chapter_limit(rule) == 2
+
+    def test_limit_to_n_per_chapter(self):
+        rule = "Limit to 4 per chapter for the construction `the way`."
+        assert vc._extract_chapter_limit(rule) == 4
+
+    def test_per_book_limit_is_not_per_chapter(self):
+        rule = "Max one use of `opened his mouth. Closed it.` per book."
+        assert vc._extract_chapter_limit(rule) == 0
+
+    def test_max_of_n_per_chapter(self):
+        rule = "Avoid `pulsed` — max of 2 per chapter."
+        assert vc._extract_chapter_limit(rule) == 2
+
+
+# ---------------------------------------------------------------------------
+# Chapter target-words loader
+# ---------------------------------------------------------------------------
+
+
+class TestChapterTargetWords:
+    def test_default_when_no_readme(self, tmp_path):
+        book = _make_book(tmp_path)
+        draft = _write_draft(book, "# Chapter 1\n")
+        assert vc._chapter_target_words(draft) == vc.DEFAULT_CHAPTER_TARGET_WORDS
+
+    def test_default_when_readme_has_no_target(self, tmp_path):
+        book = _make_book(tmp_path)
+        draft = _write_draft(book, "# Chapter 1\n")
+        readme = book / "chapters" / "01-intro" / "README.md"
+        readme.write_text("# Chapter 1\n\nNo overview.\n", encoding="utf-8")
+        assert vc._chapter_target_words(draft) == vc.DEFAULT_CHAPTER_TARGET_WORDS
+
+    def test_parses_simple_integer(self, tmp_path):
+        book = _make_book(tmp_path)
+        draft = _write_draft(book, "# Chapter 1\n")
+        _write_chapter_readme(book, 2500)
+        assert vc._chapter_target_words(draft) == 2500
+
+    def test_parses_tilde_and_comma(self, tmp_path):
+        book = _make_book(tmp_path)
+        draft = _write_draft(book, "# Chapter 1\n")
+        _write_chapter_readme(book, "~3,200")
+        assert vc._chapter_target_words(draft) == 3200
+
+    def test_parses_dot_thousand_separator(self, tmp_path):
+        book = _make_book(tmp_path)
+        draft = _write_draft(book, "# Chapter 1\n")
+        _write_chapter_readme(book, "3.200")
+        assert vc._chapter_target_words(draft) == 3200
+
+    def test_zero_falls_back_to_default(self, tmp_path):
+        book = _make_book(tmp_path)
+        draft = _write_draft(book, "# Chapter 1\n")
+        _write_chapter_readme(book, 0)
+        assert vc._chapter_target_words(draft) == vc.DEFAULT_CHAPTER_TARGET_WORDS
+
+
+# ---------------------------------------------------------------------------
+# Scaled per-scene limit math
+# ---------------------------------------------------------------------------
+
+
+class TestScaledSceneLimit:
+    def test_zero_chapter_limit_returns_zero(self):
+        assert vc._scaled_scene_limit(0, 900, 3200) == 0
+
+    def test_900_of_3200_with_chapter_3_floors_at_one(self):
+        # 3 * 900/3200 = 0.84 → ceil → 1
+        assert vc._scaled_scene_limit(3, 900, 3200) == 1
+
+    def test_1800_of_3200_with_chapter_3_returns_two(self):
+        # 3 * 1800/3200 = 1.69 → ceil → 2
+        assert vc._scaled_scene_limit(3, 1800, 3200) == 2
+
+    def test_full_chapter_returns_full_limit(self):
+        assert vc._scaled_scene_limit(3, 3200, 3200) == 3
+
+    def test_over_target_caps_at_chapter_limit(self):
+        # Going over the word target does not unlock more banned-phrase
+        # budget. The chapter cap is a hard ceiling.
+        assert vc._scaled_scene_limit(3, 4000, 3200) == 3
+        assert vc._scaled_scene_limit(3, 6400, 3200) == 3
+
+    def test_zero_target_returns_chapter_limit(self):
+        assert vc._scaled_scene_limit(3, 900, 0) == 3
+
+
+# ---------------------------------------------------------------------------
+# Per-scene counter integration
+# ---------------------------------------------------------------------------
+
+
+class TestPerSceneCounter:
+    """End-to-end tests: rule with limit + draft with hits → block when
+    the scaled scene budget is exceeded, allow otherwise."""
+
+    def _book_with_limit_rule(self, tmp_path: Path) -> Path:
+        # Backtick contains regex metacharacters (\w), so it compiles as a
+        # regex — matches "kind of corridor that", "kind of silence that",
+        # etc.
+        return _make_book(
+            tmp_path,
+            claudemd_body=(
+                "# Book\n\n"
+                "## Rules\n"
+                "- Limit the `kind of \\w+ that` construction — "
+                "max 3 per chapter.\n"
+            ),
+        )
+
+    def test_no_limit_pattern_still_blocks_on_first_hit(self, tmp_path):
+        """Backwards compat: rules without 'max N per chapter' keep
+        block-on-first-hit behavior."""
+        book = _make_book(
+            tmp_path,
+            claudemd_body=(
+                "# Book\n\n## Rules\n- Avoid `clocked` as a verb.\n"
+            ),
+        )
+        draft = _write_draft(
+            book,
+            "# Chapter 1\n\n"
+            + (
+                "Theo clocked the room. The bag slid off the bench. "
+                "He counted three breaths. " * 5
+            ),
+        )
+        findings = vc.validate_chapter(str(draft))
+        blocking = [f for f in findings if f.severity == vc.SEVERITY_BLOCK]
+        assert any(f.category == "book_rule_violation" for f in blocking)
+
+    def test_one_hit_in_short_scene_passes(self, tmp_path):
+        """900 words toward 3200 target, max 3 per chapter → scaled to 1.
+        One hit is allowed."""
+        book = self._book_with_limit_rule(tmp_path)
+        _write_chapter_readme(book, 3200)
+        # Build ~900-word draft with exactly 1 banned hit.
+        body = "# Chapter 1\n\n"
+        body += "She walked the kind of corridor that smelled like rain. "
+        body += "The door was open. She walked inside. " * 175
+        draft = _write_draft(book, body)
+        findings = vc.validate_chapter(str(draft))
+        violations = [
+            f for f in findings if f.category == "book_rule_violation"
+        ]
+        assert violations == []
+
+    def test_five_hits_in_short_scene_blocks(self, tmp_path):
+        """Beta-feedback case: 5 hits in 900-word scene must block."""
+        book = self._book_with_limit_rule(tmp_path)
+        _write_chapter_readme(book, 3200)
+        body = "# Chapter 1\n\n"
+        body += (
+            "She walked the kind of corridor that smelled like rain. "
+            "He noticed the kind of silence that follows a slam. "
+            "The lamp threw the kind of yellow that makes you tired. "
+            "The book smelled the kind of musty that only old paper has. "
+            "She turned the kind of slow that means thinking. "
+        )
+        # Pad to reach roughly 900 words.
+        body += "The room was warm. The kettle had cooled. " * 175
+        draft = _write_draft(book, body)
+        findings = vc.validate_chapter(str(draft))
+        violations = [
+            f for f in findings if f.category == "book_rule_violation"
+        ]
+        assert len(violations) >= 1
+        msg = violations[0].message
+        assert "5 times" in msg or "appears 5" in msg
+        assert "Cut at least" in msg
+
+    def test_three_hits_at_full_chapter_passes(self, tmp_path):
+        """At full chapter target (3200 words), the per-chapter cap of 3
+        applies directly. Three hits is the limit, not a violation."""
+        book = self._book_with_limit_rule(tmp_path)
+        _write_chapter_readme(book, 3200)
+        body = "# Chapter 1\n\n"
+        body += (
+            "She walked the kind of corridor that smelled like rain. "
+            "He noticed the kind of silence that follows a slam. "
+            "The lamp threw the kind of yellow that makes you tired. "
+        )
+        # Fill to ~3200 words.
+        body += "The room was warm. The kettle had cooled. " * 600
+        draft = _write_draft(book, body)
+        findings = vc.validate_chapter(str(draft))
+        violations = [
+            f for f in findings if f.category == "book_rule_violation"
+        ]
+        assert violations == []
+
+    def test_four_hits_at_full_chapter_blocks(self, tmp_path):
+        book = self._book_with_limit_rule(tmp_path)
+        _write_chapter_readme(book, 3200)
+        body = "# Chapter 1\n\n"
+        body += (
+            "She walked the kind of corridor that smelled like rain. "
+            "He noticed the kind of silence that follows a slam. "
+            "The lamp threw the kind of yellow that makes you tired. "
+            "The book smelled the kind of musty that old paper has. "
+        )
+        body += "The room was warm. The kettle had cooled. " * 600
+        draft = _write_draft(book, body)
+        findings = vc.validate_chapter(str(draft))
+        violations = [
+            f for f in findings if f.category == "book_rule_violation"
+        ]
+        assert len(violations) >= 1
+
+    def test_message_includes_occurrence_lines(self, tmp_path):
+        """Block message should list line numbers + snippets so the user
+        sees exactly which hits to cut."""
+        book = self._book_with_limit_rule(tmp_path)
+        _write_chapter_readme(book, 3200)
+        body = "# Chapter 1\n\n"
+        body += "She walked the kind of corridor that smelled like rain.\n\n"
+        body += "He noticed the kind of silence that follows a slam.\n\n"
+        body += "The lamp threw the kind of yellow that makes you tired.\n\n"
+        body += "The book smelled the kind of musty that old paper has.\n\n"
+        body += "The room was warm. The kettle had cooled. " * 175
+        draft = _write_draft(book, body)
+        findings = vc.validate_chapter(str(draft))
+        violations = [
+            f for f in findings if f.category == "book_rule_violation"
+        ]
+        assert violations, "expected at least one violation"
+        msg = violations[0].message
+        assert "line 3" in msg
+        assert "line 5" in msg or "line 7" in msg
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Beta-feedback case: a per-book CLAUDE.md rule that says *"max 2-3 per chapter"* caps structural tics at the chapter level. But in scene-by-scene writing mode (~900 words per scene), a single scene can have 5 hits while the chapter total still looks fine — and the previous hook blocked on the first hit regardless of any declared limit, forcing every rule to be all-or-nothing.

This change introduces a **scaled per-scene budget** for rules that declare a chapter cap.

## How the scaling works

Given a rule:

```markdown
- Limit the \`kind of \\w+ that\` construction — max 3 per chapter.
```

…and a chapter README that declares:

```markdown
| Target Words | ~3,200 |
```

The hook computes:

| Current draft size | Allowed hits | Reason |
|---|---|---|
| 900 words | 1 | ceil(3 × 900/3200) = ceil(0.84) = 1 |
| 1,800 words | 2 | ceil(3 × 1800/3200) = ceil(1.69) = 2 |
| 3,200 words | 3 | full chapter, full cap |
| 4,000 words | 3 | over-target chapters do **not** unlock more budget |

Floor 1 (even at 100 words you get one). Cap chapter_limit (no inflation past the cap).

When the count exceeds the scaled budget, the block message names the count, the budget, the current/target word ratio, the cut-by-N hint, and up to 5 line-numbered occurrences:

```
[BLOCK] draft.md line 3: phrase 'kind of \\w+ that' appears 5 times
  (scaled scene limit: 1; chapter cap: 3; current draft: 904w of 3200w
  target). Cut at least 4. line 3: …She walked the kind of corridor
  that smelled…; line 5: …He noticed the kind of silence that follows…;
  line 7: …The lamp threw the kind of yellow that…; line 9: …The book
  smelled the kind of musty that…; line 11: …She turned the kind of
  slow that means…
```

## Backwards compat

Rules **without** a per-chapter declaration keep block-on-first-hit behavior. The new logic only kicks in when the rule body contains \`max N per chapter\` (or its variants — see test list).

## Limit-phrasing parser

Recognized:
- \`max N per chapter\` / \`max N per kapitel\`
- \`max N-M per chapter\` (upper bound used)
- \`maximum N per chapter\`
- \`max of N per chapter\`
- \`limit to N per chapter\`

**Not** recognized (intentionally — different semantics):
- \`max N per book\` — would need cross-chapter tracking, out of scope here

## For Blood & Binary specifically

Rule 2 (\`Limit the \\\`specific kind of X that Y\\\` construction — max 2-3 per chapter\`) automatically picks up the new scaling on next write — no edit needed. The pattern was already in backticks (after the migration in PR #88) and the limit phrase was already in the rule body.

Other rules without a limit phrase continue blocking on first hit.

## Test plan

- [x] \`pytest tests/test_hooks.py\` — 65 passed (was 39; +26 new)
- [x] \`pytest\` (full suite) — 347 passed
- [x] \`ruff check hooks/ tests/ tools/\` — clean
- [x] Limit-parser coverage: 8 phrasing variants
- [x] Target-words loader: 5 README cases
- [x] Scaled-limit math: 5 boundary cases
- [x] End-to-end: backwards-compat path, 1-hit-passes, 5-hits-blocks, 3-hits-at-full-chapter-passes, 4-hits-at-full-chapter-blocks, message-includes-line-numbers
- [x] **Manual smoke**: write a Blood & Binary scene at ~900 words with 5 \`kind of X that\` hits and confirm the hook surfaces the cut hint with line numbers

## Files

- \`hooks/validate_chapter.py\` — \`_extract_chapter_limit\`, \`_chapter_target_words\`, \`_scaled_scene_limit\`, refactored \`_scan_book_banlist\` and \`_book_banned_patterns\`, \`_format_occurrences\`
- \`tests/test_hooks.py\` — 26 new tests across 4 new test classes (\`TestExtractChapterLimit\`, \`TestChapterTargetWords\`, \`TestScaledSceneLimit\`, \`TestPerSceneCounter\`)

Closes #71
Refs #69, #70