### PR TITLE
feat(linter): unified banned-phrase hook (author vocab + global anti-AI)

### DIFF
--- a/hooks/validate_chapter.py
+++ b/hooks/validate_chapter.py
@@ -45,18 +45,15 @@ DEFAULT_MODE = "strict"
 # Tools whose output should be inspected. Anything else is ignored.
 WATCHED_TOOLS = frozenset({"Write", "Edit", "MultiEdit"})
 
-# AI-tell words that mark generic LLM prose. Currently warn-only — promotion
-# to block-severity is handled per-book via the CLAUDE.md banlist (see #74).
-AI_TELL_WORDS: tuple[str, ...] = (
+# Fallback AI-tell list — used only when ``reference/craft/anti-ai-patterns.md``
+# cannot be parsed. The loader in ``tools.banlist_loader`` is the canonical
+# source. Severity stays warn for both paths to preserve #70's behavior.
+_AI_TELL_FALLBACK: tuple[str, ...] = (
     "delve", "tapestry", "nuanced", "vibrant", "embark", "resonate",
     "pivotal", "multifaceted", "realm", "testament", "intricate",
     "myriad", "unprecedented", "foster", "beacon", "juxtaposition",
     "paradigm", "synergy", "interplay", "ever-evolving", "navigate",
-    "uncover", "aforementioned", "groundbreaking", "spearhead",
-    "leverage", "underpin", "underscore", "overarching", "holistic",
-    "robust", "streamline", "cutting-edge", "utilize", "facilitate",
-    "endeavor", "comprehensive", "furthermore", "moreover",
-    "bustling", "piercing", "riveting", "captivating", "mesmerizing",
+    "uncover",
 )
 
 
@@ -440,9 +437,43 @@ def _line_for_offset(text: str, offset: int) -> int:
 
 
 def _scan_ai_tells(text: str) -> list[Finding]:
+    """Warn-severity scan against the curated global AI-tell vocabulary.
+
+    Source: ``reference/craft/anti-ai-patterns.md`` via
+    ``tools.banlist_loader.load_global_ai_tells``. Falls back to the
+    local ``_AI_TELL_FALLBACK`` list if the loader cannot read the file.
+    """
     findings: list[Finding] = []
+    try:
+        from tools.banlist_loader import load_global_ai_tells
+
+        patterns = load_global_ai_tells(PLUGIN_ROOT)
+    except Exception:
+        patterns = []
+
+    if patterns:
+        for banned in patterns:
+            matches = list(banned.pattern.finditer(text))
+            if not matches:
+                continue
+            line_num = _line_for_offset(text, matches[0].start())
+            suffix = "s" if len(matches) > 1 else ""
+            findings.append(
+                Finding(
+                    severity=SEVERITY_WARN,
+                    category="ai_tell",
+                    message=(
+                        f"AI-tell '{banned.label}' found "
+                        f"({len(matches)} occurrence{suffix})"
+                    ),
+                    line=line_num,
+                )
+            )
+        return findings
+
+    # Fallback path — loader failed or file missing.
     text_lower = text.lower()
-    for word in AI_TELL_WORDS:
+    for word in _AI_TELL_FALLBACK:
         pattern = rf"\b{re.escape(word)}\b"
         matches = list(re.finditer(pattern, text_lower))
         if not matches:
@@ -455,6 +486,47 @@ def _scan_ai_tells(text: str) -> list[Finding]:
                 category="ai_tell",
                 message=(
                     f"AI-tell word '{word}' found ({len(matches)} occurrence{suffix})"
+                ),
+                line=line_num,
+            )
+        )
+    return findings
+
+
+def _scan_author_banlist(text: str, book_root: Path) -> list[Finding]:
+    """Block-severity scan against the active book's author vocabulary.md.
+
+    Resolves the author from the book's CLAUDE.md ``Book Facts`` section,
+    loads ``~/.storyforge/authors/{slug}/vocabulary.md`` via the
+    banlist loader, and emits one ``BLOCK`` finding per matched phrase.
+    Author-vocab bans express the user's voice intent and are
+    non-negotiable.
+    """
+    try:
+        from tools.banlist_loader import author_slug_from_book, load_author_vocab
+    except Exception:
+        return []
+
+    slug = author_slug_from_book(book_root)
+    if not slug:
+        return []
+    patterns = load_author_vocab(slug)
+    if not patterns:
+        return []
+
+    findings: list[Finding] = []
+    for banned in patterns:
+        match = banned.pattern.search(text)
+        if not match:
+            continue
+        line_num = _line_for_offset(text, match.start())
+        findings.append(
+            Finding(
+                severity=SEVERITY_BLOCK,
+                category="author_vocab_violation",
+                message=(
+                    f"Banned by author voice ({banned.source}): "
+                    f"'{banned.label}'"
                 ),
                 line=line_num,
             )
@@ -580,6 +652,7 @@ def validate_chapter(file_path: str) -> list[Finding]:
     book_root = _find_book_root(path)
     if book_root is not None:
         findings.extend(_scan_book_banlist(text, book_root, path))
+        findings.extend(_scan_author_banlist(text, book_root))
     findings.extend(_scan_meta_narrative(text))
     findings.extend(_scan_ai_tells(text))
     findings.extend(_scan_sentence_variance(text))

--- a/tests/test_banlist_loader.py
+++ b/tests/test_banlist_loader.py
@@ -1,0 +1,279 @@
+"""Tests for ``tools.banlist_loader``.
+
+Covers the three loaders (author-vocab, global anti-AI tells,
+author-slug-from-book) and the BannedPattern dataclass.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.banlist_loader import (
+    SEVERITY_BLOCK,
+    SEVERITY_WARN,
+    author_slug_from_book,
+    load_author_vocab,
+    load_global_ai_tells,
+)
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# author_slug_from_book
+# ---------------------------------------------------------------------------
+
+
+def _make_book_with_author(tmp_path: Path, author_line: str | None) -> Path:
+    book = tmp_path / "test-book"
+    book.mkdir()
+    body = "# Test Book\n\n## Book Facts\n\n"
+    if author_line:
+        body += f"{author_line}\n"
+    body += "- **Genre:** test\n"
+    (book / "CLAUDE.md").write_text(body, encoding="utf-8")
+    return book
+
+
+class TestAuthorSlugFromBook:
+    def test_basic_author_line(self, tmp_path):
+        book = _make_book_with_author(tmp_path, "- **Author:** Ethan Cole")
+        assert author_slug_from_book(book) == "ethan-cole"
+
+    def test_author_with_parenthetical(self, tmp_path):
+        book = _make_book_with_author(
+            tmp_path, "- **Author:** Ethan Cole (Eddings-humor with Twilight-stakes)"
+        )
+        assert author_slug_from_book(book) == "ethan-cole"
+
+    def test_no_author_line(self, tmp_path):
+        book = _make_book_with_author(tmp_path, None)
+        assert author_slug_from_book(book) is None
+
+    def test_no_claudemd(self, tmp_path):
+        book = tmp_path / "empty-book"
+        book.mkdir()
+        assert author_slug_from_book(book) is None
+
+    def test_multi_word_name(self, tmp_path):
+        book = _make_book_with_author(tmp_path, "- **Author:** Ursula K. Le Guin")
+        assert author_slug_from_book(book) == "ursula-k-le-guin"
+
+
+# ---------------------------------------------------------------------------
+# load_author_vocab
+# ---------------------------------------------------------------------------
+
+
+def _make_vocab(
+    storyforge_home: Path, author_slug: str, body: str
+) -> Path:
+    """Write a vocabulary.md under a fake storyforge home."""
+    vocab_dir = storyforge_home / "authors" / author_slug
+    vocab_dir.mkdir(parents=True, exist_ok=True)
+    vocab_path = vocab_dir / "vocabulary.md"
+    vocab_path.write_text(body, encoding="utf-8")
+    return vocab_path
+
+
+class TestLoadAuthorVocab:
+    def test_missing_author_returns_empty(self, tmp_path):
+        patterns = load_author_vocab("nonexistent", storyforge_home=tmp_path)
+        assert patterns == []
+
+    def test_parses_absolutely_forbidden(self, tmp_path):
+        body = (
+            "# Vocabulary Profile\n\n"
+            "## Banned Words — AI Tells\n\n"
+            "### Absolutely Forbidden\n"
+            "- delve\n"
+            "- tapestry\n"
+            "- vibrant\n"
+        )
+        _make_vocab(tmp_path, "alice", body)
+        patterns = load_author_vocab("alice", storyforge_home=tmp_path)
+        labels = [p.label for p in patterns]
+        assert "delve" in labels
+        assert "tapestry" in labels
+        assert "vibrant" in labels
+        assert all(p.severity == SEVERITY_BLOCK for p in patterns)
+        assert all("author-vocab" in p.source for p in patterns)
+
+    def test_splits_aliases_on_slash(self, tmp_path):
+        body = (
+            "## Banned Words\n\n"
+            "### Absolutely Forbidden\n"
+            "- delve / delve into\n"
+            "- embark / embark on\n"
+        )
+        _make_vocab(tmp_path, "bob", body)
+        patterns = load_author_vocab("bob", storyforge_home=tmp_path)
+        labels = [p.label for p in patterns]
+        assert "delve" in labels
+        assert "delve into" in labels
+        assert "embark" in labels
+        assert "embark on" in labels
+
+    def test_strips_parenthetical_clarifications(self, tmp_path):
+        body = (
+            "## Banned Words\n\n"
+            "### Absolutely Forbidden\n"
+            "- tapestry (metaphorical)\n"
+            "- landscape (metaphorical)\n"
+        )
+        _make_vocab(tmp_path, "carol", body)
+        patterns = load_author_vocab("carol", storyforge_home=tmp_path)
+        labels = [p.label for p in patterns]
+        assert "tapestry" in labels
+        assert "landscape" in labels
+        # Original parenthetical not present
+        assert not any("metaphorical" in label for label in labels)
+
+    def test_loads_all_four_forbidden_sections(self, tmp_path):
+        body = (
+            "## Banned\n\n"
+            "### Absolutely Forbidden\n- delve\n\n"
+            "### Forbidden Hedging Phrases\n- it's worth noting that\n\n"
+            "### Forbidden Emotional Tells\n- her heart raced\n\n"
+            "### Forbidden Structural Patterns\n- in essence\n"
+        )
+        _make_vocab(tmp_path, "dora", body)
+        patterns = load_author_vocab("dora", storyforge_home=tmp_path)
+        labels = [p.label for p in patterns]
+        assert "delve" in labels
+        assert "it's worth noting that" in labels
+        assert "her heart raced" in labels
+        assert "in essence" in labels
+
+    def test_dedupes_across_sections(self, tmp_path):
+        body = (
+            "## Banned\n\n"
+            "### Absolutely Forbidden\n- delve\n\n"
+            "### Forbidden Hedging Phrases\n- delve\n"
+        )
+        _make_vocab(tmp_path, "eve", body)
+        patterns = load_author_vocab("eve", storyforge_home=tmp_path)
+        delves = [p for p in patterns if p.label == "delve"]
+        assert len(delves) == 1
+
+    def test_skips_short_entries(self, tmp_path):
+        body = (
+            "## Banned\n\n"
+            "### Absolutely Forbidden\n"
+            "- a\n"
+            "- delve\n"
+        )
+        _make_vocab(tmp_path, "frank", body)
+        patterns = load_author_vocab("frank", storyforge_home=tmp_path)
+        labels = [p.label for p in patterns]
+        assert "delve" in labels
+        assert "a" not in labels
+
+    def test_pattern_catches_inflections_for_single_word(self, tmp_path):
+        body = "## Banned\n\n### Absolutely Forbidden\n- delve\n"
+        _make_vocab(tmp_path, "gina", body)
+        patterns = load_author_vocab("gina", storyforge_home=tmp_path)
+        delve = next(p for p in patterns if p.label == "delve")
+        # Catches inflections (delved, delves, delving)
+        assert delve.pattern.search("she delved into the box") is not None
+        assert delve.pattern.search("she delves into") is not None
+        assert delve.pattern.search("delving deep") is not None
+        # Bare word still matches
+        assert delve.pattern.search("she went to delve into") is not None
+        # Mid-word matches NOT triggered (leading word-boundary)
+        assert delve.pattern.search("the redelve was misnamed") is None
+        # Case-insensitive
+        assert delve.pattern.search("DELVE!") is not None
+        # Unrelated word does not match
+        assert delve.pattern.search("the deliverer arrived") is None
+
+    def test_multi_word_phrase_uses_full_boundary(self, tmp_path):
+        body = "## Banned\n\n### Forbidden Hedging Phrases\n- it's worth noting that\n"
+        _make_vocab(tmp_path, "henrietta", body)
+        patterns = load_author_vocab("henrietta", storyforge_home=tmp_path)
+        phrase = next(
+            p for p in patterns if p.label == "it's worth noting that"
+        )
+        assert phrase.pattern.search(
+            "Now it's worth noting that we tried."
+        ) is not None
+        # Same phrase mid-sentence still works
+        assert phrase.pattern.search(
+            "Look — it's worth noting that this fails."
+        ) is not None
+
+    def test_higher_heading_terminates_section(self, tmp_path):
+        """A `##`-level heading after a `###` Forbidden block stops parsing."""
+        body = (
+            "## Banned Words\n\n"
+            "### Absolutely Forbidden\n- delve\n\n"
+            "## Preferred Vocabulary\n\n"
+            "- said\n- went\n"
+        )
+        _make_vocab(tmp_path, "henry", body)
+        patterns = load_author_vocab("henry", storyforge_home=tmp_path)
+        labels = [p.label for p in patterns]
+        assert "delve" in labels
+        # 'said' / 'went' must NOT be banned — they live under Preferred Vocabulary.
+        assert "said" not in labels
+        assert "went" not in labels
+
+
+# ---------------------------------------------------------------------------
+# load_global_ai_tells
+# ---------------------------------------------------------------------------
+
+
+class TestLoadGlobalAITells:
+    def test_loads_from_real_anti_ai_patterns_md(self):
+        """Sanity check against the actual repo file. Should yield > 30
+        tells (the curated list is much longer)."""
+        patterns = load_global_ai_tells(PLUGIN_ROOT)
+        assert len(patterns) >= 30
+        labels = [p.label.lower() for p in patterns]
+        # Spot-check a few high-confidence entries
+        assert "delve" in labels
+        assert "tapestry" in labels
+        assert "vibrant" in labels
+        assert all(p.severity == SEVERITY_WARN for p in patterns)
+        assert all(p.source == "global anti-ai" for p in patterns)
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        patterns = load_global_ai_tells(tmp_path)
+        assert patterns == []
+
+    def test_parses_synthetic_section(self, tmp_path):
+        # Simulate a minimal anti-ai-patterns.md
+        ref = tmp_path / "reference" / "craft"
+        ref.mkdir(parents=True)
+        (ref / "anti-ai-patterns.md").write_text(
+            "# Anti-AI Patterns\n\n"
+            "## 1. Known AI Tells — Vocabulary\n\n"
+            "### Heavily Flagged Words and Phrases (AI Tell Indicators)\n\n"
+            "1. **Delve** / **Delve into** — One of the most notorious AI tells.\n"
+            "2. **Tapestry** (metaphorical) — Almost never used by humans.\n"
+            "3. **Vibrant** — Favored descriptor for colors.\n"
+            "\n## 2. Other Section\n\n- something irrelevant\n",
+            encoding="utf-8",
+        )
+        patterns = load_global_ai_tells(tmp_path)
+        labels = [p.label for p in patterns]
+        assert "Delve" in labels
+        assert "Delve into" in labels
+        assert "Tapestry" in labels
+        assert "Vibrant" in labels
+        # Section after `## 2.` must not be picked up.
+        assert "something irrelevant" not in labels
+
+    def test_explanation_truncated_into_reason(self, tmp_path):
+        ref = tmp_path / "reference" / "craft"
+        ref.mkdir(parents=True)
+        long_expl = "Lorem ipsum " * 20
+        (ref / "anti-ai-patterns.md").write_text(
+            "### Heavily Flagged Words and Phrases (X)\n\n"
+            f"1. **Delve** — {long_expl}\n",
+            encoding="utf-8",
+        )
+        patterns = load_global_ai_tells(tmp_path)
+        delve = next(p for p in patterns if p.label == "Delve")
+        assert len(delve.reason) <= 120

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from hooks import validate_chapter as vc
 from hooks.validate_character import validate_character
+from tools import banlist_loader
 
 
 # ---------------------------------------------------------------------------
@@ -25,6 +26,21 @@ def _make_book(tmp_path: Path, claudemd_body: str | None = None) -> Path:
     if claudemd_body is not None:
         (book / "CLAUDE.md").write_text(claudemd_body, encoding="utf-8")
     return book
+
+
+def _install_author_vocab(
+    tmp_path: Path, author_slug: str, banned_words: list[str]
+) -> Path:
+    """Place a fake ~/.storyforge/authors/{slug}/vocabulary.md and patch
+    the loader to read from this temp home for the duration of the test."""
+    home = tmp_path / "_storyforge_home"
+    vocab_dir = home / "authors" / author_slug
+    vocab_dir.mkdir(parents=True)
+    body = "## Banned Words\n\n### Absolutely Forbidden\n"
+    for w in banned_words:
+        body += f"- {w}\n"
+    (vocab_dir / "vocabulary.md").write_text(body, encoding="utf-8")
+    return home
 
 
 def _write_draft(book: Path, body: str, chapter: str = "01-intro") -> Path:
@@ -379,6 +395,178 @@ class TestValidateChapter:
         findings = vc.validate_chapter(str(draft))
         blocking = [f for f in findings if f.severity == vc.SEVERITY_BLOCK]
         assert blocking == []
+
+
+# ---------------------------------------------------------------------------
+# Author vocabulary banlist (block-severity)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthorVocabBanlist:
+    """Verify that words listed in ~/.storyforge/authors/{slug}/vocabulary.md
+    block writes when found in prose."""
+
+    def _patch_storyforge_home(self, monkeypatch, fake_home: Path) -> None:
+        """Patch Path.home() so the loader reads from fake_home."""
+        monkeypatch.setattr(
+            banlist_loader,
+            "_author_vocab_path",
+            lambda slug, storyforge_home=None: (
+                fake_home / "authors" / slug / "vocabulary.md"
+            ),
+        )
+
+    def test_author_vocab_word_blocks_write(self, tmp_path, monkeypatch):
+        book = _make_book(
+            tmp_path,
+            claudemd_body=(
+                "# Book\n\n## Book Facts\n\n- **Author:** Alice Author\n"
+            ),
+        )
+        home = _install_author_vocab(
+            tmp_path, "alice-author", ["delve", "tapestry"]
+        )
+        self._patch_storyforge_home(monkeypatch, home)
+
+        draft = _write_draft(
+            book,
+            "# Chapter 1\n\n"
+            + (
+                "She delved into the tapestry of memory. The room was warm. "
+                "She had not slept. " * 5
+            ),
+        )
+        findings = vc.validate_chapter(str(draft))
+        author_blocks = [
+            f for f in findings if f.category == "author_vocab_violation"
+        ]
+        assert len(author_blocks) >= 2
+        assert all(f.severity == vc.SEVERITY_BLOCK for f in author_blocks)
+        labels = " ".join(f.message for f in author_blocks)
+        assert "delve" in labels.lower() or "tapestry" in labels.lower()
+
+    def test_author_vocab_clean_prose_passes(self, tmp_path, monkeypatch):
+        book = _make_book(
+            tmp_path,
+            claudemd_body=(
+                "# Book\n\n## Book Facts\n\n- **Author:** Alice Author\n"
+            ),
+        )
+        home = _install_author_vocab(tmp_path, "alice-author", ["delve"])
+        self._patch_storyforge_home(monkeypatch, home)
+
+        draft = _write_draft(
+            book,
+            "# Chapter 1\n\n"
+            + (
+                "She investigated the box. The room was warm. The kettle "
+                "had cooled. She had not slept. " * 5
+            ),
+        )
+        findings = vc.validate_chapter(str(draft))
+        author_blocks = [
+            f for f in findings if f.category == "author_vocab_violation"
+        ]
+        assert author_blocks == []
+
+    def test_no_author_in_book_skips_check(self, tmp_path, monkeypatch):
+        book = _make_book(
+            tmp_path,
+            claudemd_body="# Book\n\n## Book Facts\n\n- **Genre:** test\n",
+        )
+        # Even with vocab installed for "alice-author", the book does not
+        # name an author → skip.
+        home = _install_author_vocab(tmp_path, "alice-author", ["delve"])
+        self._patch_storyforge_home(monkeypatch, home)
+
+        draft = _write_draft(
+            book,
+            "# Chapter 1\n\n"
+            + (
+                "She delved into the tapestry. " * 30
+            ),
+        )
+        findings = vc.validate_chapter(str(draft))
+        author_blocks = [
+            f for f in findings if f.category == "author_vocab_violation"
+        ]
+        assert author_blocks == []
+
+    def test_author_without_vocab_file_does_not_error(
+        self, tmp_path, monkeypatch
+    ):
+        book = _make_book(
+            tmp_path,
+            claudemd_body=(
+                "# Book\n\n## Book Facts\n\n- **Author:** Bob Bookwright\n"
+            ),
+        )
+        # No vocab.md installed for bob-bookwright. Loader should return [].
+        home = tmp_path / "_storyforge_home"
+        (home / "authors" / "bob-bookwright").mkdir(parents=True)
+        self._patch_storyforge_home(monkeypatch, home)
+
+        draft = _write_draft(
+            book,
+            "# Chapter 1\n\n" + ("She delved into the tapestry. " * 30),
+        )
+        findings = vc.validate_chapter(str(draft))
+        author_blocks = [
+            f for f in findings if f.category == "author_vocab_violation"
+        ]
+        assert author_blocks == []
+
+    def test_block_message_attributes_source(self, tmp_path, monkeypatch):
+        book = _make_book(
+            tmp_path,
+            claudemd_body=(
+                "# Book\n\n## Book Facts\n\n- **Author:** Alice Author\n"
+            ),
+        )
+        home = _install_author_vocab(tmp_path, "alice-author", ["delve"])
+        self._patch_storyforge_home(monkeypatch, home)
+
+        draft = _write_draft(
+            book,
+            "# Chapter 1\n\n" + ("She delved into the box. " * 30),
+        )
+        findings = vc.validate_chapter(str(draft))
+        author_blocks = [
+            f for f in findings if f.category == "author_vocab_violation"
+        ]
+        assert author_blocks
+        assert "author voice" in author_blocks[0].message.lower()
+        assert "author-vocab" in author_blocks[0].message.lower()
+        assert "absolutely forbidden" in author_blocks[0].message.lower()
+
+
+# ---------------------------------------------------------------------------
+# Global AI-tells loaded from anti-ai-patterns.md
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalAITellsLoading:
+    """The hook now reads its AI-tells from
+    ``reference/craft/anti-ai-patterns.md`` via the loader, not from a
+    hardcoded list. Verify the wiring still produces warnings on the
+    previously-hardcoded set."""
+
+    def test_delve_still_produces_warn(self, tmp_path):
+        book = _make_book(tmp_path)
+        draft = _write_draft(
+            book,
+            "# Chapter 1\n\n"
+            + (
+                "She delved into the tapestry of vibrant memory. The room "
+                "was warm. The kettle had cooled. " * 5
+            ),
+        )
+        findings = vc.validate_chapter(str(draft))
+        ai_tells = [f for f in findings if f.category == "ai_tell"]
+        assert ai_tells
+        assert all(f.severity == vc.SEVERITY_WARN for f in ai_tells)
+        labels = " ".join(f.message.lower() for f in ai_tells)
+        assert "delve" in labels
 
 
 # ---------------------------------------------------------------------------

--- a/tools/banlist_loader.py
+++ b/tools/banlist_loader.py
@@ -1,0 +1,269 @@
+"""Unified loader for banned-phrase patterns.
+
+The PostToolUse hook (#70) needs to enforce three independent banlists:
+
+1. **Book-scoped** rules from the active book's ``CLAUDE.md`` (#70).
+2. **Author-scoped** banned-vocabulary from
+   ``~/.storyforge/authors/{slug}/vocabulary.md``. Surfaces an explicit
+   "this author never uses these words" list maintained per voice.
+3. **Globally curated** AI-tells from
+   ``reference/craft/anti-ai-patterns.md``. Default warn-severity so
+   merging this on top of an existing book does not break drafts.
+
+Each loader returns ``BannedPattern`` records with severity, source, and
+human-readable reason so the hook can produce attributed block messages.
+
+The module is dependency-free (stdlib only) so the hook can call it
+inline without additional setup.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+SEVERITY_BLOCK = "block"
+SEVERITY_WARN = "warn"
+
+
+@dataclass(frozen=True)
+class BannedPattern:
+    """A single banned phrase or regex that the hook can scan against."""
+
+    label: str  # human-readable display label
+    pattern: re.Pattern[str]  # compiled regex
+    severity: str  # SEVERITY_BLOCK | SEVERITY_WARN
+    source: str  # provenance shown in block message
+    reason: str = ""  # short explanation (truncated for display)
+    chapter_limit: int = 0  # 0 = block on first hit; >0 = scaled limit
+
+
+# ---------------------------------------------------------------------------
+# Author-vocabulary loader
+# ---------------------------------------------------------------------------
+
+# Section markers the loader treats as banned-phrase sources. Each is a
+# subsection (### heading) inside the ``## Banned Words`` block.
+_AUTHOR_BANNED_SECTION_RE = re.compile(
+    r"^###\s+(Absolutely\s+Forbidden|Forbidden\s+Hedging\s+Phrases|"
+    r"Forbidden\s+Emotional\s+Tells|Forbidden\s+Structural\s+Patterns)\s*$",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+_BOOK_AUTHOR_LINE_RE = re.compile(
+    r"^\s*-\s*\*\*Author:\*\*\s*(?P<name>[^\n(]+?)(?:\s*\(.*\))?\s*$",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+
+def _slugify(text: str) -> str:
+    """Local copy of ``tools.shared.paths.slugify`` to avoid a hard import
+    dependency from the hook (which adds plugin_root to sys.path lazily)."""
+    text = text.lower().strip()
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[\s_]+", "-", text)
+    text = re.sub(r"-+", "-", text)
+    return text.strip("-")
+
+
+def author_slug_from_book(book_root: Path) -> str | None:
+    """Extract the author slug from a book's ``CLAUDE.md`` Book Facts.
+
+    Looks for a line shaped like ``- **Author:** Ethan Cole (...)`` and
+    slugifies the display name. Returns ``None`` if the line is missing
+    or unparseable.
+    """
+    claudemd = book_root / "CLAUDE.md"
+    if not claudemd.is_file():
+        return None
+    try:
+        text = claudemd.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    match = _BOOK_AUTHOR_LINE_RE.search(text)
+    if not match:
+        return None
+    name = match.group("name").strip()
+    if not name:
+        return None
+    return _slugify(name)
+
+
+def _strip_parenthetical(text: str) -> str:
+    """Remove trailing parenthetical clarifications like '(metaphorical)'."""
+    return re.sub(r"\s*\([^)]+\)\s*", " ", text).strip()
+
+
+def _author_vocab_path(
+    author_slug: str, storyforge_home: Path | None = None
+) -> Path:
+    home = storyforge_home or (Path.home() / ".storyforge")
+    return home / "authors" / author_slug / "vocabulary.md"
+
+
+def load_author_vocab(
+    author_slug: str,
+    *,
+    storyforge_home: Path | None = None,
+) -> list[BannedPattern]:
+    """Load forbidden-word patterns from an author's ``vocabulary.md``.
+
+    Parses the four ``### Forbidden ...`` subsections, splits aliases on
+    `` / ``, strips parentheticals, and emits one ``BannedPattern`` per
+    unique cleaned phrase. Severity is always ``block`` — author-scoped
+    bans express the user's voice intent and are non-negotiable.
+    """
+    vocab_path = _author_vocab_path(author_slug, storyforge_home)
+    if not vocab_path.is_file():
+        return []
+    try:
+        text = vocab_path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+
+    patterns: list[BannedPattern] = []
+    seen: set[str] = set()
+
+    sections = list(_AUTHOR_BANNED_SECTION_RE.finditer(text))
+    for index, match in enumerate(sections):
+        section_name = re.sub(r"\s+", " ", match.group(1)).strip().title()
+        body_start = match.end()
+        body_end = (
+            sections[index + 1].start()
+            if index + 1 < len(sections)
+            else len(text)
+        )
+        # Stop early if we hit a higher-level (## or # only) heading.
+        higher_heading = re.search(
+            r"^##\s+\S", text[body_start:body_end], re.MULTILINE
+        )
+        if higher_heading:
+            body_end = body_start + higher_heading.start()
+
+        body = text[body_start:body_end]
+        for line in body.splitlines():
+            stripped = line.strip()
+            if not stripped.startswith("- "):
+                continue
+            entry = stripped[2:].strip()
+            if not entry:
+                continue
+            for raw_alias in entry.split(" / "):
+                cleaned = _strip_parenthetical(raw_alias).strip()
+                if len(cleaned) < 2:
+                    continue
+                key = cleaned.lower()
+                if key in seen:
+                    continue
+                seen.add(key)
+                pattern = _build_inflection_pattern(cleaned)
+                patterns.append(
+                    BannedPattern(
+                        label=cleaned,
+                        pattern=pattern,
+                        severity=SEVERITY_BLOCK,
+                        source=f"author-vocab ({section_name})",
+                        reason="banned for this author voice",
+                    )
+                )
+    return patterns
+
+
+def _build_inflection_pattern(text: str) -> re.Pattern[str]:
+    """Compile a regex that matches the phrase plus common inflections.
+
+    Strategy:
+
+    - Multi-word and hyphenated phrases get an exact ``\\b...\\b`` match.
+      They are usually idiomatic; matching inflections has too many edge
+      cases to be worth the complexity.
+    - Single words ending in a silent ``e`` (``delve``, ``embrace``) drop
+      the ``e`` from the stem so suffixes like ``-ed``, ``-ing``, ``-es``
+      land on the verbal root and still match (``delved``, ``delving``,
+      ``embraced``).
+    - Other single words use ``\\b{word}\\w*`` to catch the bare form
+      and any added suffix (``embark`` → ``embarked``, ``embarking``).
+
+    A leading ``\\b`` keeps ``redelve`` from matching ``delve``.
+    """
+    is_single_word = " " not in text and "-" not in text
+    if not is_single_word:
+        return re.compile(rf"\b{re.escape(text)}\b", re.IGNORECASE)
+
+    stem = text[:-1] if len(text) > 3 and text.endswith("e") else text
+    return re.compile(rf"\b{re.escape(stem)}\w*", re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# Global anti-AI tells (warn-severity)
+# ---------------------------------------------------------------------------
+
+_ANTI_AI_SECTION_RE = re.compile(
+    r"^###\s+Heavily\s+Flagged\s+Words\s+and\s+Phrases.*$",
+    re.MULTILINE | re.IGNORECASE,
+)
+_NUMBERED_ENTRY_RE = re.compile(r"^\d+\.\s+(?P<line>.+)$", re.MULTILINE)
+_BOLD_TERM_RE = re.compile(r"\*\*([^*]+)\*\*")
+_DASH_SPLIT_RE = re.compile(r"\s+[—-]\s+")
+
+
+def load_global_ai_tells(plugin_root: Path) -> list[BannedPattern]:
+    """Parse the AI-tell vocabulary from ``reference/craft/anti-ai-patterns.md``.
+
+    Reads the ``### Heavily Flagged Words and Phrases`` section, extracts
+    each numbered entry's bolded terms (split on `` / ``), and emits one
+    ``BannedPattern`` per unique phrase. Severity is ``warn`` — global
+    advisory rather than user-asserted. Promotion to ``block`` is the
+    job of the per-author or per-book banlist.
+    """
+    path = plugin_root / "reference" / "craft" / "anti-ai-patterns.md"
+    if not path.is_file():
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+
+    section_match = _ANTI_AI_SECTION_RE.search(text)
+    if not section_match:
+        return []
+    section_text = text[section_match.end():]
+    next_section = re.search(r"^##+\s+\S", section_text, re.MULTILINE)
+    if next_section:
+        section_text = section_text[: next_section.start()]
+
+    patterns: list[BannedPattern] = []
+    seen: set[str] = set()
+
+    for entry in _NUMBERED_ENTRY_RE.finditer(section_text):
+        line = entry.group("line")
+        parts = _DASH_SPLIT_RE.split(line, maxsplit=1)
+        bold_zone = parts[0]
+        explanation = parts[1].strip() if len(parts) > 1 else ""
+
+        bold_terms = [m.group(1) for m in _BOLD_TERM_RE.finditer(bold_zone)]
+        for raw in bold_terms:
+            cleaned = _strip_parenthetical(raw).strip()
+            if len(cleaned) < 2:
+                continue
+            key = cleaned.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            pattern = _build_inflection_pattern(cleaned)
+            short_reason = explanation[:120] if explanation else "AI-tell vocabulary"
+            patterns.append(
+                BannedPattern(
+                    label=cleaned,
+                    pattern=pattern,
+                    severity=SEVERITY_WARN,
+                    source="global anti-ai",
+                    reason=short_reason,
+                )
+            )
+    return patterns


### PR DESCRIPTION
## Summary

Closes the third banlist source for the PostToolUse hook, after #70 (book CLAUDE.md) and #71 (per-scene counter). The hook now enforces three independent banlists with a shared loader and a shared severity model.

| Source | Severity | When |
|---|---|---|
| Book CLAUDE.md (backtick patterns) | block | #70 + #71 |
| Author vocabulary.md (Forbidden sections) | block | **NEW (this PR)** |
| Global anti-AI vocabulary | warn | **refactored to use loader** |

## New module: \`tools/banlist_loader.py\`

- \`BannedPattern\` dataclass: label, compiled regex, severity, source, reason, optional chapter_limit.
- \`author_slug_from_book(book_root)\` — parses \`- **Author:** Ethan Cole (...)\` from the book CLAUDE.md and slugifies it.
- \`load_author_vocab(slug)\` — parses the four \`### Forbidden ...\` subsections of \`~/.storyforge/authors/{slug}/vocabulary.md\`, splits aliases on \` / \`, strips parentheticals.
- \`load_global_ai_tells(plugin_root)\` — parses \`reference/craft/anti-ai-patterns.md\` "Heavily Flagged Words and Phrases" section.

## Inflection-aware regex

Single words ending in silent \`e\` (\`delve\`, \`embrace\`) drop the \`e\` so \`\\bdelv\\w*\` catches \`delve\`, \`delved\`, \`delves\`, \`delving\`. Other single words use \`\\b{word}\\w*\`. Multi-word phrases get exact \`\\b{phrase}\\b\` matching. Leading word-boundary in all cases prevents \`redelve\` from matching \`delve\`.

## Hook changes (\`hooks/validate_chapter.py\`)

- \`_scan_ai_tells\` now reads the global list via the loader. Falls back to a 22-entry in-source list if \`anti-ai-patterns.md\` is missing. Severity stays warn (#70 behavior preserved).
- New \`_scan_author_banlist\` resolves the active book's author from CLAUDE.md, loads the vocab, blocks on first hit per pattern.
- Hardcoded \`AI_TELL_WORDS\` reduced to a 22-entry fallback. The full curated list (46+ entries) now lives in \`reference/craft/anti-ai-patterns.md\` as the canonical source.

## For Blood & Binary specifically

Author \`ethan-cole\` resolves automatically from the book CLAUDE.md, 82 banned phrases load on first scan (Absolutely Forbidden + Forbidden Hedging + Forbidden Emotional + Forbidden Structural sections), each blocks on first hit with attributed messages:

\`\`\`
[BLOCK] draft.md line 42: Banned by author voice
  (author-vocab (Absolutely Forbidden)): 'delve'
\`\`\`

## Test plan

- [x] \`pytest tests/test_banlist_loader.py\` — 19 passed (NEW file)
- [x] \`pytest tests/test_hooks.py\` — 71 passed (was 65; +6 new)
- [x] \`pytest\` (full suite) — 372 passed
- [x] \`ruff check hooks/ tests/ tools/\` — clean
- [x] Sanity-check loader against real Blood & Binary book → 82 patterns load correctly
- [x] **Manual smoke**: write a draft containing \`delved into\` against Blood & Binary and confirm hook blocks with the attributed message

## What I deliberately did NOT do

- **Did not promote global AI-tells to block severity.** The issue body suggested block, but that would block every existing draft mentioning \`delve\`, \`tapestry\`, etc. — too disruptive without per-author opt-in. Author vocab promotes them implicitly (Ethan Cole's vocab.md already lists them).
- **Did not strip the now-redundant Step 5 from \`chapter-writer\` SKILL.md.** The skill prompt cleanup is a separate concern; mechanical change deferred to keep this PR focused on the loader/hook wiring.
- **Did not dedupe overlapping patterns across sources.** If \`delve\` is in both author vocab AND global anti-ai, the user sees one BLOCK + one WARN finding. Attribution is clear, output is verbose but informative. Optimize later if it becomes noise.

Closes #74
Refs #69, #70, #71