### PR TITLE
feat(skills): tactical sanity check before combat/travel scenes

### DIFF
--- a/servers/storyforge-server/server.py
+++ b/servers/storyforge-server/server.py
@@ -25,6 +25,9 @@ from tools.shared.paths import slugify, resolve_project_path, resolve_chapter_pa
 from tools.state.indexer import StateCache, rebuild
 from tools.state.parsers import parse_frontmatter, count_words_in_file, is_chapter_drafted, parse_chapter_readme
 from tools.analysis.manuscript_checker import scan_repetitions, render_report
+from tools.analysis.tactical_checker import (
+    verify_tactical_setup as _verify_tactical_setup_impl,
+)
 from tools.state.chapter_timeline_parser import (
     get_recent_chapter_timelines as _get_recent_chapter_timelines_impl,
 )
@@ -238,6 +241,54 @@ def get_recent_chapter_timelines(book_slug: str, n: int = 3) -> str:
 
     grids = _get_recent_chapter_timelines_impl(book_root, n=n)
     return json.dumps({"chapters": [g.to_dict() for g in grids]})
+
+
+@mcp.tool()
+def verify_tactical_setup(
+    book_slug: str,
+    scene_outline_text: str,
+    characters_present: list[str],
+) -> str:
+    """Pre-write sanity check for combat/travel scenes (#75).
+
+    Cross-references each character's optional ``tactical`` frontmatter
+    block (`protector_role`, `protected_role`, `combat_skill`,
+    `movement_lead`, `movement_rear`) with the scene outline and
+    surfaces walking-order or formation problems.
+
+    Use this from `chapter-writer` and `rolling-planner` BEFORE writing
+    a scene that involves group movement through dangerous space or
+    combat. The tool produces a JSON brief: ``passes`` (false when
+    any warn-severity rule fires), ``warnings`` (severity + message),
+    ``questions_for_writer`` (always at least 3 — universal pre-write
+    questions, specialized per protected/vulnerable character), and
+    ``detected_positions`` (map of character to ``lead`` / ``rear`` /
+    ``middle`` / ``unknown``).
+
+    Args:
+        book_slug: book identifier.
+        scene_outline_text: free-text outline or first-pass paragraph
+            describing the scene's group movement.
+        characters_present: character slugs (matching the
+            ``characters/{slug}.md`` filename without the suffix) that
+            participate in the scene.
+
+    Returns JSON with ``passes``, ``warnings``, ``questions_for_writer``,
+    ``detected_positions``.
+    """
+    book_root = resolve_project_path(load_config(), book_slug)
+    if not book_root.is_dir():
+        return json.dumps({
+            "error": f"Book directory missing on disk: {book_root}"
+        })
+
+    return json.dumps(
+        _verify_tactical_setup_impl(
+            book_root,
+            scene_outline_text=scene_outline_text,
+            characters_present=characters_present,
+        )
+    )
 
 
 @mcp.tool()

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -88,6 +88,8 @@ Target ~900 words per scene (can vary — some scenes need 600, others 1200). Th
 #### Step A2: Write One Scene
 For the current scene, apply ALL craft rules (Steps 3-6 from Mode B below). Write ONLY this scene — do not continue into the next scene.
 
+**Before writing, if this scene involves combat OR group movement through dangerous space (keywords like `walk`, `hike`, `drive`, `attack`, `mission`, `enter the building`, `approach`, multi-character formation), call MCP `verify_tactical_setup(book_slug, scene_outline_text, characters_present)`.** Resolve every warn-severity warning before drafting — do not paper over walking-order or formation problems in prose. Use the returned `questions_for_writer` as a 30-second sanity-check checklist (who scouts, who covers the protected character, fallback formation if attacked).
+
 **Before appending, run the Step 6c Simile Discipline Scan on the scene text.** No scene goes into `draft.md` before the scan.
 
 After writing the scene:

--- a/skills/rolling-planner/SKILL.md
+++ b/skills/rolling-planner/SKILL.md
@@ -62,6 +62,11 @@ expansion:
 
 This is optional. Skip for straightforward scenes.
 
+### Step 4b: Tactical Sanity Check (combat/travel scenes only)
+If the scene recipe involves combat OR group movement through dangerous space (keywords like `walk`, `hike`, `drive`, `attack`, `mission`, `enter the building`, `approach` with multiple characters), call MCP `verify_tactical_setup(book_slug, scene_outline_text, characters_present)` before saving the recipe. Resolve every warn-severity warning by adjusting the scene plan — do not defer to the chapter-writer to fix walking-order or formation problems in prose. Capture the answers to the returned `questions_for_writer` (who scouts, who covers the protected character, fallback formation) directly in the recipe so the chapter-writer has them when drafting.
+
+Skip this step for kitchen-table dialogue, internal monologue, or any scene without group movement.
+
 ### Step 5: Save to Chapter README
 Write the scene recipe (and optional outline) to the next chapter's README via
 MCP `update_field(chapter_readme_path, "scene_recipe", value)`.

