### PR TITLE
feat(timeline): get_current_story_anchor() MCP tool + relative-time hook

### DIFF
--- a/hooks/validate_chapter.py
+++ b/hooks/validate_chapter.py
@@ -493,6 +493,89 @@ def _scan_ai_tells(text: str) -> list[Finding]:
     return findings
 
 
+# ---------------------------------------------------------------------------
+# Story-time anchor scan (relative phrases vs. chapter timeline)
+# ---------------------------------------------------------------------------
+
+# Phrases the anchor mapper knows how to resolve. Pattern keeps each
+# phrase as its own group so we can match them case-insensitively without
+# losing the matched text. Multi-word phrases must come before their
+# substrings (``last night`` before ``night``).
+_RELATIVE_PHRASE_RE = re.compile(
+    r"\b("
+    r"yesterday"
+    r"|tomorrow"
+    r"|tonight"
+    r"|last\s+night"
+    r"|last\s+week"
+    r"|next\s+week"
+    r"|this\s+morning"
+    r"|this\s+afternoon"
+    r"|this\s+evening"
+    r"|two\s+hours\s+ago"
+    r"|one\s+hour\s+ago"
+    r"|an\s+hour\s+ago"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+def _scan_time_anchor(text: str, draft_path: Path) -> list[Finding]:
+    """Warn when prose uses a relative time phrase, naming the implied
+    story-calendar target so the writer can verify against
+    ``plot/timeline.md``.
+
+    Severity is ``warn`` — semantic event-vs-timeline matching is out of
+    scope for this hook (would need NLP). The annotation alone catches
+    most drift cases by giving the writer a concrete date to check
+    against. Block-on-conflict can come in a follow-up issue.
+    """
+    findings: list[Finding] = []
+    chapter_dir = draft_path.parent
+
+    try:
+        from tools.timeline_anchor import (
+            compute_relative_phrase_mapping,
+            get_chapter_anchor,
+        )
+    except Exception:
+        return findings
+
+    anchor = get_chapter_anchor(chapter_dir)
+    if anchor is None or anchor.start is None:
+        return findings
+
+    mapping = compute_relative_phrase_mapping(anchor)
+    if not mapping:
+        return findings
+
+    seen_offsets: set[int] = set()
+    for match in _RELATIVE_PHRASE_RE.finditer(text):
+        offset = match.start()
+        if offset in seen_offsets:
+            continue
+        seen_offsets.add(offset)
+        # Normalize whitespace inside the matched phrase for lookup.
+        phrase = re.sub(r"\s+", " ", match.group(1).lower())
+        implied = mapping.get(phrase)
+        if implied is None:
+            continue
+        line_num = _line_for_offset(text, offset)
+        findings.append(
+            Finding(
+                severity=SEVERITY_WARN,
+                category="time_anchor",
+                message=(
+                    f"phrase '{match.group(1)}' implies {implied} "
+                    f"(chapter starts {anchor.start.label()}). "
+                    f"Verify against plot/timeline.md."
+                ),
+                line=line_num,
+            )
+        )
+    return findings
+
+
 def _scan_author_banlist(text: str, book_root: Path) -> list[Finding]:
     """Block-severity scan against the active book's author vocabulary.md.
 
@@ -653,6 +736,7 @@ def validate_chapter(file_path: str) -> list[Finding]:
     if book_root is not None:
         findings.extend(_scan_book_banlist(text, book_root, path))
         findings.extend(_scan_author_banlist(text, book_root))
+    findings.extend(_scan_time_anchor(text, path))
     findings.extend(_scan_meta_narrative(text))
     findings.extend(_scan_ai_tells(text))
     findings.extend(_scan_sentence_variance(text))

--- a/servers/storyforge-server/server.py
+++ b/servers/storyforge-server/server.py
@@ -25,6 +25,7 @@ from tools.shared.paths import slugify, resolve_project_path, resolve_chapter_pa
 from tools.state.indexer import StateCache, rebuild
 from tools.state.parsers import parse_frontmatter, count_words_in_file, is_chapter_drafted, parse_chapter_readme
 from tools.analysis.manuscript_checker import scan_repetitions, render_report
+from tools.timeline_anchor import get_story_anchor
 from tools.claudemd.manager import (
     append_callback as _append_callback_impl,
     append_rule as _append_rule_impl,
@@ -153,6 +154,53 @@ def get_chapter(book_slug: str, chapter_slug: str) -> str:
         return json.dumps({"error": f"Chapter '{chapter_slug}' not found in '{book_slug}'"})
 
     return json.dumps(chapter)
+
+
+@mcp.tool()
+def get_current_story_anchor(book_slug: str, chapter_slug: str = "") -> str:
+    """Resolve the current story-time anchor for a chapter.
+
+    Loads the chapter's `## Chapter Timeline` section (Start / End points)
+    plus the previous chapter's anchor, and returns a structured payload
+    that maps common relative phrases (`yesterday`, `this morning`,
+    `last week`, etc.) to their implied story-calendar dates.
+
+    Use this from `chapter-writer` instead of computing date math by
+    hand — it's the fix for the cross-chapter time-anchor drift that
+    surfaced in the Blood & Binary Ch 22 review (#72).
+
+    Args:
+        book_slug: book identifier (`get_book_full` slug).
+        chapter_slug: chapter identifier. When empty, uses the current
+            session's `last_chapter` if set, otherwise returns an error.
+
+    Returns JSON with keys ``current_chapter``, ``previous_chapter`` and
+    ``available_relative_phrases``.
+    """
+    state = _cache.get()
+    book = state.get("books", {}).get(book_slug)
+    if not book:
+        return json.dumps({"error": f"Book '{book_slug}' not found"})
+
+    if not chapter_slug:
+        session = state.get("session", {}) or {}
+        chapter_slug = session.get("last_chapter") or ""
+    if not chapter_slug:
+        return json.dumps({
+            "error": (
+                "chapter_slug not provided and no last_chapter in session. "
+                "Pass chapter_slug explicitly or call update_session first."
+            )
+        })
+
+    book_root = resolve_project_path(load_config(), book_slug)
+    if not book_root.is_dir():
+        return json.dumps({
+            "error": f"Book directory missing on disk: {book_root}"
+        })
+
+    anchor = get_story_anchor(book_root, chapter_slug)
+    return json.dumps(anchor.to_dict())
 
 
 @mcp.tool()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -545,6 +545,108 @@ class TestAuthorVocabBanlist:
 # ---------------------------------------------------------------------------
 
 
+class TestTimeAnchorScanner:
+    """End-to-end: chapter README has a Chapter Timeline → relative
+    phrases in prose surface as warn-severity findings annotated with
+    the implied story date."""
+
+    def _setup_chapter(self, tmp_path: Path) -> Path:
+        book = _make_book(tmp_path)
+        chapter_dir = book / "chapters" / "01-intro"
+        (chapter_dir / "README.md").write_text(
+            "# Chapter\n\n"
+            "## Chapter Timeline\n\n"
+            "**Start:** Tue Dec 24 ~19:30 (library)\n"
+            "**End:** Wed Dec 25 ~07:00 (trailhead)\n",
+            encoding="utf-8",
+        )
+        return book
+
+    def test_yesterday_in_prose_triggers_warn(self, tmp_path):
+        book = self._setup_chapter(tmp_path)
+        draft = _write_draft(
+            book,
+            "# Chapter 22\n\n"
+            + (
+                "Yesterday felt like a different country, the kind he could "
+                "not return to. He sat at the window and watched the snow. "
+                "The room was cold. " * 5
+            ),
+        )
+        findings = vc.validate_chapter(str(draft))
+        time_warns = [f for f in findings if f.category == "time_anchor"]
+        assert time_warns
+        assert all(f.severity == vc.SEVERITY_WARN for f in time_warns)
+        # Annotation should point at the implied date.
+        msg = time_warns[0].message
+        assert "Mon Dec 23" in msg
+        assert "yesterday" in msg.lower()
+
+    def test_an_hour_ago_resolves_to_specific_time(self, tmp_path):
+        book = self._setup_chapter(tmp_path)
+        draft = _write_draft(
+            book,
+            "# Chapter 22\n\n"
+            + (
+                "An hour ago he had still believed the message would come. "
+                "Now the silence had its own gravity. " * 5
+            ),
+        )
+        findings = vc.validate_chapter(str(draft))
+        time_warns = [f for f in findings if f.category == "time_anchor"]
+        assert any("18:30" in f.message for f in time_warns)
+
+    def test_no_chapter_timeline_skips_scan(self, tmp_path):
+        book = _make_book(tmp_path)
+        # No README written for the chapter → scanner has no anchor.
+        draft = _write_draft(
+            book,
+            "# Chapter 1\n\n"
+            + (
+                "Yesterday felt distant. He sat at the window and watched. "
+                "The room was cold. " * 5
+            ),
+        )
+        findings = vc.validate_chapter(str(draft))
+        time_warns = [f for f in findings if f.category == "time_anchor"]
+        assert time_warns == []
+
+    def test_unrelated_phrases_do_not_match(self, tmp_path):
+        book = self._setup_chapter(tmp_path)
+        draft = _write_draft(
+            book,
+            "# Chapter 22\n\n"
+            + (
+                "He had not slept. The kettle had cooled. The book on the "
+                "table was still open. The hour was hard to read. " * 5
+            ),
+        )
+        findings = vc.validate_chapter(str(draft))
+        time_warns = [f for f in findings if f.category == "time_anchor"]
+        assert time_warns == []
+
+    def test_block_in_strict_mode_does_not_fire(self, tmp_path, monkeypatch, capsys):
+        """Time-anchor findings are warn-only — even in strict mode they
+        must not trigger exit code 2 (#72 keeps semantics conservative
+        until block-on-conflict is added in a follow-up)."""
+        book = self._setup_chapter(tmp_path)
+        draft = _write_draft(
+            book,
+            "# Chapter 22\n\n"
+            + (
+                "Yesterday already felt like a different country. He sat "
+                "at the window and watched the snow. " * 5
+            ),
+        )
+        payload = {
+            "tool_name": "Write",
+            "tool_input": {"file_path": str(draft)},
+        }
+        rc = _run_hook(payload, monkeypatch, capsys)
+        # No block — only warn.
+        assert rc == 0
+
+
 class TestGlobalAITellsLoading:
     """The hook now reads its AI-tells from
     ``reference/craft/anti-ai-patterns.md`` via the loader, not from a

--- a/tests/test_timeline_anchor.py
+++ b/tests/test_timeline_anchor.py
@@ -1,0 +1,296 @@
+"""Tests for ``tools.timeline_anchor`` — chapter README parser, anchor
+computation, day-shift arithmetic, relative-phrase mapping, and the
+multi-chapter ``get_story_anchor`` orchestrator.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.timeline_anchor import (
+    ChapterAnchor,
+    TimePoint,
+    compute_relative_phrase_mapping,
+    get_chapter_anchor,
+    get_story_anchor,
+    parse_chapter_timeline,
+    shift_days,
+    shift_hours,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_chapter_timeline
+# ---------------------------------------------------------------------------
+
+
+CH22_README = (
+    "# Chapter 22: The Night Before\n\n"
+    "## Chapter Timeline\n\n"
+    "**Start:** Tue Dec 24 ~19:30 (library window seat)\n"
+    "**End:** Wed Dec 25 ~07:00 (trailhead, engine cut)\n"
+)
+
+CH4_NO_TIME = (
+    "## Chapter Timeline\n\n"
+    "**Start:** Mon Oct 21\n"
+    "**End:** Mon Oct 21\n"
+)
+
+
+class TestParseChapterTimeline:
+    def test_parses_start_and_end(self):
+        start, end = parse_chapter_timeline(CH22_README)
+        assert start == TimePoint(
+            day_of_week="Tue", month="Dec", day=24, time="19:30"
+        )
+        assert end == TimePoint(
+            day_of_week="Wed", month="Dec", day=25, time="07:00"
+        )
+
+    def test_optional_time(self):
+        start, end = parse_chapter_timeline(CH4_NO_TIME)
+        assert start == TimePoint(
+            day_of_week="Mon", month="Oct", day=21, time=None
+        )
+        assert end == TimePoint(
+            day_of_week="Mon", month="Oct", day=21, time=None
+        )
+
+    def test_empty_returns_none(self):
+        start, end = parse_chapter_timeline("# Chapter 1\n\nNo timeline.\n")
+        assert start is None
+        assert end is None
+
+    def test_only_start_present(self):
+        text = "## Chapter Timeline\n\n**Start:** Fri Oct 18 ~08:00\n"
+        start, end = parse_chapter_timeline(text)
+        assert start is not None
+        assert end is None
+
+    def test_handles_extra_whitespace(self):
+        text = (
+            "## Chapter Timeline\n\n"
+            "**Start:**     Tue Dec 24    ~19:30 (anything)\n"
+        )
+        start, _ = parse_chapter_timeline(text)
+        assert start == TimePoint(
+            day_of_week="Tue", month="Dec", day=24, time="19:30"
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_chapter_anchor (filesystem path)
+# ---------------------------------------------------------------------------
+
+
+def _make_chapter(tmp_path: Path, slug: str, readme_text: str) -> Path:
+    chapter = tmp_path / slug
+    chapter.mkdir(parents=True)
+    (chapter / "README.md").write_text(readme_text, encoding="utf-8")
+    return chapter
+
+
+class TestGetChapterAnchor:
+    def test_loads_anchor_from_readme(self, tmp_path):
+        ch = _make_chapter(tmp_path, "22-the-night-before", CH22_README)
+        anchor = get_chapter_anchor(ch)
+        assert anchor is not None
+        assert anchor.chapter_slug == "22-the-night-before"
+        assert anchor.start.day == 24
+        assert anchor.end.day == 25
+
+    def test_returns_none_for_missing_readme(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        assert get_chapter_anchor(empty) is None
+
+    def test_returns_none_for_readme_without_timeline(self, tmp_path):
+        ch = _make_chapter(
+            tmp_path, "01-x", "# Ch\n\nNo timeline section.\n"
+        )
+        assert get_chapter_anchor(ch) is None
+
+
+# ---------------------------------------------------------------------------
+# Day-shift arithmetic
+# ---------------------------------------------------------------------------
+
+
+class TestShiftDays:
+    def test_yesterday_from_tue_dec_24(self):
+        tp = TimePoint("Tue", "Dec", 24, "19:30")
+        result = shift_days(tp, -1)
+        assert result == TimePoint("Mon", "Dec", 23, "19:30")
+
+    def test_tomorrow_from_tue_dec_24(self):
+        tp = TimePoint("Tue", "Dec", 24, "19:30")
+        result = shift_days(tp, 1)
+        assert result == TimePoint("Wed", "Dec", 25, "19:30")
+
+    def test_seven_days_back(self):
+        tp = TimePoint("Tue", "Dec", 24, "19:30")
+        result = shift_days(tp, -7)
+        assert result == TimePoint("Tue", "Dec", 17, "19:30")
+
+    def test_cross_month_boundary(self):
+        tp = TimePoint("Tue", "Dec", 31, "12:00")
+        result = shift_days(tp, 1)
+        assert result.month == "Jan"
+        assert result.day == 1
+
+    def test_invalid_month_returns_none(self):
+        tp = TimePoint("Tue", "Foo", 24)
+        assert shift_days(tp, 1) is None
+
+    def test_year_picked_to_match_dow(self):
+        # Tue Dec 24 is real in 2024. The shift logic must use a year
+        # where the DOW actually matches, otherwise +7 days lands on the
+        # wrong DOW.
+        tp = TimePoint("Tue", "Dec", 24, "12:00")
+        result = shift_days(tp, 7)
+        assert result == TimePoint("Tue", "Dec", 31, "12:00")
+
+
+class TestShiftHours:
+    def test_one_hour_back(self):
+        tp = TimePoint("Tue", "Dec", 24, "19:30")
+        result = shift_hours(tp, -1)
+        assert result == TimePoint("Tue", "Dec", 24, "18:30")
+
+    def test_two_hours_forward(self):
+        tp = TimePoint("Tue", "Dec", 24, "19:30")
+        result = shift_hours(tp, 2)
+        assert result == TimePoint("Tue", "Dec", 24, "21:30")
+
+    def test_crosses_midnight(self):
+        tp = TimePoint("Tue", "Dec", 24, "23:30")
+        result = shift_hours(tp, 1)
+        assert result == TimePoint("Wed", "Dec", 25, "00:30")
+
+
+# ---------------------------------------------------------------------------
+# Relative phrase mapping
+# ---------------------------------------------------------------------------
+
+
+class TestRelativePhraseMapping:
+    def _ch22_anchor(self) -> ChapterAnchor:
+        return ChapterAnchor(
+            chapter_slug="22-the-night-before",
+            start=TimePoint("Tue", "Dec", 24, "19:30"),
+            end=TimePoint("Wed", "Dec", 25, "07:00"),
+        )
+
+    def test_yesterday_resolves_to_prev_day(self):
+        mapping = compute_relative_phrase_mapping(self._ch22_anchor())
+        assert "Mon Dec 23" in mapping["yesterday"]
+
+    def test_tomorrow_resolves_to_next_day(self):
+        mapping = compute_relative_phrase_mapping(self._ch22_anchor())
+        assert "Wed Dec 25" in mapping["tomorrow"]
+
+    def test_last_night_is_prev_day_night_not_12h_ago(self):
+        mapping = compute_relative_phrase_mapping(self._ch22_anchor())
+        # Should be "night of Mon Dec 23" — the night before today.
+        assert "Mon Dec 23" in mapping["last night"]
+        assert "night" in mapping["last night"]
+
+    def test_an_hour_ago_is_one_hour_back(self):
+        mapping = compute_relative_phrase_mapping(self._ch22_anchor())
+        assert "18:30" in mapping["an hour ago"]
+
+    def test_last_week_is_seven_days_back(self):
+        mapping = compute_relative_phrase_mapping(self._ch22_anchor())
+        assert "Dec 17" in mapping["last week"]
+
+    def test_no_start_returns_empty(self):
+        anchor = ChapterAnchor("01-x", start=None, end=None)
+        assert compute_relative_phrase_mapping(anchor) == {}
+
+    def test_this_morning_includes_today(self):
+        mapping = compute_relative_phrase_mapping(self._ch22_anchor())
+        assert "Tue Dec 24" in mapping["this morning"]
+        assert "morning" in mapping["this morning"]
+
+
+# ---------------------------------------------------------------------------
+# Multi-chapter orchestrator
+# ---------------------------------------------------------------------------
+
+
+def _make_book_with_chapters(tmp_path: Path) -> Path:
+    book = tmp_path / "book"
+    chapters = book / "chapters"
+    chapters.mkdir(parents=True)
+
+    _make_chapter(
+        chapters,
+        "21-i-forbid-it",
+        (
+            "## Chapter Timeline\n\n"
+            "**Start:** Tue Dec 24 ~14:45\n"
+            "**End:** Tue Dec 24 ~17:30\n"
+        ),
+    )
+    _make_chapter(chapters, "22-the-night-before", CH22_README)
+    return book
+
+
+class TestGetStoryAnchor:
+    def test_returns_current_and_previous(self, tmp_path):
+        book = _make_book_with_chapters(tmp_path)
+        story = get_story_anchor(book, "22-the-night-before")
+        assert story.current is not None
+        assert story.current.chapter_slug == "22-the-night-before"
+        assert story.previous is not None
+        assert story.previous.chapter_slug == "21-i-forbid-it"
+
+    def test_relative_mapping_uses_current_chapter_start(self, tmp_path):
+        book = _make_book_with_chapters(tmp_path)
+        story = get_story_anchor(book, "22-the-night-before")
+        # Anchor is Tue Dec 24 19:30 → "yesterday" = Mon Dec 23.
+        assert "Mon Dec 23" in story.relative_phrase_mapping["yesterday"]
+
+    def test_falls_back_to_prev_end_if_current_lacks_timeline(
+        self, tmp_path
+    ):
+        book = tmp_path / "book"
+        chapters = book / "chapters"
+        chapters.mkdir(parents=True)
+        _make_chapter(
+            chapters,
+            "01-prev",
+            (
+                "## Chapter Timeline\n\n"
+                "**Start:** Mon Oct 21 ~08:00\n"
+                "**End:** Mon Oct 21 ~17:00\n"
+            ),
+        )
+        # Current chapter has no Chapter Timeline yet (still drafting).
+        _make_chapter(
+            chapters, "02-current", "# Chapter 2\n\nNo timeline yet.\n"
+        )
+
+        story = get_story_anchor(book, "02-current")
+        assert story.current is None
+        # Mapping derived from previous chapter's end.
+        assert story.relative_phrase_mapping
+        assert "yesterday" in story.relative_phrase_mapping
+
+    def test_serializes_to_dict(self, tmp_path):
+        book = _make_book_with_chapters(tmp_path)
+        story = get_story_anchor(book, "22-the-night-before")
+        payload = story.to_dict()
+        assert "current_chapter" in payload
+        assert "previous_chapter" in payload
+        assert "available_relative_phrases" in payload
+        assert "yesterday" in payload["available_relative_phrases"]
+
+    def test_no_chapters_returns_empty(self, tmp_path):
+        book = tmp_path / "book"
+        (book / "chapters").mkdir(parents=True)
+        story = get_story_anchor(book, "no-such-chapter")
+        assert story.current is None
+        assert story.previous is None
+        assert story.relative_phrase_mapping == {}

--- a/tools/timeline_anchor.py
+++ b/tools/timeline_anchor.py
@@ -1,0 +1,392 @@
+"""Story-time anchor for the active chapter.
+
+Parses the per-chapter ``## Chapter Timeline`` section in a chapter
+README and returns a structured anchor (start/end day-of-week, month,
+day, time). The anchor lets the PostToolUse hook warn when prose uses
+relative time phrases (``yesterday``, ``this morning``, ``tomorrow``,
+etc.) so the writer can verify the implied date against
+``plot/timeline.md``.
+
+The MCP server surfaces the anchor via ``get_current_story_anchor`` so
+``chapter-writer`` can consume it as structured data instead of doing
+date math itself (the source of #72's beta-feedback bug).
+
+Pure stdlib so the hook can call it without extra setup.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Calendar primitives
+# ---------------------------------------------------------------------------
+
+DAY_NAMES_SHORT: tuple[str, ...] = (
+    "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun",
+)
+DAY_NAMES_FULL: tuple[str, ...] = (
+    "Monday", "Tuesday", "Wednesday", "Thursday",
+    "Friday", "Saturday", "Sunday",
+)
+MONTH_NAMES_SHORT: tuple[str, ...] = (
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+)
+
+_DAY_FULL_BY_SHORT = dict(zip(DAY_NAMES_SHORT, DAY_NAMES_FULL))
+_MONTH_INDEX = {name: idx + 1 for idx, name in enumerate(MONTH_NAMES_SHORT)}
+
+# Fallback year for the rare case where no real year produces the
+# point's stated day-of-week (corrupt input). Otherwise we auto-detect a
+# matching year so date arithmetic preserves the README's calendar.
+_FALLBACK_YEAR = 2025
+
+
+# ---------------------------------------------------------------------------
+# TimePoint dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TimePoint:
+    """A single moment on the story calendar."""
+
+    day_of_week: str  # short name: "Tue"
+    month: str  # short name: "Dec"
+    day: int  # 24
+    time: str | None = None  # "19:30" or None when not specified
+
+    def label(self) -> str:
+        """Human-readable label like 'Tue Dec 24 ~19:30'."""
+        base = f"{self.day_of_week} {self.month} {self.day}"
+        if self.time:
+            return f"{base} ~{self.time}"
+        return base
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ChapterAnchor:
+    """Story-time anchor for a single chapter."""
+
+    chapter_slug: str
+    start: TimePoint | None = None
+    end: TimePoint | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "chapter_slug": self.chapter_slug,
+            "start": self.start.to_dict() if self.start else None,
+            "end": self.end.to_dict() if self.end else None,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Chapter Timeline parser
+# ---------------------------------------------------------------------------
+
+# Matches:
+#   **Start:** Tue Dec 24 ~19:30 (library window seat, ...)
+#   **End:** Wed Dec 25 ~07:00 (trailhead, ...)
+# Time is optional; the leading "~" is consumed as part of the time prefix.
+_TIMELINE_LINE_RE = re.compile(
+    r"^\*\*(?P<label>Start|End):\*\*\s+"
+    r"(?P<dow>Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s+"
+    r"(?P<mon>Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+"
+    r"(?P<day>\d{1,2})"
+    r"(?:\s+~?(?P<time>\d{1,2}:\d{2}))?",
+    re.MULTILINE,
+)
+
+
+def parse_chapter_timeline(
+    readme_text: str,
+) -> tuple[TimePoint | None, TimePoint | None]:
+    """Return ``(start, end)`` TimePoints from a chapter README, or
+    ``(None, None)`` if no Chapter Timeline section is present.
+
+    Tolerant of extra whitespace and case-variants — the regex anchors
+    on the bold ``**Start:**`` / ``**End:**`` markers that the
+    chapter-writer skill writes when a chapter reaches review status.
+    """
+    start: TimePoint | None = None
+    end: TimePoint | None = None
+    for match in _TIMELINE_LINE_RE.finditer(readme_text):
+        point = TimePoint(
+            day_of_week=match.group("dow"),
+            month=match.group("mon"),
+            day=int(match.group("day")),
+            time=match.group("time"),
+        )
+        if match.group("label") == "Start":
+            start = point
+        else:
+            end = point
+    return start, end
+
+
+def get_chapter_anchor(chapter_dir: Path) -> ChapterAnchor | None:
+    """Load the anchor for a single chapter directory.
+
+    Returns ``None`` when the README is missing or has no parseable
+    Chapter Timeline section.
+    """
+    readme = chapter_dir / "README.md"
+    if not readme.is_file():
+        return None
+    try:
+        text = readme.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    start, end = parse_chapter_timeline(text)
+    if start is None and end is None:
+        return None
+    return ChapterAnchor(
+        chapter_slug=chapter_dir.name,
+        start=start,
+        end=end,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Day-shift arithmetic
+# ---------------------------------------------------------------------------
+
+
+def _matching_year(point: TimePoint) -> int:
+    """Find a real year where ``point.month`` ``point.day`` falls on
+    ``point.day_of_week``. Required so calendar arithmetic preserves
+    the README-stated day-of-week across shifts.
+    """
+    month = _MONTH_INDEX.get(point.month)
+    if month is None:
+        return _FALLBACK_YEAR
+    target = None
+    try:
+        target = DAY_NAMES_SHORT.index(point.day_of_week)
+    except ValueError:
+        return _FALLBACK_YEAR
+    for year in range(2020, 2040):
+        try:
+            candidate = datetime(year, month, point.day)
+        except ValueError:
+            continue
+        if candidate.weekday() == target:
+            return year
+    return _FALLBACK_YEAR
+
+
+def _to_datetime(point: TimePoint) -> datetime | None:
+    """Map a TimePoint into a real datetime using a year that preserves
+    its stated day-of-week.
+
+    Returns ``None`` if the month/day combination is invalid
+    (e.g. Feb 30) or month is unknown.
+    """
+    month = _MONTH_INDEX.get(point.month)
+    if month is None:
+        return None
+    hour = 0
+    minute = 0
+    if point.time and ":" in point.time:
+        try:
+            hour_str, minute_str = point.time.split(":", 1)
+            hour = int(hour_str)
+            minute = int(minute_str)
+        except ValueError:
+            pass
+    year = _matching_year(point)
+    try:
+        return datetime(year, month, point.day, hour, minute)
+    except ValueError:
+        return None
+
+
+def _from_datetime(dt: datetime, time: str | None) -> TimePoint:
+    return TimePoint(
+        day_of_week=DAY_NAMES_SHORT[dt.weekday()],
+        month=MONTH_NAMES_SHORT[dt.month - 1],
+        day=dt.day,
+        time=time,
+    )
+
+
+def shift_days(point: TimePoint, delta_days: int) -> TimePoint | None:
+    """Shift a TimePoint by ``delta_days``. Returns None on invalid math."""
+    base = _to_datetime(point)
+    if base is None:
+        return None
+    shifted = base + timedelta(days=delta_days)
+    return _from_datetime(shifted, point.time)
+
+
+def shift_hours(point: TimePoint, delta_hours: int) -> TimePoint | None:
+    """Shift a TimePoint by ``delta_hours`` (preserves time-of-day)."""
+    base = _to_datetime(point)
+    if base is None:
+        return None
+    shifted = base + timedelta(hours=delta_hours)
+    new_time = f"{shifted.hour:02d}:{shifted.minute:02d}"
+    return _from_datetime(shifted, new_time)
+
+
+# ---------------------------------------------------------------------------
+# Relative phrase mapping
+# ---------------------------------------------------------------------------
+
+
+def compute_relative_phrase_mapping(
+    anchor: ChapterAnchor,
+) -> dict[str, str]:
+    """Map common relative time phrases to their implied story-calendar
+    target, given the chapter's start point.
+
+    Used by the hook to surface "phrase X implies date Y — verify against
+    timeline" warnings.
+    """
+    mapping: dict[str, str] = {}
+    if anchor.start is None:
+        return mapping
+    start = anchor.start
+
+    yesterday = shift_days(start, -1)
+    if yesterday is not None:
+        mapping["yesterday"] = yesterday.label()
+
+    tomorrow = shift_days(start, 1)
+    if tomorrow is not None:
+        mapping["tomorrow"] = tomorrow.label()
+
+    last_week = shift_days(start, -7)
+    if last_week is not None:
+        mapping["last week"] = f"week of {last_week.label()}"
+
+    next_week = shift_days(start, 7)
+    if next_week is not None:
+        mapping["next week"] = f"week of {next_week.label()}"
+
+    today_label = f"{start.day_of_week} {start.month} {start.day}"
+    mapping["this morning"] = f"morning of {today_label}"
+    mapping["this afternoon"] = f"afternoon of {today_label}"
+    mapping["this evening"] = f"evening of {today_label}"
+    mapping["tonight"] = f"night of {today_label}"
+
+    # "last night" = the night previous to today, not 12h ago.
+    if yesterday is not None:
+        prev_label = f"{yesterday.day_of_week} {yesterday.month} {yesterday.day}"
+        mapping["last night"] = f"night of {prev_label}"
+
+    one_hour = shift_hours(start, -1)
+    if one_hour is not None:
+        mapping["an hour ago"] = one_hour.label()
+        mapping["one hour ago"] = one_hour.label()
+
+    two_hours = shift_hours(start, -2)
+    if two_hours is not None:
+        mapping["two hours ago"] = two_hours.label()
+
+    return mapping
+
+
+# ---------------------------------------------------------------------------
+# Multi-chapter anchor (used by the MCP tool)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StoryAnchor:
+    """Anchor that combines current chapter + previous chapter context."""
+
+    current: ChapterAnchor | None
+    previous: ChapterAnchor | None
+    relative_phrase_mapping: dict[str, str]
+
+    def to_dict(self) -> dict[str, Any]:
+        current_dict = self.current.to_dict() if self.current else None
+        previous_dict = self.previous.to_dict() if self.previous else None
+        return {
+            "current_chapter": current_dict,
+            "previous_chapter": previous_dict,
+            "available_relative_phrases": self.relative_phrase_mapping,
+        }
+
+
+# Matches "01-something", "22-the-night-before", etc. The leading number
+# is the chapter index used for ordering.
+_CHAPTER_DIR_RE = re.compile(r"^(?P<num>\d{1,3})-")
+
+
+def _list_chapter_dirs(book_root: Path) -> list[tuple[int, Path]]:
+    chapters_dir = book_root / "chapters"
+    if not chapters_dir.is_dir():
+        return []
+    out: list[tuple[int, Path]] = []
+    for entry in chapters_dir.iterdir():
+        if not entry.is_dir():
+            continue
+        match = _CHAPTER_DIR_RE.match(entry.name)
+        if not match:
+            continue
+        out.append((int(match.group("num")), entry))
+    out.sort(key=lambda pair: pair[0])
+    return out
+
+
+def _previous_chapter_dir(
+    book_root: Path, current_slug: str
+) -> Path | None:
+    chapters = _list_chapter_dirs(book_root)
+    prev: Path | None = None
+    for _, chapter_dir in chapters:
+        if chapter_dir.name == current_slug:
+            return prev
+        prev = chapter_dir
+    return None
+
+
+def get_story_anchor(
+    book_root: Path, current_chapter_slug: str
+) -> StoryAnchor:
+    """Load current + previous chapter anchors and compute the relative
+    phrase mapping.
+
+    Returns a ``StoryAnchor`` even when one or both chapters lack a
+    Chapter Timeline section — the relative-phrase mapping is then
+    derived from whichever anchor is available (current, then previous).
+    """
+    chapters_dir = book_root / "chapters"
+    current_dir = chapters_dir / current_chapter_slug
+    current = (
+        get_chapter_anchor(current_dir) if current_dir.is_dir() else None
+    )
+
+    prev_dir = _previous_chapter_dir(book_root, current_chapter_slug)
+    previous = get_chapter_anchor(prev_dir) if prev_dir is not None else None
+
+    # Pick whichever anchor we can use as the "now" for the mapping.
+    base_anchor = current
+    if base_anchor is None or base_anchor.start is None:
+        # Fall back to the previous chapter's end as the current "now".
+        if previous is not None and previous.end is not None:
+            base_anchor = ChapterAnchor(
+                chapter_slug=current_chapter_slug,
+                start=previous.end,
+                end=None,
+            )
+
+    mapping: dict[str, str] = {}
+    if base_anchor is not None:
+        mapping = compute_relative_phrase_mapping(base_anchor)
+
+    return StoryAnchor(
+        current=current,
+        previous=previous,
+        relative_phrase_mapping=mapping,
+    )


### PR DESCRIPTION
## Summary

Beta-feedback case: \`chapter-writer\` doing date math by hand under prereq-load pressure → \`yesterday four hours into the drive\` written for Wed Dec 25 when the last anchor was Mon Dec 16 (9 days off, not 1). Math belongs in the tool, not in the model's head.

This PR adds the data side: a structured anchor that names what common relative phrases imply in the current story-calendar context, plus a warn-severity hook scanner that surfaces the implication on every write.

## What lands

### \`tools/timeline_anchor.py\`
- \`TimePoint\` (day_of_week, month, day, time) and \`ChapterAnchor\` (slug + start + end) dataclasses.
- \`parse_chapter_timeline(readme_text)\` extracts \`**Start:**\` / \`**End:**\` lines from the chapter README's \`## Chapter Timeline\` section.
- \`shift_days\` / \`shift_hours\` do calendar-aware date arithmetic. **Year is auto-detected** to match the README's day-of-week (so +7 days actually lands on the same DOW — the obvious-looking pseudo-year approach gave \`Wed Dec 31\` for \`Tue + 7\`).
- \`compute_relative_phrase_mapping(anchor)\` maps \`yesterday\`, \`tomorrow\`, \`last week\`, \`this morning\`, \`an hour ago\`, \`last night\` etc. to their implied story-calendar dates.
- \`get_story_anchor(book_root, slug)\` orchestrates: loads current + previous chapter anchors, falls back to previous chapter's end if current chapter has no Chapter Timeline yet (still drafting).

### MCP tool: \`get_current_story_anchor(book_slug, chapter_slug=\"\")\`
Returns JSON:
\`\`\`json
{
  \"current_chapter\": {
    \"chapter_slug\": \"22-the-night-before\",
    \"start\": {\"day_of_week\": \"Tue\", \"month\": \"Dec\", \"day\": 24, \"time\": \"19:30\"},
    \"end\": {\"day_of_week\": \"Wed\", \"month\": \"Dec\", \"day\": 25, \"time\": \"07:00\"}
  },
  \"previous_chapter\": { ... },
  \"available_relative_phrases\": {
    \"yesterday\": \"Mon Dec 23 ~19:30\",
    \"tomorrow\": \"Wed Dec 25 ~19:30\",
    \"last week\": \"week of Tue Dec 17 ~19:30\",
    \"last night\": \"night of Mon Dec 23\",
    \"an hour ago\": \"Tue Dec 24 ~18:30\",
    \"two hours ago\": \"Tue Dec 24 ~17:30\",
    ...
  }
}
\`\`\`

When \`chapter_slug\` is empty, falls back to \`session.last_chapter\`.

### Hook: \`_scan_time_anchor\`
Scans prose for the known relative phrases (yesterday, tomorrow, tonight, last night, last week, next week, this morning, this afternoon, this evening, an hour ago, two hours ago, one hour ago). Each match emits a **warn** finding:

\`\`\`
[WARN] draft.md line 47: phrase 'yesterday' implies Mon Dec 23 ~19:30
  (chapter starts Tue Dec 24 ~19:30). Verify against plot/timeline.md.
\`\`\`

## What I deliberately did NOT do

**Block-on-conflict is deferred.** The issue body's acceptance criterion suggests blocking when the implied date conflicts with timeline.md events by >12h. That requires semantic event-matching — the hook would need to know which event in timeline.md the phrase \`yesterday\` is referring to. Without LLM-level understanding, this is a false-positive minefield.

This PR ships the warn path with a clear annotation. That alone catches most drift cases by giving the writer a concrete date to verify. Block-on-conflict can come in a follow-up issue when we have empirical data on what gets flagged.

**\`chapter-writer\` skill prompt is not updated.** The MCP tool exists and is callable; wiring it into the skill's prereq-load is a one-line change but belongs in a separate PR (touches a different file class).

## Test plan

- [x] \`pytest tests/test_timeline_anchor.py\` — 29 passed (NEW file)
- [x] \`pytest tests/test_hooks.py\` — 76 passed (was 71; +5 new)
- [x] \`pytest\` (full suite) — 406 passed (was 372; +34 new)
- [x] \`ruff check hooks/ tests/ tools/ servers/\` — clean
- [x] Sanity-check on real Blood & Binary Ch 22 → anchor + mapping resolve correctly
- [x] **Manual smoke**: \`mcp__storyforge-mcp__get_current_story_anchor blood-and-binary-firelight 22-the-night-before\` produces the expected JSON
- [x] **Manual smoke**: write \`yesterday\` into a Blood & Binary chapter draft and confirm the hook's warn output names the implied date

## For Blood & Binary specifically

Ch 22 anchor (auto-loaded from \`README.md\`):
- Start: Tue Dec 24 ~19:30
- End: Wed Dec 25 ~07:00
- \"yesterday\" → Mon Dec 23 (the actual day before)
- \"last week\" → week of Tue Dec 17

If the writer types \`yesterday\` referring to a Mon-Dec-16 event, the warning surfaces \"phrase 'yesterday' implies Mon Dec 23\" — the writer immediately sees the 9-day gap and either fixes the prose or fixes the timeline.

Closes #72
Refs #69, #70, #71, #73, #74