--- a/templates/character.md
+++ b/templates/character.md
@@ -7,6 +7,18 @@ gender: ""
 job: ""
 archetype: ""
 description: ""
+# Optional tactical profile — used by `verify_tactical_setup` (#75) to
+# pre-check combat and travel scenes for walking-order plausibility.
+# Delete this block for non-action characters; fill in for any
+# character likely to appear in fights, raids, or group movement.
+# tactical:
+#   protector_role: false       # actively protects others
+#   protected_role: false       # needs protection in combat
+#   combat_skill: unknown       # none|low|medium|high|elite|unknown
+#   movement_lead: false        # tends to take point
+#   movement_rear: false        # tends to bring up the rear
+#   vulnerable_to: []           # e.g. [daylight, silver]
+#   carries: []                 # e.g. [knife, backup_blade]
 ---
 
 # {{name}}

--- a/tests/test_tactical_checker.py
+++ b/tests/test_tactical_checker.py
@@ -1,0 +1,387 @@
+"""Tests for ``tools.analysis.tactical_checker`` — Issue #75.
+
+Pre-write sanity check for combat and travel scenes: cross-reference
+character tactical profiles with the scene outline and surface
+walking-order / formation problems before they make it to draft.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.analysis.tactical_checker import (
+    TacticalProfile,
+    analyze_tactical_setup,
+    detect_positions,
+    is_tactical_scene,
+    load_tactical_profiles,
+    parse_tactical_profile,
+    verify_tactical_setup,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_tactical_scene — combat/travel keyword detector
+# ---------------------------------------------------------------------------
+
+
+class TestIsTacticalScene:
+    def test_walk_through_dangerous_space_triggers(self):
+        text = "They walk through the snow toward the trailhead."
+        assert is_tactical_scene(text) is True
+
+    def test_combat_keyword_attack_triggers(self):
+        text = "The attack comes from the tree line."
+        assert is_tactical_scene(text) is True
+
+    def test_drive_to_location_triggers(self):
+        text = "Kael drives the truck up the mountain pass."
+        assert is_tactical_scene(text) is True
+
+    def test_hike_triggers(self):
+        text = "They hike single-file toward the cabin."
+        assert is_tactical_scene(text) is True
+
+    def test_enter_the_building_triggers(self):
+        text = "They approach and enter the building from the south."
+        assert is_tactical_scene(text) is True
+
+    def test_quiet_dialogue_scene_does_not_trigger(self):
+        text = (
+            "Theo and Miriel sit at the kitchen table. Miriel kneads bread. "
+            "They talk about the past."
+        )
+        assert is_tactical_scene(text) is False
+
+    def test_empty_text_does_not_trigger(self):
+        assert is_tactical_scene("") is False
+
+
+# ---------------------------------------------------------------------------
+# parse_tactical_profile — load tactical block from character markdown
+# ---------------------------------------------------------------------------
+
+
+THEO_MD = """---
+name: "Theo"
+role: "protagonist"
+tactical:
+  protector_role: false
+  protected_role: true
+  combat_skill: none
+  movement_lead: false
+  movement_rear: false
+  vulnerable_to:
+    - daylight
+    - silver
+  carries: []
+---
+
+# Theo
+"""
+
+KAEL_MD = """---
+name: "Kael"
+role: "deuteragonist"
+tactical:
+  protector_role: true
+  protected_role: false
+  combat_skill: high
+  movement_lead: true
+  movement_rear: false
+  vulnerable_to:
+    - daylight
+  carries: [knife, backup_blade]
+---
+
+# Kael
+"""
+
+CHARACTER_NO_TACTICAL_MD = """---
+name: "Random Side Character"
+role: "supporting"
+---
+
+# Random
+"""
+
+
+def _write_char(tmp_path: Path, slug: str, content: str) -> Path:
+    path = tmp_path / f"{slug}.md"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+class TestParseTacticalProfile:
+    def test_loads_full_tactical_block(self, tmp_path):
+        path = _write_char(tmp_path, "theo", THEO_MD)
+        profile = parse_tactical_profile(path)
+        assert profile is not None
+        assert profile.name == "Theo"
+        assert profile.slug == "theo"
+        assert profile.protector_role is False
+        assert profile.protected_role is True
+        assert profile.combat_skill == "none"
+        assert profile.movement_lead is False
+        assert profile.movement_rear is False
+        assert "daylight" in profile.vulnerable_to
+        assert profile.has_tactical_data is True
+
+    def test_protector_profile_loads(self, tmp_path):
+        path = _write_char(tmp_path, "kael", KAEL_MD)
+        profile = parse_tactical_profile(path)
+        assert profile is not None
+        assert profile.protector_role is True
+        assert profile.movement_lead is True
+        assert "knife" in profile.carries
+
+    def test_character_without_tactical_block_returns_default(self, tmp_path):
+        path = _write_char(tmp_path, "random", CHARACTER_NO_TACTICAL_MD)
+        profile = parse_tactical_profile(path)
+        # Still returns a profile so we know the character exists, but
+        # has_tactical_data signals there's nothing to validate against.
+        assert profile is not None
+        assert profile.has_tactical_data is False
+        assert profile.protector_role is False
+        assert profile.protected_role is False
+
+    def test_missing_file_returns_none(self, tmp_path):
+        assert parse_tactical_profile(tmp_path / "ghost.md") is None
+
+
+# ---------------------------------------------------------------------------
+# detect_positions — extract walking-order positions from scene text
+# ---------------------------------------------------------------------------
+
+
+class TestDetectPositions:
+    def test_rear_keyword_back_of_formation(self):
+        text = "Theo walked at the back of the formation, the others ahead."
+        positions = detect_positions(
+            text,
+            character_names=["Theo", "Kael", "Viktor", "Dom"],
+        )
+        assert positions["Theo"] == "rear"
+
+    def test_point_keyword_takes_lead(self):
+        text = "Kael took point. Viktor brought up the rear."
+        positions = detect_positions(text, character_names=["Kael", "Viktor"])
+        assert positions["Kael"] == "lead"
+        assert positions["Viktor"] == "rear"
+
+    def test_flanked_keyword_yields_middle(self):
+        text = "Theo walked flanked by Kael at point and Viktor at the rear."
+        positions = detect_positions(
+            text, character_names=["Theo", "Kael", "Viktor"],
+        )
+        assert positions["Theo"] == "middle"
+        assert positions["Kael"] == "lead"
+        assert positions["Viktor"] == "rear"
+
+    def test_unknown_when_character_not_mentioned(self):
+        text = "Kael took point."
+        positions = detect_positions(text, character_names=["Theo", "Kael"])
+        assert positions["Theo"] == "unknown"
+        assert positions["Kael"] == "lead"
+
+
+# ---------------------------------------------------------------------------
+# analyze_tactical_setup — heuristic engine
+# ---------------------------------------------------------------------------
+
+
+def _theo() -> TacticalProfile:
+    return TacticalProfile(
+        name="Theo", slug="theo",
+        protector_role=False, protected_role=True,
+        combat_skill="none",
+        movement_lead=False, movement_rear=False,
+        vulnerable_to=("daylight", "silver"),
+        carries=(),
+        has_tactical_data=True,
+    )
+
+
+def _kael() -> TacticalProfile:
+    return TacticalProfile(
+        name="Kael", slug="kael",
+        protector_role=True, protected_role=False,
+        combat_skill="high",
+        movement_lead=True, movement_rear=False,
+        vulnerable_to=("daylight",),
+        carries=("knife", "backup_blade"),
+        has_tactical_data=True,
+    )
+
+
+def _viktor() -> TacticalProfile:
+    return TacticalProfile(
+        name="Viktor", slug="viktor",
+        protector_role=True, protected_role=False,
+        combat_skill="elite",
+        movement_lead=False, movement_rear=True,
+        vulnerable_to=("daylight",),
+        carries=("blade",),
+        has_tactical_data=True,
+    )
+
+
+def _dom() -> TacticalProfile:
+    return TacticalProfile(
+        name="Dom", slug="dom",
+        protector_role=True, protected_role=False,
+        combat_skill="high",
+        movement_lead=False, movement_rear=False,
+        vulnerable_to=("daylight",),
+        carries=(),
+        has_tactical_data=True,
+    )
+
+
+class TestAnalyzeTacticalSetup:
+    def test_protected_at_rear_warns(self):
+        # Acceptance: Theo at the rear of a Kael/Viktor/Dom protector
+        # team triggers a warning.
+        scene_text = (
+            "Theo walked at the back of the formation. "
+            "Kael led the way, Viktor and Dom flanked the middle."
+        )
+        analysis = analyze_tactical_setup(
+            scene_text,
+            profiles=[_theo(), _kael(), _viktor(), _dom()],
+        )
+        assert analysis.passes is False
+        assert any(
+            "Theo" in w.message and "rear" in w.message.lower()
+            for w in analysis.warnings
+        )
+
+    def test_protected_flanked_passes(self):
+        # Acceptance: Theo flanked by Kael (point) and Viktor (rear) passes.
+        scene_text = (
+            "Theo walked flanked by Kael at point and Viktor at the rear. "
+            "They moved single-file toward the trailhead."
+        )
+        analysis = analyze_tactical_setup(
+            scene_text,
+            profiles=[_theo(), _kael(), _viktor()],
+        )
+        assert analysis.passes is True
+        # No "Theo at rear" warnings.
+        assert not any(
+            "Theo" in w.message and "rear" in w.message.lower()
+            for w in analysis.warnings
+        )
+
+    def test_returns_at_least_three_questions(self):
+        # Acceptance: tool returns at least 3 tactical questions for
+        # any combat/travel scene.
+        scene_text = "They walk through the woods toward the cabin."
+        analysis = analyze_tactical_setup(
+            scene_text, profiles=[_theo(), _kael()],
+        )
+        assert len(analysis.questions_for_writer) >= 3
+
+    def test_questions_returned_even_when_passes(self):
+        scene_text = (
+            "Theo walked flanked by Kael at point and Viktor at the rear."
+        )
+        analysis = analyze_tactical_setup(
+            scene_text,
+            profiles=[_theo(), _kael(), _viktor()],
+        )
+        assert analysis.passes is True
+        assert len(analysis.questions_for_writer) >= 3
+
+    def test_no_tactical_data_degrades_gracefully(self):
+        # Acceptance: graceful degrade when characters lack tactical data.
+        no_data_theo = TacticalProfile(
+            name="Theo", slug="theo",
+            protector_role=False, protected_role=False,
+            combat_skill="unknown",
+            movement_lead=False, movement_rear=False,
+            vulnerable_to=(), carries=(),
+            has_tactical_data=False,
+        )
+        scene_text = "Theo walked at the back of the line."
+        analysis = analyze_tactical_setup(
+            scene_text, profiles=[no_data_theo],
+        )
+        # No crash; passes (we can't validate without data) but a
+        # warning notes the missing tactical profile.
+        assert analysis.passes is True
+        assert any(
+            "tactical profile" in w.message.lower()
+            or "no tactical" in w.message.lower()
+            for w in analysis.warnings
+        )
+        assert len(analysis.questions_for_writer) >= 3
+
+
+# ---------------------------------------------------------------------------
+# load_tactical_profiles — book-level loader
+# ---------------------------------------------------------------------------
+
+
+class TestLoadTacticalProfiles:
+    def test_loads_profiles_for_listed_slugs(self, tmp_path):
+        chars = tmp_path / "book" / "characters"
+        chars.mkdir(parents=True)
+        _write_char(chars, "theo", THEO_MD)
+        _write_char(chars, "kael", KAEL_MD)
+        # Skip a character that isn't requested.
+        _write_char(chars, "random", CHARACTER_NO_TACTICAL_MD)
+
+        profiles = load_tactical_profiles(
+            tmp_path / "book", slugs=["theo", "kael"],
+        )
+        assert {p.slug for p in profiles} == {"theo", "kael"}
+
+    def test_missing_character_dropped_silently(self, tmp_path):
+        chars = tmp_path / "book" / "characters"
+        chars.mkdir(parents=True)
+        _write_char(chars, "theo", THEO_MD)
+
+        profiles = load_tactical_profiles(
+            tmp_path / "book", slugs=["theo", "ghost"],
+        )
+        # Only Theo loaded; ghost is not on disk so it's dropped.
+        assert {p.slug for p in profiles} == {"theo"}
+
+
+# ---------------------------------------------------------------------------
+# verify_tactical_setup — full orchestrator (used by MCP tool)
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyTacticalSetup:
+    def test_end_to_end_warn_case(self, tmp_path):
+        chars = tmp_path / "book" / "characters"
+        chars.mkdir(parents=True)
+        _write_char(chars, "theo", THEO_MD)
+        _write_char(chars, "kael", KAEL_MD)
+        _write_char(chars, "viktor", """---
+name: "Viktor"
+tactical:
+  protector_role: true
+  protected_role: false
+  combat_skill: elite
+  movement_lead: false
+  movement_rear: true
+---
+
+# Viktor
+""")
+
+        result = verify_tactical_setup(
+            tmp_path / "book",
+            scene_outline_text=(
+                "Theo walks at the back of the formation. "
+                "Kael leads, Viktor walks in the middle."
+            ),
+            characters_present=["theo", "kael", "viktor"],
+        )
+        assert result["passes"] is False
+        assert isinstance(result["warnings"], list)
+        assert isinstance(result["questions_for_writer"], list)
+        assert len(result["questions_for_writer"]) >= 3

--- a/tools/analysis/tactical_checker.py
+++ b/tools/analysis/tactical_checker.py
@@ -1,0 +1,567 @@
+"""Tactical sanity checker for combat and travel scenes — Issue #75.
+
+Cross-references the optional `tactical` block of each character's
+markdown profile with the scene outline, and surfaces walking-order
+or formation problems before the scene is written. The MCP tool
+``verify_tactical_setup`` orchestrates load + analysis and returns a
+JSON brief (``passes`` / ``warnings`` / ``questions_for_writer``) so
+``chapter-writer`` can resolve issues before drafting.
+
+Heuristic — not a ground-truth model. The purpose is to force 30
+seconds of structured thought before tactical scenes, not to validate
+every formation. False positives are acceptable; false negatives
+(silent passes on the obviously broken setup beta-feedback called
+out) are not.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from tools.state.parsers import parse_frontmatter
+
+
+# ---------------------------------------------------------------------------
+# Tactical-scene detection
+# ---------------------------------------------------------------------------
+
+# Single-word triggers covered by a word-boundary match. Multi-word
+# phrases are matched separately because the boundary regex would fight
+# the whitespace between tokens.
+_TACTICAL_WORD_KEYWORDS = (
+    "fight",
+    "fights",
+    "fighting",
+    "fought",
+    "attack",
+    "attacks",
+    "attacking",
+    "attacked",
+    "combat",
+    "drive",
+    "drives",
+    "driving",
+    "drove",
+    "walk",
+    "walks",
+    "walking",
+    "walked",
+    "hike",
+    "hikes",
+    "hiking",
+    "hiked",
+    "run",
+    "runs",
+    "running",
+    "ran",
+    "mission",
+    "approach",
+    "approaches",
+    "approaching",
+    "approached",
+    "ambush",
+    "ambushed",
+    "raid",
+    "infiltrate",
+    "extract",
+    "pursue",
+    "flee",
+    "fled",
+)
+
+_TACTICAL_PHRASES = (
+    "enter the building",
+    "enter the house",
+    "breach the door",
+    "go in hot",
+    "single-file",
+    "cover me",
+)
+
+
+def is_tactical_scene(scene_text: str) -> bool:
+    """Return True when the scene reads as combat or group movement.
+
+    Detects overt action verbs (``fight``, ``attack``, ``walk``,
+    ``drive``, etc.) and a small set of multi-word phrases. A quiet
+    dialogue scene with no movement keywords stays False so the
+    pre-write check does not run on every kitchen-table beat.
+    """
+    if not scene_text:
+        return False
+    lowered = scene_text.lower()
+    for phrase in _TACTICAL_PHRASES:
+        if phrase in lowered:
+            return True
+    if re.search(
+        r"\b(?:" + "|".join(_TACTICAL_WORD_KEYWORDS) + r")\b",
+        lowered,
+    ):
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Tactical profile (loaded from character markdown frontmatter)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TacticalProfile:
+    """Per-character tactical metadata used by the formation checker."""
+
+    name: str
+    slug: str
+    protector_role: bool = False
+    protected_role: bool = False
+    combat_skill: str = "unknown"
+    movement_lead: bool = False
+    movement_rear: bool = False
+    vulnerable_to: tuple[str, ...] = ()
+    carries: tuple[str, ...] = ()
+    has_tactical_data: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "slug": self.slug,
+            "protector_role": self.protector_role,
+            "protected_role": self.protected_role,
+            "combat_skill": self.combat_skill,
+            "movement_lead": self.movement_lead,
+            "movement_rear": self.movement_rear,
+            "vulnerable_to": list(self.vulnerable_to),
+            "carries": list(self.carries),
+            "has_tactical_data": self.has_tactical_data,
+        }
+
+
+def _coerce_list(value: Any) -> tuple[str, ...]:
+    if isinstance(value, list):
+        return tuple(str(v) for v in value)
+    if isinstance(value, str):
+        return (value,)
+    return ()
+
+
+def parse_tactical_profile(path: Path) -> TacticalProfile | None:
+    """Load a TacticalProfile from a character markdown file.
+
+    Characters without a ``tactical:`` frontmatter block still load —
+    the returned profile carries ``has_tactical_data=False`` so the
+    analyzer can warn rather than silently pass.
+    """
+    if not path.is_file():
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    meta, _body = parse_frontmatter(text)
+    tactical = meta.get("tactical")
+    has_data = isinstance(tactical, dict) and bool(tactical)
+    if not isinstance(tactical, dict):
+        tactical = {}
+
+    return TacticalProfile(
+        name=str(meta.get("name", path.stem)),
+        slug=path.stem,
+        protector_role=bool(tactical.get("protector_role", False)),
+        protected_role=bool(tactical.get("protected_role", False)),
+        combat_skill=str(tactical.get("combat_skill", "unknown")),
+        movement_lead=bool(tactical.get("movement_lead", False)),
+        movement_rear=bool(tactical.get("movement_rear", False)),
+        vulnerable_to=_coerce_list(tactical.get("vulnerable_to", [])),
+        carries=_coerce_list(tactical.get("carries", [])),
+        has_tactical_data=has_data,
+    )
+
+
+def load_tactical_profiles(
+    book_root: Path,
+    slugs: list[str],
+) -> list[TacticalProfile]:
+    """Load tactical profiles for the given character slugs.
+
+    Missing files are silently dropped so callers can pass scene-derived
+    rosters that may include placeholder names. Pure I/O wrapper around
+    :func:`parse_tactical_profile`.
+    """
+    chars_dir = book_root / "characters"
+    profiles: list[TacticalProfile] = []
+    for slug in slugs:
+        profile = parse_tactical_profile(chars_dir / f"{slug}.md")
+        if profile is not None:
+            profiles.append(profile)
+    return profiles
+
+
+# ---------------------------------------------------------------------------
+# Position detection
+# ---------------------------------------------------------------------------
+
+# Position-keyword vocabularies. Order matters within a class — the
+# more specific phrase wins when multiple match the same character.
+_LEAD_KEYWORDS = (
+    "took the lead",
+    "takes the lead",
+    "leads the way",
+    "led the way",
+    "took point",
+    "takes point",
+    "at point",
+    "on point",
+    "leading",
+    "leads",
+    "led",
+    "lead",
+    "point",
+    "front",
+    "ahead",
+    "scouts",
+    "scout",
+    "scouting",
+)
+_REAR_KEYWORDS = (
+    "brings up the rear",
+    "brought up the rear",
+    "at the rear",
+    "in the rear",
+    "at the back",
+    "in the back",
+    "falls behind",
+    "fell behind",
+    "trailing",
+    "trailed",
+    "trail",
+    "rear",
+    "back",
+    "tail",
+    "last",
+)
+_MIDDLE_KEYWORDS = (
+    "flanked by",
+    "flanked",
+    "flanks",
+    "in the middle",
+    "in between",
+    "between",
+    "walks in the middle",
+    "walked in the middle",
+)
+
+_POSITION_CLASSES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("middle", _MIDDLE_KEYWORDS),
+    ("lead", _LEAD_KEYWORDS),
+    ("rear", _REAR_KEYWORDS),
+)
+
+# Flat keyword list, sorted longest-first so multi-word phrases match
+# before their substrings (e.g. "at the back" wins over "back").
+_FLAT_POSITION_KEYWORDS: tuple[tuple[str, str], ...] = tuple(
+    sorted(
+        (
+            (kw, label)
+            for label, keywords in _POSITION_CLASSES
+            for kw in keywords
+        ),
+        key=lambda item: -len(item[0]),
+    )
+)
+
+
+def _find_position_keywords(text: str) -> list[tuple[int, int, str]]:
+    """Return non-overlapping (start, end, class) hits, longest-match first.
+
+    The greedy occupation pass guarantees ``"at the back"`` consumes its
+    span before the bare ``"back"`` keyword can claim a subset of the
+    same characters.
+    """
+    text_lower = text.lower()
+    occupied = [False] * len(text)
+    hits: list[tuple[int, int, str]] = []
+    for keyword, label in _FLAT_POSITION_KEYWORDS:
+        for match in re.finditer(re.escape(keyword), text_lower):
+            start, end = match.start(), match.end()
+            if any(occupied[start:end]):
+                continue
+            for i in range(start, end):
+                occupied[i] = True
+            hits.append((start, end, label))
+    hits.sort()
+    return hits
+
+
+def _split_sentences(text: str) -> list[tuple[int, int]]:
+    """Sentence boundaries as ``(start, end)`` offsets into ``text``."""
+    spans: list[tuple[int, int]] = []
+    last = 0
+    for match in re.finditer(r"[.!?](?:\s|$)", text):
+        spans.append((last, match.end()))
+        last = match.end()
+    if last < len(text):
+        spans.append((last, len(text)))
+    return spans
+
+
+def detect_positions(
+    scene_text: str,
+    character_names: list[str],
+) -> dict[str, str]:
+    """Map each character name to ``lead`` / ``rear`` / ``middle`` / ``unknown``.
+
+    Heuristic — attributes each position keyword to the *preceding*
+    character name in its sentence. This matches natural prose
+    syntax: "Theo walked flanked by Kael at point" attributes
+    ``flanked`` to Theo and ``point`` to Kael, not the reverse.
+    Sentence boundaries prevent keyword bleed across full stops.
+    Falls back to nearest-name attribution when no name precedes the
+    keyword in the same sentence.
+    """
+    positions: dict[str, str] = {name: "unknown" for name in character_names}
+    if not scene_text or not character_names:
+        return positions
+
+    for sent_start, sent_end in _split_sentences(scene_text):
+        sentence = scene_text[sent_start:sent_end]
+        name_hits: list[tuple[int, int, str]] = []
+        for name in character_names:
+            for match in re.finditer(re.escape(name), sentence):
+                name_hits.append((match.start(), match.end(), name))
+        if not name_hits:
+            continue
+        keyword_hits = _find_position_keywords(sentence)
+        if not keyword_hits:
+            continue
+        for kstart, _kend, klabel in keyword_hits:
+            preceding = [hit for hit in name_hits if hit[1] <= kstart]
+            target_name: str | None = None
+            if preceding:
+                target_name = max(preceding, key=lambda hit: hit[1])[2]
+            else:
+                target_name = min(
+                    name_hits,
+                    key=lambda hit: abs(hit[0] - kstart),
+                )[2]
+            if positions[target_name] == "unknown":
+                positions[target_name] = klabel
+    return positions
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TacticalWarning:
+    severity: str  # "warn" | "info"
+    message: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"severity": self.severity, "message": self.message}
+
+
+@dataclass(frozen=True)
+class TacticalAnalysis:
+    passes: bool
+    warnings: list[TacticalWarning] = field(default_factory=list)
+    questions_for_writer: list[str] = field(default_factory=list)
+    detected_positions: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "passes": self.passes,
+            "warnings": [w.to_dict() for w in self.warnings],
+            "questions_for_writer": list(self.questions_for_writer),
+            "detected_positions": dict(self.detected_positions),
+        }
+
+
+# Universal questions surface for every combat/travel scene. The first
+# three apply to any group-movement scene; the last two specialize
+# when a protected/vulnerable character is present.
+_BASE_QUESTIONS: tuple[str, ...] = (
+    "Who scouts ahead?",
+    "What is the formation if they need to break and run?",
+    "Who has line-of-sight on whom when contact happens?",
+    "What's the order of march if attacked from behind?",
+    "Where does each character go to ground if shooting starts?",
+)
+
+_PROTECTED_QUESTION_TEMPLATE = "Who is closest to {name} at all times?"
+_VULNERABLE_QUESTION_TEMPLATE = (
+    "{name} is most vulnerable — who is covering them?"
+)
+
+
+def _build_questions(profiles: list[TacticalProfile]) -> list[str]:
+    questions: list[str] = []
+    protected = [p for p in profiles if p.protected_role]
+    if protected:
+        # One specialized question per protected character (cap at 2 to
+        # keep the brief readable).
+        for p in protected[:2]:
+            questions.append(
+                _PROTECTED_QUESTION_TEMPLATE.format(name=p.name)
+            )
+    most_vulnerable = _pick_most_vulnerable(profiles)
+    if most_vulnerable is not None and not protected:
+        questions.append(
+            _VULNERABLE_QUESTION_TEMPLATE.format(name=most_vulnerable.name)
+        )
+    # Backfill from the base list until we have at least 3 questions.
+    for q in _BASE_QUESTIONS:
+        if len(questions) >= 5:
+            break
+        if q not in questions:
+            questions.append(q)
+    return questions[:5]
+
+
+def _pick_most_vulnerable(
+    profiles: list[TacticalProfile],
+) -> TacticalProfile | None:
+    """Pick the lowest-skill / non-protector character for the
+    'who covers them' question."""
+    skill_rank = {"none": 0, "low": 1, "medium": 2, "high": 3, "elite": 4}
+    candidates = [p for p in profiles if not p.protector_role]
+    if not candidates:
+        return None
+    return min(
+        candidates,
+        key=lambda p: skill_rank.get(p.combat_skill, 5),
+    )
+
+
+def analyze_tactical_setup(
+    scene_text: str,
+    profiles: list[TacticalProfile],
+) -> TacticalAnalysis:
+    """Apply walking-order heuristics and return the analysis brief.
+
+    Rules:
+
+    * **Protected at rear** → warn. The unprotected human at the back
+      of a protector formation is the named beta-feedback regression.
+    * **Protected at lead** → warn. Scouts go up front; protected
+      characters do not.
+    * **Protectors absent or all at rear** when a protected character
+      is present → warn.
+    * **No tactical data on any present character** → warn (graceful
+      degrade — the writer should still get the questions).
+
+    Always returns at least three questions for the writer regardless
+    of pass/fail.
+    """
+    warnings: list[TacticalWarning] = []
+    positions = detect_positions(
+        scene_text, character_names=[p.name for p in profiles],
+    )
+
+    protectors = [p for p in profiles if p.protector_role]
+    protected = [p for p in profiles if p.protected_role]
+
+    # R0: missing tactical data → info-severity. Graceful degrade so
+    # the writer still gets the questions list, but with a nudge to
+    # add tactical frontmatter on these characters.
+    missing_data = [p for p in profiles if not p.has_tactical_data]
+    if missing_data and not protectors and not protected:
+        names = ", ".join(p.name for p in missing_data)
+        warnings.append(TacticalWarning(
+            severity="info",
+            message=(
+                f"No tactical profile for: {names}. "
+                "Add a `tactical` block to each character's frontmatter "
+                "for richer formation checks."
+            ),
+        ))
+
+    # R1: protected character at rear.
+    for p in protected:
+        if positions.get(p.name) == "rear" and protectors:
+            others = ", ".join(pr.name for pr in protectors)
+            warnings.append(TacticalWarning(
+                severity="warn",
+                message=(
+                    f"{p.name} (protected_role: true, "
+                    f"combat_skill: {p.combat_skill}) is in rear position. "
+                    f"Protectors ({others}) should flank or trail."
+                ),
+            ))
+
+    # R2: protected character at lead.
+    for p in protected:
+        if positions.get(p.name) == "lead":
+            warnings.append(TacticalWarning(
+                severity="warn",
+                message=(
+                    f"{p.name} (protected_role: true) is at the lead. "
+                    "Scouts/protectors take point — not the protected character."
+                ),
+            ))
+
+    # R3: protected present but no protector covers a forward or rear
+    # position.
+    if protected and protectors:
+        protector_positions = {
+            positions.get(pr.name, "unknown") for pr in protectors
+        }
+        if not (protector_positions & {"lead", "rear", "middle"}):
+            warnings.append(TacticalWarning(
+                severity="warn",
+                message=(
+                    "Protected character present but no protector has a "
+                    "detectable position. Spell out who covers lead and rear."
+                ),
+            ))
+
+    # R4: lead position should match `movement_lead: true` when known.
+    for name, pos in positions.items():
+        if pos != "lead":
+            continue
+        profile = next((p for p in profiles if p.name == name), None)
+        if profile is None or not profile.has_tactical_data:
+            continue
+        if not profile.movement_lead and not profile.protector_role:
+            warnings.append(TacticalWarning(
+                severity="warn",
+                message=(
+                    f"{name} is taking the lead but their profile has "
+                    "movement_lead: false and protector_role: false. "
+                    "Confirm this is intentional."
+                ),
+            ))
+
+    passes = not any(w.severity == "warn" for w in warnings)
+    return TacticalAnalysis(
+        passes=passes,
+        warnings=warnings,
+        questions_for_writer=_build_questions(profiles),
+        detected_positions=positions,
+    )
+
+
+# ---------------------------------------------------------------------------
+# MCP-facing orchestrator
+# ---------------------------------------------------------------------------
+
+
+def verify_tactical_setup(
+    book_root: Path,
+    scene_outline_text: str,
+    characters_present: list[str],
+) -> dict[str, Any]:
+    """Load profiles + analyze + return JSON-ready dict.
+
+    The MCP tool layer wraps this and wraps the result in
+    ``json.dumps``. Returning a dict keeps unit tests cheap and lets
+    the analyzer call this for assertion convenience.
+    """
+    profiles = load_tactical_profiles(book_root, characters_present)
+    analysis = analyze_tactical_setup(scene_outline_text, profiles)
+    return analysis.to_dict()


### PR DESCRIPTION
## Summary

Closes #75 (Sprint 2, P1).

Walking-order errors (the unprotected human at the back of a vampire-protector team) survived because nothing forced 30 seconds of structured thought before action scenes. Skill-prompt reminders got skimmed under context pressure. This moves the check to a hard tool.

- **New `tools/analysis/tactical_checker.py`**: parses an optional `tactical:` block from each character's frontmatter and runs heuristics against the scene outline. `is_tactical_scene` filters on action/movement keywords so the check only fires when relevant.
- **Position detector** attributes lead/rear/middle keywords to the *preceding* character name within each sentence — matches natural prose syntax ("Theo walked flanked by Kael at point and Viktor at the rear" → Theo=middle, Kael=lead, Viktor=rear).
- **New MCP tool** `verify_tactical_setup(book_slug, scene_outline_text, characters_present)` returns JSON with `passes`, `warnings`, `questions_for_writer` (always ≥ 3), and `detected_positions`.
- **Skill wiring**: `chapter-writer` Step A2 and `rolling-planner` Step 4b call the tool before drafting combat / travel scenes and resolve warn-severity findings before prose hits `draft.md`.
- **Template extension**: `templates/character.md` ships the tactical block as commented-out scaffolding so creators see the shape but only fill it in for action characters.

## Acceptance criteria (from #75)

- [x] Sample scene with Theo at the rear of a Kael/Viktor/Dom team triggers a warning.
- [x] Sample scene with Theo flanked by Kael (point) and Viktor (rear) passes.
- [x] Tool returns at least 3 tactical questions for any combat/travel scene.
- [x] `chapter-writer` skill prompt updated to invoke this tool before relevant scenes (`rolling-planner` too).
- [x] Tests cover: protector-at-rear (warn), protected-at-rear (warn), correct formation (pass), no-tactical-data (graceful info-severity degrade).

## Test plan

- [x] `pytest` — 448 passed (23 new in `test_tactical_checker.py`)
- [x] `ruff check` — clean
- [x] Smoke check on the two acceptance scene snippets (Theo-at-rear and Theo-flanked) confirms expected warn / pass behavior
- [x] Manual: write a Blood & Binary scene with combat/travel and confirm the pre-write call surfaces the questions in the brief

## Design notes

- The five rules deliberately favor false positives over false negatives. The whole point is forcing 30 seconds of thought; surfacing one extra question is cheaper than missing the walking-order regression a second time.
- Missing-data warnings are info-severity, not warn — `passes` stays True even when characters have no tactical block. The writer gets the questions list either way.
- Heuristic position attribution is sentence-bounded and uses preceding-name attribution. This handles common patterns ("X took point", "Y brought up the rear", "X flanked by Y") without trying to parse arbitrary syntax. Edge cases that confuse it (multiple verbs in one sentence) still produce reasonable defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)