### PR TITLE
refactor: replace direct file reads with get_review_brief() and get_continuity_brief() MCP tools

### DIFF
--- a/servers/storyforge-server/server.py
+++ b/servers/storyforge-server/server.py
@@ -36,6 +36,10 @@ from tools.state.chapter_timeline_parser import (
 from tools.state.chapter_writing_brief import (
     build_chapter_writing_brief as _build_chapter_writing_brief_impl,
 )
+from tools.state.review_brief import build_review_brief as _build_review_brief_impl
+from tools.state.continuity_brief import (
+    build_continuity_brief as _build_continuity_brief_impl,
+)
 from tools.timeline_anchor import get_story_anchor
 from tools.claudemd.manager import (
     append_callback as _append_callback_impl,
@@ -358,6 +362,76 @@ def get_chapter_writing_brief(book_slug: str, chapter_slug: str) -> str:
         chapter_slug=chapter_slug,
         plugin_root=plugin_root,
         review_handle=review_handle,
+    ))
+
+
+@mcp.tool()
+def get_review_brief(book_slug: str, chapter_slug: str) -> str:
+    """Structured brief for chapter-reviewer — Issue #99 (ADR-0001).
+
+    Replaces direct file reads in ``chapter-reviewer`` with a single
+    structured JSON payload. The brief bundles every piece of project-state
+    metadata the reviewer needs: chapter timelines, canonical timeline,
+    travel matrix, canon log facts, tonal rules, and book CLAUDE.md rules.
+
+    Chapter draft text is intentionally NOT included — the reviewer reads
+    that directly as the primary content under review.
+
+    Args:
+        book_slug: Book identifier.
+        chapter_slug: Chapter identifier (e.g. "22-the-night-before").
+
+    Returns JSON with:
+        chapter_timeline        — start/end/scenes for the target chapter
+        previous_chapter_timeline — same for the preceding chapter (or null)
+        canonical_timeline_entries — parsed plot/timeline.md events
+        travel_matrix           — parsed world/setting.md Travel Matrix rows
+        canon_log_facts         — parsed plot/canon-log.md Established Facts
+        tonal_rules             — non-negotiable rules, litmus, banned patterns
+        active_rules            — book CLAUDE.md ## Rules with severity
+        active_callbacks        — book CLAUDE.md ## Callback Register items
+        errors                  — partial failures (brief ships with degraded data)
+    """
+    book_root = resolve_project_path(load_config(), book_slug)
+    if not book_root.is_dir():
+        return json.dumps({"error": f"Book directory missing on disk: {book_root}"})
+
+    return json.dumps(_build_review_brief_impl(
+        book_root=book_root,
+        book_slug=book_slug,
+        chapter_slug=chapter_slug,
+    ))
+
+
+@mcp.tool()
+def get_continuity_brief(book_slug: str) -> str:
+    """Structured brief for continuity-checker — Issue #100 (ADR-0001).
+
+    Replaces direct file reads in ``continuity-checker`` with a single
+    structured JSON payload. Bundles canonical calendar, travel matrix,
+    canon log facts, character index, and all chapter timeline grids.
+
+    Chapter draft texts are intentionally NOT included — they are the data
+    being checked, not project-state metadata (ADR-0001).
+
+    Args:
+        book_slug: Book identifier.
+
+    Returns JSON with:
+        canonical_calendar  — parsed plot/timeline.md events
+        travel_matrix       — parsed world/setting.md Travel Matrix rows
+        canon_log_facts     — parsed plot/canon-log.md Established Facts
+        character_index     — all character files as flat list
+        chapter_timelines   — all chapter timeline grids (any status)
+        errors              — partial failures (brief ships with degraded data)
+    """
+    book_root = resolve_project_path(load_config(), book_slug)
+    if not book_root.is_dir():
+        return json.dumps({"error": f"Book directory missing on disk: {book_root}"})
+
+    return json.dumps(_build_continuity_brief_impl(
+        book_root=book_root,
+        book_slug=book_slug,
     ))
 
 

--- a/skills/chapter-reviewer/SKILL.md
+++ b/skills/chapter-reviewer/SKILL.md
@@ -12,6 +12,25 @@ argument-hint: "<book-slug> <chapter-slug>"
 # Chapter Reviewer
 
 ## Prerequisites — MANDATORY LOADS
+
+### Step 1 — Load the review brief (single MCP call, replaces 6+ direct file reads)
+
+Call MCP `get_review_brief(book_slug, chapter_slug)`. This returns:
+
+- `chapter_timeline` — intra-day time grid for this chapter (start/end/scenes)
+- `previous_chapter_timeline` — same for the preceding chapter (cross-chapter time checks)
+- `canonical_timeline_entries` — parsed `plot/timeline.md` events (day/date/chapter/events)
+- `travel_matrix` — parsed `world/setting.md` Travel Matrix rows (from/to/distance/travel_time)
+- `canon_log_facts` — parsed `plot/canon-log.md` facts with status (ACTIVE / CHANGED)
+- `tonal_rules` — non-negotiable rules, litmus test, banned patterns, warning signs from `plot/tone.md`
+- `active_rules` — book CLAUDE.md ## Rules with severity (block / advisory)
+- `active_callbacks` — book CLAUDE.md ## Callback Register items
+- `errors` — graceful degrade: non-empty means some files were missing or unreadable
+
+Honor every populated field in the brief. Empty lists / null means "file missing — degrade gracefully, do not invent."
+
+### Step 2 — Load author and craft context (MCP calls)
+
 - **Author profile** via MCP `get_author()`. **Why:** Voice consistency check needs the documented baseline — without it, "voice match" is gut-feel.
 - **Author vocabulary** from `~/.storyforge/authors/{slug}/vocabulary.md`. **Why:** Banned-word scan and preferred-word presence check both run against this list.
 - **Craft references** via MCP `get_craft_reference()`:
@@ -21,18 +40,14 @@ argument-hint: "<book-slug> <chapter-slug>"
   - `dialog-craft` — **Why:** Subtext, voice differentiation, tag discipline — for points 9 and 15.
   - `show-dont-tell` — **Why:** Show/tell balance check for points 6 and 24.
   - `simile-discipline` — **Why:** The two-question test sub-point 10b runs.
-- **Detect if this is Chapter 1:** Check chapter slug (starts with `01-` or `001-`) or frontmatter chapter number (`chapter: 1`). If Chapter 1: also load `openings-and-endings` craft reference.
+- **Detect if this is Chapter 1:** Check chapter slug (starts with `01-` or `001-`) or frontmatter chapter number. If Chapter 1: also load `openings-and-endings` craft reference.
+
+### Step 3 — Read the prose (direct file reads — this is the content under review)
+
 - Read the chapter draft: `{project}/chapters/{chapter}/draft.md`
 - Read the chapter outline: `{project}/chapters/{chapter}/README.md`
-- Read previous chapter draft for continuity
-- Read `{project}/plot/canon-log.md` — check for facts marked `CHANGED` that this chapter may still reference incorrectly
-- Read `{project}/plot/timeline.md` — verify temporal claims match the canonical timeline
-- Read `{project}/world/setting.md` — verify travel times/distances match the Travel Matrix
-- Read `{project}/plot/tone.md` if it exists — check tonal rules, warning signs, and litmus test for this chapter's arc position
-- Read the `## Chapter Timeline` section from this chapter's `README.md` — verify all time references in the prose match the logged times
-- Read the `## Chapter Timeline` from the PREVIOUS chapter's `README.md` — verify cross-chapter time references (e.g. "an hour ago" across chapter boundaries)
+- Read previous chapter draft for continuity context
 - Optional: If `{project}/research/manuscript-report.md` exists, read it and check whether any of THIS chapter's distinctive 5-7 word phrases already appear in earlier chapters (lightweight cross-chapter repetition check). Flag any matches in the Continuity Report section.
-- **Per-book CLAUDE.md** — MCP `get_book_claudemd(book_slug)`. Mandatory. Check the draft against every **Rule** (deduct points if violated) and verify that **Callbacks** are either honored, intentionally deferred, or not applicable to this chapter. Flag missed callbacks in the Continuity Report section.
 
 ## First Chapter Checklist — 13 Points (ONLY for Chapter 1)
 

--- a/skills/continuity-checker/SKILL.md
+++ b/skills/continuity-checker/SKILL.md
@@ -18,13 +18,29 @@ Systematically scan all chapter drafts for inconsistencies in:
 2. **Spatial continuity** — distances, travel times, location descriptions
 
 ## Prerequisites
+
+### Step 1 — Load the continuity brief (single MCP call, replaces 4+ direct file reads)
+
+Call MCP `get_continuity_brief(book_slug)`. This returns:
+
+- `canonical_calendar` — parsed `plot/timeline.md` events (story_day/real_date/chapter_slug/key_events)
+- `travel_matrix` — parsed `world/setting.md` Travel Matrix rows (from/to/distance/transport/travel_time/notes)
+- `canon_log_facts` — parsed `plot/canon-log.md` facts with status (ACTIVE / CHANGED / SUPERSEDED) and domain
+- `character_index` — all character files as flat list (slug/name/role/description)
+- `chapter_timelines` — intra-day timeline grids for ALL chapters (any status); use these as the source of truth for chapter start/end anchors and scene-level clock times instead of re-parsing each `README.md`
+- `errors` — graceful degrade: non-empty means some files were missing or unreadable
+
+Honor every populated field in the brief. Empty lists mean "file missing — degrade gracefully, do not invent."
+
+### Step 2 — Load book metadata
+
 - Load book data via MCP `get_book_full()`
-- Read `{project}/plot/timeline.md` — canonical timeline
-- Read `{project}/plot/canon-log.md` — established facts and revision tracking
-- Read `{project}/world/setting.md` — Travel Matrix and location data
-- Load recent chapter timeline grids via MCP `get_recent_chapter_timelines(book_slug, n=99)` — structured intra-day grids for every review-or-later chapter; use these as the source of truth for chapter Start/End anchors and scene-level clock times instead of re-parsing each `README.md`.
+
+### Step 3 — Read the chapter drafts (direct file reads — this is the content under review)
+
+Chapter draft texts are intentionally NOT in the brief — they are the data being checked, not project-state metadata.
+
 - Read ALL chapter drafts: `{project}/chapters/*/draft.md`
-- Read ALL character files: `{project}/characters/*.md`
 
 ## Workflow
 

--- a/tests/test_continuity_brief.py
+++ b/tests/test_continuity_brief.py
@@ -1,0 +1,239 @@
+"""Tests for tools.state.continuity_brief — Issue #100.
+
+Verifies that build_continuity_brief() returns the correct structured
+payload including canonical_calendar, travel_matrix, canon_log_facts,
+character_index, and chapter_timelines for ALL chapters.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.state.continuity_brief import (
+    _build_character_index,
+    _get_all_chapter_timelines,
+    build_continuity_brief,
+)
+from tests.test_review_brief import (
+    CANON_LOG_SAMPLE,
+    TRAVEL_MATRIX_SAMPLE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_book(tmp_path: Path) -> tuple[Path, str]:
+    book_slug = "test-book"
+    book = tmp_path / book_slug
+    (book / "chapters").mkdir(parents=True)
+    (book / "characters").mkdir()
+    (book / "plot").mkdir()
+    (book / "world").mkdir()
+    (book / "README.md").write_text(
+        '---\ntitle: "Test Book"\nauthor: ""\n---\n\n# Test Book\n',
+        encoding="utf-8",
+    )
+    return book, book_slug
+
+
+def _add_chapter(
+    book: Path,
+    slug: str,
+    *,
+    number: int,
+    status: str = "Draft",
+) -> Path:
+    chapter = book / "chapters" / slug
+    chapter.mkdir(parents=True)
+    (chapter / "README.md").write_text(
+        f'---\ntitle: "Chapter {number}"\nnumber: {number}\n'
+        f'status: "{status}"\n---\n\n# Chapter {number}\n',
+        encoding="utf-8",
+    )
+    (chapter / "draft.md").write_text(
+        f"Draft content for chapter {number}.", encoding="utf-8"
+    )
+    return chapter
+
+
+def _add_character(
+    book: Path,
+    slug: str,
+    *,
+    name: str,
+    role: str = "supporting",
+) -> None:
+    (book / "characters" / f"{slug}.md").write_text(
+        f'---\nname: "{name}"\nrole: "{role}"\n---\n\n# {name}\n',
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _build_character_index
+# ---------------------------------------------------------------------------
+
+
+def test_build_character_index_finds_all_characters(tmp_path):
+    book, _ = _make_book(tmp_path)
+    _add_character(book, "marcus", name="Marcus", role="protagonist")
+    _add_character(book, "lena", name="Lena", role="supporting")
+
+    result = _build_character_index(book)
+    assert len(result) == 2
+
+
+def test_build_character_index_correct_fields(tmp_path):
+    book, _ = _make_book(tmp_path)
+    _add_character(book, "marcus", name="Marcus", role="protagonist")
+
+    result = _build_character_index(book)
+    assert result[0]["slug"] == "marcus"
+    assert result[0]["name"] == "Marcus"
+    assert result[0]["role"] == "protagonist"
+
+
+def test_build_character_index_skips_index_md(tmp_path):
+    book, _ = _make_book(tmp_path)
+    _add_character(book, "marcus", name="Marcus", role="protagonist")
+    (book / "characters" / "INDEX.md").write_text(
+        "# Characters Index\n", encoding="utf-8"
+    )
+
+    result = _build_character_index(book)
+    slugs = [c["slug"] for c in result]
+    assert "INDEX" not in slugs
+    assert "marcus" in slugs
+
+
+def test_build_character_index_empty_chars_dir(tmp_path):
+    book, _ = _make_book(tmp_path)
+    result = _build_character_index(book)
+    assert result == []
+
+
+def test_build_character_index_missing_chars_dir(tmp_path):
+    book, _ = _make_book(tmp_path)
+    (book / "characters").rmdir()
+    result = _build_character_index(book)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _get_all_chapter_timelines
+# ---------------------------------------------------------------------------
+
+
+def test_get_all_chapter_timelines_includes_all_statuses(tmp_path):
+    """Unlike get_recent_chapter_timelines, all statuses must be included."""
+    book, _ = _make_book(tmp_path)
+    _add_chapter(book, "01-opening", number=1, status="Outline")
+    _add_chapter(book, "02-draft", number=2, status="Draft")
+    _add_chapter(book, "03-review", number=3, status="Revision")
+
+    result = _get_all_chapter_timelines(book)
+    assert len(result) == 3
+
+
+def test_get_all_chapter_timelines_correct_order(tmp_path):
+    book, _ = _make_book(tmp_path)
+    _add_chapter(book, "01-opening", number=1)
+    _add_chapter(book, "02-conflict", number=2)
+    _add_chapter(book, "03-resolution", number=3)
+
+    result = _get_all_chapter_timelines(book)
+    numbers = [r["number"] for r in result]
+    assert numbers == sorted(numbers)
+
+
+def test_get_all_chapter_timelines_empty_book(tmp_path):
+    book, _ = _make_book(tmp_path)
+    result = _get_all_chapter_timelines(book)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — build_continuity_brief
+# ---------------------------------------------------------------------------
+
+
+def test_build_continuity_brief_returns_all_expected_keys(tmp_path):
+    book, slug = _make_book(tmp_path)
+
+    result = build_continuity_brief(book_root=book, book_slug=slug)
+
+    expected_keys = {
+        "book_slug",
+        "canonical_calendar",
+        "travel_matrix",
+        "canon_log_facts",
+        "character_index",
+        "chapter_timelines",
+        "errors",
+    }
+    assert expected_keys <= set(result.keys())
+
+
+def test_build_continuity_brief_no_errors_empty_book(tmp_path):
+    book, slug = _make_book(tmp_path)
+
+    result = build_continuity_brief(book_root=book, book_slug=slug)
+
+    assert result["errors"] == []
+
+
+def test_build_continuity_brief_travel_matrix_populated(tmp_path):
+    book, slug = _make_book(tmp_path)
+    (book / "world" / "setting.md").write_text(TRAVEL_MATRIX_SAMPLE, encoding="utf-8")
+
+    result = build_continuity_brief(book_root=book, book_slug=slug)
+
+    assert len(result["travel_matrix"]) == 2
+
+
+def test_build_continuity_brief_canon_log_facts_populated(tmp_path):
+    book, slug = _make_book(tmp_path)
+    (book / "plot" / "canon-log.md").write_text(CANON_LOG_SAMPLE, encoding="utf-8")
+
+    result = build_continuity_brief(book_root=book, book_slug=slug)
+
+    assert len(result["canon_log_facts"]) == 3
+
+
+def test_build_continuity_brief_character_index_populated(tmp_path):
+    book, slug = _make_book(tmp_path)
+    _add_character(book, "marcus", name="Marcus", role="protagonist")
+    _add_character(book, "lena", name="Lena")
+
+    result = build_continuity_brief(book_root=book, book_slug=slug)
+
+    assert len(result["character_index"]) == 2
+    names = {c["name"] for c in result["character_index"]}
+    assert names == {"Marcus", "Lena"}
+
+
+def test_build_continuity_brief_chapter_timelines_all_statuses(tmp_path):
+    """Chapter timelines must include ALL chapters regardless of status."""
+    book, slug = _make_book(tmp_path)
+    _add_chapter(book, "01-opening", number=1, status="Outline")
+    _add_chapter(book, "02-draft", number=2, status="Draft")
+    _add_chapter(book, "03-done", number=3, status="Revision")
+
+    result = build_continuity_brief(book_root=book, book_slug=slug)
+
+    assert len(result["chapter_timelines"]) == 3
+
+
+def test_build_continuity_brief_missing_optional_files_graceful(tmp_path):
+    """No setting.md, no canon-log.md → empty lists, no errors."""
+    book, slug = _make_book(tmp_path)
+
+    result = build_continuity_brief(book_root=book, book_slug=slug)
+
+    assert result["canonical_calendar"] == []
+    assert result["travel_matrix"] == []
+    assert result["canon_log_facts"] == []
+    assert result["errors"] == []

--- a/tests/test_review_brief.py
+++ b/tests/test_review_brief.py
@@ -1,0 +1,395 @@
+"""Tests for tools.state.review_brief — Issue #99.
+
+Verifies that build_review_brief() returns the correct structured payload
+and that the individual parsers handle the template format correctly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.state.review_brief import (
+    _parse_canon_log_facts,
+    _parse_tonal_rules,
+    _parse_travel_matrix,
+    build_review_brief,
+)
+
+# ---------------------------------------------------------------------------
+# Sample data matching the template format (world-setting.md, plot-canon-log.md,
+# plot-tone.md)
+# ---------------------------------------------------------------------------
+
+TRAVEL_MATRIX_SAMPLE = """\
+## Travel Matrix
+
+| From | To | Distance | Transport | Travel Time | Notes |
+|------|-----|----------|-----------|-------------|-------|
+| City | Campground | 120 km | Car | 2h 30min | Highway, no traffic |
+| Airport | Hotel | 15 km | Taxi | 20min | City traffic |
+"""
+
+CANON_LOG_SAMPLE = """\
+## Established Facts
+
+### Character Facts
+
+| Fact | Established In | Status | Notes |
+|------|----------------|--------|-------|
+| Marcus is a vampire | Ch 1 | ACTIVE | |
+| Lena eats normal food | Ch 4 (rev) | CHANGED | Was: Lena doesn't eat (Ch 4 original) |
+
+### World / Setting Facts
+
+| Fact | Established In | Status | Notes |
+|------|----------------|--------|-------|
+| Vampires can walk in daylight | Ch 1 | ACTIVE | But weakened by sunlight |
+"""
+
+TONE_SAMPLE = """\
+## Non-Negotiable Rules
+
+- At least one genuine laugh per chapter
+- Minimum 40% dialog ratio
+
+## Litmus Test
+
+1. Does the chapter make you want to turn the page?
+2. Is the protagonist's want clear by the end?
+
+## Banned Prose Patterns (Book-Specific)
+
+- No extended interiority without interruption
+- No weather descriptions as mood-setting
+
+## Tonal Arc
+
+| Stage | Chapters | Dominant Mode | Secondary Mode | Warning Signs |
+|-------|----------|---------------|----------------|---------------|
+| Act 1 | Ch. 1-3 | humor-forward | mystery undercurrent | reads as depressive |
+| Act 2 | Ch. 4-10 | tension rising | humor | no humor at all |
+"""
+
+
+# ---------------------------------------------------------------------------
+# Parser unit tests — _parse_travel_matrix
+# ---------------------------------------------------------------------------
+
+
+def test_parse_travel_matrix_returns_routes():
+    result = _parse_travel_matrix(TRAVEL_MATRIX_SAMPLE)
+    assert len(result) == 2
+
+
+def test_parse_travel_matrix_correct_fields():
+    result = _parse_travel_matrix(TRAVEL_MATRIX_SAMPLE)
+    first = result[0]
+    assert first["from"] == "City"
+    assert first["to"] == "Campground"
+    assert first["distance"] == "120 km"
+    assert first["travel_time"] == "2h 30min"
+    assert first["notes"] == "Highway, no traffic"
+
+
+def test_parse_travel_matrix_no_section():
+    result = _parse_travel_matrix("# No travel matrix here\n\nSome text.")
+    assert result == []
+
+
+def test_parse_travel_matrix_skips_placeholder_rows():
+    text = """\
+## Travel Matrix
+
+| From | To | Distance | Transport | Travel Time | Notes |
+|------|-----|----------|-----------|-------------|-------|
+| *e.g. City center* | *e.g. Campground* | *120 km* | *Car* | *2h 30min* | *Highway* |
+| Real City | Real Camp | 50 km | Bike | 3h | Dirt road |
+"""
+    result = _parse_travel_matrix(text)
+    assert len(result) == 1
+    assert result[0]["from"] == "Real City"
+
+
+# ---------------------------------------------------------------------------
+# Parser unit tests — _parse_canon_log_facts
+# ---------------------------------------------------------------------------
+
+
+def test_parse_canon_log_facts_extracts_all_facts():
+    result = _parse_canon_log_facts(CANON_LOG_SAMPLE)
+    assert len(result) == 3
+
+
+def test_parse_canon_log_facts_correct_status():
+    result = _parse_canon_log_facts(CANON_LOG_SAMPLE)
+    by_fact = {f["fact"]: f for f in result}
+    assert by_fact["Marcus is a vampire"]["status"] == "ACTIVE"
+    assert by_fact["Lena eats normal food"]["status"] == "CHANGED"
+
+
+def test_parse_canon_log_facts_includes_domain():
+    result = _parse_canon_log_facts(CANON_LOG_SAMPLE)
+    char_facts = [f for f in result if f["domain"] == "Character Facts"]
+    assert len(char_facts) == 2
+    world_facts = [f for f in result if f["domain"] == "World / Setting Facts"]
+    assert len(world_facts) == 1
+
+
+def test_parse_canon_log_facts_no_section():
+    result = _parse_canon_log_facts("# Canon Log\n\nNo established facts section.")
+    assert result == []
+
+
+def test_parse_canon_log_facts_skips_placeholder_rows():
+    text = """\
+## Established Facts
+
+### Character Facts
+
+| Fact | Established In | Status | Notes |
+|------|----------------|--------|-------|
+| *e.g. Marcus is a vampire who eats normal food* | Ch 4 (rev) | CHANGED | |
+| Real fact | Ch 1 | ACTIVE | |
+"""
+    result = _parse_canon_log_facts(text)
+    assert len(result) == 1
+    assert result[0]["fact"] == "Real fact"
+
+
+# ---------------------------------------------------------------------------
+# Parser unit tests — _parse_tonal_rules
+# ---------------------------------------------------------------------------
+
+
+def test_parse_tonal_rules_extracts_all_sections():
+    result = _parse_tonal_rules(TONE_SAMPLE)
+    assert "non_negotiable_rules" in result
+    assert "litmus_test" in result
+    assert "banned_prose_patterns" in result
+    assert "warning_signs" in result
+
+
+def test_parse_tonal_rules_non_negotiable_count():
+    result = _parse_tonal_rules(TONE_SAMPLE)
+    assert len(result["non_negotiable_rules"]) == 2
+
+
+def test_parse_tonal_rules_litmus_test_count():
+    result = _parse_tonal_rules(TONE_SAMPLE)
+    assert len(result["litmus_test"]) == 2
+
+
+def test_parse_tonal_rules_banned_patterns_count():
+    result = _parse_tonal_rules(TONE_SAMPLE)
+    assert len(result["banned_prose_patterns"]) == 2
+
+
+def test_parse_tonal_rules_warning_signs_from_arc_table():
+    result = _parse_tonal_rules(TONE_SAMPLE)
+    assert "reads as depressive" in result["warning_signs"]
+    assert "no humor at all" in result["warning_signs"]
+
+
+def test_parse_tonal_rules_empty_tone_file():
+    result = _parse_tonal_rules("")
+    assert result["non_negotiable_rules"] == []
+    assert result["litmus_test"] == []
+    assert result["banned_prose_patterns"] == []
+    assert result["warning_signs"] == []
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — build_review_brief
+# ---------------------------------------------------------------------------
+
+
+def _make_book(tmp_path: Path) -> tuple[Path, str]:
+    book_slug = "test-book"
+    book = tmp_path / book_slug
+    (book / "chapters").mkdir(parents=True)
+    (book / "plot").mkdir()
+    (book / "world").mkdir()
+    (book / "README.md").write_text(
+        '---\ntitle: "Test Book"\nauthor: ""\n---\n\n# Test Book\n',
+        encoding="utf-8",
+    )
+    return book, book_slug
+
+
+def _make_chapter(
+    book: Path,
+    slug: str,
+    *,
+    number: int,
+    status: str = "Draft",
+    has_timeline: bool = False,
+) -> Path:
+    chapter = book / "chapters" / slug
+    chapter.mkdir(parents=True)
+    timeline_section = (
+        "\n\n## Chapter Timeline\n\n"
+        "**Start:** Day 5 (Dec 25, 2025) — 14:30\n"
+        "**End:** Day 5 (Dec 25, 2025) — 17:00\n"
+    ) if has_timeline else ""
+    (chapter / "README.md").write_text(
+        f'---\ntitle: "Chapter {number}"\nnumber: {number}\n'
+        f'status: "{status}"\n---\n\n# Chapter {number}\n{timeline_section}',
+        encoding="utf-8",
+    )
+    (chapter / "draft.md").write_text("The chapter draft content.", encoding="utf-8")
+    return chapter
+
+
+def test_build_review_brief_returns_all_expected_keys(tmp_path):
+    book, slug = _make_book(tmp_path)
+    _make_chapter(book, "01-opening", number=1)
+
+    result = build_review_brief(
+        book_root=book,
+        book_slug=slug,
+        chapter_slug="01-opening",
+    )
+
+    expected_keys = {
+        "book_slug",
+        "chapter_slug",
+        "chapter_timeline",
+        "previous_chapter_timeline",
+        "canonical_timeline_entries",
+        "travel_matrix",
+        "canon_log_facts",
+        "tonal_rules",
+        "active_rules",
+        "active_callbacks",
+        "errors",
+    }
+    assert expected_keys <= set(result.keys())
+
+
+def test_build_review_brief_no_errors_for_minimal_book(tmp_path):
+    book, slug = _make_book(tmp_path)
+    _make_chapter(book, "01-opening", number=1)
+
+    result = build_review_brief(
+        book_root=book,
+        book_slug=slug,
+        chapter_slug="01-opening",
+    )
+
+    assert result["errors"] == []
+
+
+def test_build_review_brief_travel_matrix_populated(tmp_path):
+    book, slug = _make_book(tmp_path)
+    _make_chapter(book, "01-opening", number=1)
+    (book / "world" / "setting.md").write_text(TRAVEL_MATRIX_SAMPLE, encoding="utf-8")
+
+    result = build_review_brief(
+        book_root=book,
+        book_slug=slug,
+        chapter_slug="01-opening",
+    )
+
+    assert len(result["travel_matrix"]) == 2
+    assert result["travel_matrix"][0]["from"] == "City"
+
+
+def test_build_review_brief_canon_log_facts_populated(tmp_path):
+    book, slug = _make_book(tmp_path)
+    _make_chapter(book, "01-opening", number=1)
+    (book / "plot" / "canon-log.md").write_text(CANON_LOG_SAMPLE, encoding="utf-8")
+
+    result = build_review_brief(
+        book_root=book,
+        book_slug=slug,
+        chapter_slug="01-opening",
+    )
+
+    assert len(result["canon_log_facts"]) == 3
+    changed = [f for f in result["canon_log_facts"] if f["status"] == "CHANGED"]
+    assert len(changed) == 1
+
+
+def test_build_review_brief_tonal_rules_populated(tmp_path):
+    book, slug = _make_book(tmp_path)
+    _make_chapter(book, "01-opening", number=1)
+    (book / "plot" / "tone.md").write_text(TONE_SAMPLE, encoding="utf-8")
+
+    result = build_review_brief(
+        book_root=book,
+        book_slug=slug,
+        chapter_slug="01-opening",
+    )
+
+    assert len(result["tonal_rules"]["non_negotiable_rules"]) == 2
+    assert len(result["tonal_rules"]["warning_signs"]) == 2
+
+
+def test_build_review_brief_previous_chapter_populated(tmp_path):
+    book, slug = _make_book(tmp_path)
+    _make_chapter(book, "01-opening", number=1)
+    _make_chapter(book, "02-conflict", number=2)
+
+    result = build_review_brief(
+        book_root=book,
+        book_slug=slug,
+        chapter_slug="02-conflict",
+    )
+
+    assert result["previous_chapter_timeline"] is not None
+    assert result["previous_chapter_timeline"]["slug"] == "01-opening"
+
+
+def test_build_review_brief_no_previous_for_first_chapter(tmp_path):
+    book, slug = _make_book(tmp_path)
+    _make_chapter(book, "01-opening", number=1)
+
+    result = build_review_brief(
+        book_root=book,
+        book_slug=slug,
+        chapter_slug="01-opening",
+    )
+
+    assert result["previous_chapter_timeline"] is None
+
+
+def test_build_review_brief_active_rules_from_claudemd(tmp_path):
+    book, slug = _make_book(tmp_path)
+    _make_chapter(book, "01-opening", number=1)
+    (book / "CLAUDE.md").write_text(
+        "# Book Rules\n\n"
+        "## Rules\n\n"
+        "- Never contradict the canon log\n"
+        "- Always load the timeline before writing\n\n"
+        "## Callback Register\n\n"
+        "- Marcus must reveal his secret by Ch 10\n",
+        encoding="utf-8",
+    )
+
+    result = build_review_brief(
+        book_root=book,
+        book_slug=slug,
+        chapter_slug="01-opening",
+    )
+
+    assert len(result["active_rules"]) == 2
+    assert len(result["active_callbacks"]) == 1
+
+
+def test_build_review_brief_missing_optional_files_graceful(tmp_path):
+    """No setting.md, no canon-log.md, no tone.md → empty lists, no errors."""
+    book, slug = _make_book(tmp_path)
+    _make_chapter(book, "01-opening", number=1)
+
+    result = build_review_brief(
+        book_root=book,
+        book_slug=slug,
+        chapter_slug="01-opening",
+    )
+
+    assert result["travel_matrix"] == []
+    assert result["canon_log_facts"] == []
+    assert result["tonal_rules"] == {}
+    assert result["errors"] == []

--- a/tools/state/continuity_brief.py
+++ b/tools/state/continuity_brief.py
@@ -1,0 +1,195 @@
+"""Continuity brief assembler — Issue #100.
+
+Bundles canonical_calendar, travel_matrix, canon_log_facts,
+character_index, and chapter_timelines into one structured JSON brief.
+
+Chapter draft texts are intentionally NOT included — they are the data
+being checked, not project-state metadata (ADR-0001: data-briefs-over-
+prompt-instructions).
+
+Design follows ``chapter_writing_brief.py`` (Issue #78).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from tools.analysis.timeline_validator import parse_plot_timeline
+from tools.state.chapter_timeline_parser import parse_chapter_timeline_grid
+from tools.state.parsers import parse_frontmatter
+from tools.state.review_brief import (
+    _Recorder,
+    _CHAPTER_NUM_RE,
+    _parse_canon_log_facts,
+    _parse_travel_matrix,
+)
+
+
+# ---------------------------------------------------------------------------
+# Character index builder
+# ---------------------------------------------------------------------------
+
+
+def _build_character_index(book_root: Path) -> list[dict[str, str]]:
+    """Load all character files and return a flat index.
+
+    Returns a list of dicts with ``slug``, ``name``, ``role``,
+    ``description`` keys. INDEX.md is excluded.
+    """
+    chars_dir = book_root / "characters"
+    if not chars_dir.is_dir():
+        return []
+
+    index: list[dict[str, str]] = []
+    for path in sorted(chars_dir.iterdir()):
+        if path.suffix.lower() != ".md" or path.name.upper() == "INDEX.MD":
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        meta, _body = parse_frontmatter(text)
+        index.append({
+            "slug": path.stem,
+            "name": str(meta.get("name", path.stem)),
+            "role": str(meta.get("role", "supporting")),
+            "description": str(meta.get("description", "")),
+        })
+
+    return index
+
+
+# ---------------------------------------------------------------------------
+# All-chapter timelines (no review-rank filter — continuity needs all)
+# ---------------------------------------------------------------------------
+
+
+def _get_all_chapter_timelines(book_root: Path) -> list[dict[str, Any]]:
+    """Return timeline grids for ALL chapters regardless of status.
+
+    Unlike ``get_recent_chapter_timelines``, this imposes no review-rank
+    filter — continuity-checker scans the full manuscript, including
+    drafts and outline-stage chapters.
+    """
+    chapters_dir = book_root / "chapters"
+    if not chapters_dir.is_dir():
+        return []
+
+    numbered: list[tuple[int, Path]] = []
+    for entry in chapters_dir.iterdir():
+        if not entry.is_dir():
+            continue
+        m = _CHAPTER_NUM_RE.match(entry.name)
+        if not m:
+            continue
+        numbered.append((int(m.group(1)), entry))
+    numbered.sort(key=lambda pair: pair[0])
+
+    grids: list[dict[str, Any]] = []
+    for _, chapter_dir in numbered:
+        grid = parse_chapter_timeline_grid(chapter_dir)
+        if grid is not None:
+            grids.append(grid.to_dict())
+    return grids
+
+
+# ---------------------------------------------------------------------------
+# Public assembler
+# ---------------------------------------------------------------------------
+
+
+def build_continuity_brief(
+    *,
+    book_root: Path,
+    book_slug: str,
+) -> dict[str, Any]:
+    """Assemble the continuity-checker brief — Issue #100.
+
+    Bundles canonical_calendar, travel_matrix, canon_log_facts,
+    character_index, and all chapter_timelines into a single
+    JSON-serializable dict. ``continuity-checker`` calls this once
+    instead of reading timeline/setting/canon/character files by hand.
+
+    Chapter draft texts are intentionally excluded — they are the data
+    being checked, not project-state metadata (ADR-0001).
+
+    Args:
+        book_root: Absolute path to the book project directory.
+        book_slug: Book identifier.
+
+    Returns dict with:
+        canonical_calendar  — parsed plot/timeline.md events
+        travel_matrix       — parsed world/setting.md Travel Matrix rows
+        canon_log_facts     — parsed plot/canon-log.md Established Facts
+        character_index     — all character files as flat list
+        chapter_timelines   — all chapter timeline grids (any status)
+        errors              — component → error map for graceful degrade
+    """
+    recorder = _Recorder(errors=[])
+
+    # ----- canonical calendar -----------------------------------------------
+    canonical_calendar: list[dict[str, Any]] = []
+    calendar = recorder.run(
+        "canonical_calendar",
+        lambda: parse_plot_timeline(book_root),
+        None,
+    )
+    if calendar is not None:
+        canonical_calendar = [e.to_dict() for e in calendar.events]
+
+    # ----- travel matrix ----------------------------------------------------
+    travel_matrix: list[dict[str, str]] = []
+    setting_path = book_root / "world" / "setting.md"
+    if setting_path.is_file():
+        setting_text = recorder.run(
+            "setting.read",
+            lambda: setting_path.read_text(encoding="utf-8"),
+            "",
+        )
+        if setting_text:
+            travel_matrix = recorder.run(
+                "travel_matrix",
+                lambda: _parse_travel_matrix(setting_text),
+                [],
+            )
+
+    # ----- canon log facts --------------------------------------------------
+    canon_log_facts: list[dict[str, str]] = []
+    canon_path = book_root / "plot" / "canon-log.md"
+    if canon_path.is_file():
+        canon_text = recorder.run(
+            "canon_log.read",
+            lambda: canon_path.read_text(encoding="utf-8"),
+            "",
+        )
+        if canon_text:
+            canon_log_facts = recorder.run(
+                "canon_log_facts",
+                lambda: _parse_canon_log_facts(canon_text),
+                [],
+            )
+
+    # ----- character index --------------------------------------------------
+    character_index = recorder.run(
+        "character_index",
+        lambda: _build_character_index(book_root),
+        [],
+    )
+
+    # ----- all chapter timelines (no status filter) -------------------------
+    chapter_timelines = recorder.run(
+        "chapter_timelines",
+        lambda: _get_all_chapter_timelines(book_root),
+        [],
+    )
+
+    return {
+        "book_slug": book_slug,
+        "canonical_calendar": canonical_calendar,
+        "travel_matrix": travel_matrix,
+        "canon_log_facts": canon_log_facts,
+        "character_index": character_index,
+        "chapter_timelines": chapter_timelines,
+        "errors": list(recorder.errors),
+    }

--- a/tools/state/review_brief.py
+++ b/tools/state/review_brief.py
@@ -1,0 +1,508 @@
+"""Review brief assembler — Issue #99.
+
+Bundles the pre-computed state reads that ``chapter-reviewer`` used to
+do by hand (timeline, travel matrix, canon log, tone, chapter timelines)
+into a single structured JSON brief.
+
+Design follows ``chapter_writing_brief.py`` (Issue #78):
+- Each sub-component is wrapped in try/except via _Recorder.
+- Output is plain dicts/lists/strings — JSON-serializable.
+- No I/O outside the book root. Skill prompts consume the brief directly.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from tools.analysis.timeline_validator import parse_plot_timeline
+from tools.state.chapter_timeline_parser import parse_chapter_timeline_grid
+from tools.state.parsers import parse_frontmatter
+
+
+# ---------------------------------------------------------------------------
+# Error recorder (mirrors chapter_writing_brief._Recorder)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Recorder:
+    """Collects sub-tool errors so the brief can ship with partial data."""
+
+    errors: list[dict[str, str]]
+
+    def run(self, component: str, fn, default):
+        try:
+            return fn()
+        except Exception as exc:  # pylint: disable=broad-except
+            self.errors.append({
+                "component": component,
+                "error": f"{type(exc).__name__}: {exc}",
+            })
+            return default
+
+
+# ---------------------------------------------------------------------------
+# Shared markdown table helpers (also used by continuity_brief)
+# ---------------------------------------------------------------------------
+
+_SEPARATOR_ROW_RE = re.compile(r"^\|[\s|:-]+\|\s*$")
+
+
+def _split_cells(row: str) -> list[str]:
+    """Split a markdown table row into trimmed cell values."""
+    return [c.strip() for c in row.strip().strip("|").split("|")]
+
+
+def _is_placeholder_row(cells: list[str]) -> bool:
+    """Return True if every non-empty cell looks like a template placeholder."""
+    non_empty = [c for c in cells if c]
+    return bool(non_empty) and all(c.startswith("*") for c in non_empty)
+
+
+# ---------------------------------------------------------------------------
+# Travel Matrix parser (shared with continuity_brief)
+# ---------------------------------------------------------------------------
+
+_TRAVEL_MATRIX_SECTION_RE = re.compile(
+    r"##\s+Travel Matrix\b(.*?)(?=\n##\s|\Z)",
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def _parse_travel_matrix(setting_text: str) -> list[dict[str, str]]:
+    """Parse the Travel Matrix table from world/setting.md.
+
+    Returns a list of route dicts with normalised keys derived from the
+    header row (e.g. ``from``, ``to``, ``distance``, ``transport``,
+    ``travel_time``, ``notes``). Placeholder rows and the template example
+    row are skipped.
+    """
+    match = _TRAVEL_MATRIX_SECTION_RE.search(setting_text)
+    if not match:
+        return []
+
+    rows: list[dict[str, str]] = []
+    header: list[str] | None = None
+
+    for line in match.group(1).splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        if _SEPARATOR_ROW_RE.match(stripped):
+            continue
+        cells = _split_cells(stripped)
+        if not cells:
+            continue
+        if header is None:
+            header = [
+                re.sub(r"\s+", "_", c.lower()) for c in cells
+            ]
+            continue
+        if _is_placeholder_row(cells):
+            continue
+        row: dict[str, str] = {
+            header[i]: cells[i] if i < len(cells) else ""
+            for i in range(len(header))
+        }
+        rows.append(row)
+
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Canon log facts parser (shared with continuity_brief)
+# ---------------------------------------------------------------------------
+
+_ESTABLISHED_FACTS_RE = re.compile(
+    r"##\s+Established Facts\b(.*?)(?=\n##\s|\Z)",
+    re.DOTALL | re.IGNORECASE,
+)
+_SUB_SECTION_RE = re.compile(r"^###\s+(.+?)\s*$", re.MULTILINE)
+
+
+def _parse_canon_log_facts(canon_text: str) -> list[dict[str, str]]:
+    """Parse facts from plot/canon-log.md into a flat list.
+
+    Scans only the ``## Established Facts`` section. Each table row
+    becomes a dict with keys: ``fact``, ``established_in``, ``status``,
+    ``notes``, ``domain``. Placeholder rows and header rows are skipped.
+    """
+    match = _ESTABLISHED_FACTS_RE.search(canon_text)
+    if not match:
+        return []
+
+    section_text = match.group(1)
+    facts: list[dict[str, str]] = []
+    current_domain = ""
+
+    for line in section_text.splitlines():
+        stripped = line.strip()
+        # Track domain sub-sections (### Character Facts, etc.)
+        domain_match = _SUB_SECTION_RE.match(stripped)
+        if domain_match:
+            current_domain = domain_match.group(1)
+            continue
+        if not stripped.startswith("|"):
+            continue
+        if _SEPARATOR_ROW_RE.match(stripped):
+            continue
+        cells = _split_cells(stripped)
+        if not cells or not cells[0]:
+            continue
+        # Skip header row
+        if cells[0].lower() in ("fact", "field"):
+            continue
+        if cells[0].startswith("*"):
+            continue
+        facts.append({
+            "fact": cells[0],
+            "established_in": cells[1] if len(cells) > 1 else "",
+            "status": cells[2] if len(cells) > 2 else "ACTIVE",
+            "notes": cells[3] if len(cells) > 3 else "",
+            "domain": current_domain,
+        })
+
+    return facts
+
+
+# ---------------------------------------------------------------------------
+# Tonal rules parser (review brief only)
+# ---------------------------------------------------------------------------
+
+_BULLET_RE = re.compile(r"^\s*[-*]\s+(?P<body>.+?)\s*$", re.MULTILINE)
+_NUMBERED_RE = re.compile(r"^\s*\d+[.)]\s+(?P<body>.+?)\s*$", re.MULTILINE)
+_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+_NON_NEG_SECTION_RE = re.compile(
+    r"^##\s+Non-Negotiable Rules\s*$(.*?)(?=^##\s|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+_LITMUS_SECTION_RE = re.compile(
+    r"^##\s+Litmus Test\s*$(.*?)(?=^##\s|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+_BANNED_PATTERNS_RE = re.compile(
+    r"^##\s+Banned Prose Patterns.*?$(.*?)(?=^##\s|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+_TONAL_ARC_SECTION_RE = re.compile(
+    r"^##\s+Tonal Arc\s*$(.*?)(?=^##\s|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def _bullets_from_section(text: str, section_re: re.Pattern) -> list[str]:
+    match = section_re.search(text)
+    if not match:
+        return []
+    body = _COMMENT_RE.sub("", match.group(1))
+    items = []
+    for m in _BULLET_RE.finditer(body):
+        item = re.sub(r"\s+", " ", m.group("body")).strip()
+        if item:
+            items.append(item)
+    return items
+
+
+def _numbered_or_bullets_from_section(text: str, section_re: re.Pattern) -> list[str]:
+    match = section_re.search(text)
+    if not match:
+        return []
+    body = match.group(1)
+    items: list[str] = []
+    for pat in (_NUMBERED_RE, _BULLET_RE):
+        for m in pat.finditer(body):
+            item = re.sub(r"\s+", " ", m.group("body")).strip()
+            if item and item not in items:
+                items.append(item)
+    return items
+
+
+def _parse_tonal_arc_warning_signs(tone_text: str) -> list[str]:
+    """Extract Warning Signs column values from the Tonal Arc table."""
+    match = _TONAL_ARC_SECTION_RE.search(tone_text)
+    if not match:
+        return []
+
+    section = match.group(1)
+    header: list[str] | None = None
+    warning_idx: int | None = None
+    warnings: list[str] = []
+
+    for line in section.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        if _SEPARATOR_ROW_RE.match(stripped):
+            continue
+        cells = _split_cells(stripped)
+        if header is None:
+            header = [c.lower() for c in cells]
+            for i, h in enumerate(header):
+                if "warning" in h:
+                    warning_idx = i
+                    break
+            continue
+        if warning_idx is not None and warning_idx < len(cells):
+            val = cells[warning_idx].strip()
+            if val and not val.startswith("*"):
+                warnings.append(val)
+
+    return warnings
+
+
+def _parse_tonal_rules(tone_text: str) -> dict[str, list[str]]:
+    """Parse plot/tone.md into structured tonal rule sections."""
+    return {
+        "non_negotiable_rules": _bullets_from_section(tone_text, _NON_NEG_SECTION_RE),
+        "litmus_test": _numbered_or_bullets_from_section(tone_text, _LITMUS_SECTION_RE),
+        "banned_prose_patterns": _bullets_from_section(tone_text, _BANNED_PATTERNS_RE),
+        "warning_signs": _parse_tonal_arc_warning_signs(tone_text),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Book CLAUDE.md rules + callbacks (shared logic)
+# ---------------------------------------------------------------------------
+
+_RULES_SECTION_RE = re.compile(
+    r"^##\s+Rules\s*$(.*?)^##\s+",
+    re.MULTILINE | re.DOTALL,
+)
+_CALLBACKS_SECTION_RE = re.compile(
+    r"^##\s+Callback Register\s*$(.*?)(?=^---\s*$|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+_BAN_CUE_RE = re.compile(
+    r"\b(banned|ban|avoid|never|don['']?t\s+use|do\s+not\s+use|"
+    r"limit|stop\s+using)\b",
+    re.IGNORECASE,
+)
+
+
+def _classify_rule(rule: str) -> str:
+    if "`" in rule and _BAN_CUE_RE.search(rule):
+        return "block"
+    return "advisory"
+
+
+def _section_bullets(text: str, section_re: re.Pattern) -> list[str]:
+    match = section_re.search(text)
+    if not match:
+        return []
+    body = _COMMENT_RE.sub("", match.group(1))
+    items = []
+    for m in _BULLET_RE.finditer(body):
+        item = re.sub(r"\s+", " ", m.group("body")).strip()
+        if item:
+            items.append(item)
+    return items
+
+
+def _load_book_rules_and_callbacks(
+    book_root: Path,
+    recorder: _Recorder,
+) -> tuple[list[dict[str, str]], list[str]]:
+    """Extract active_rules and active_callbacks from book CLAUDE.md."""
+    rules: list[dict[str, str]] = []
+    callbacks: list[str] = []
+    claudemd_path = book_root / "CLAUDE.md"
+    if not claudemd_path.is_file():
+        return rules, callbacks
+
+    text = recorder.run(
+        "claudemd.read",
+        lambda: claudemd_path.read_text(encoding="utf-8"),
+        "",
+    )
+    if not text:
+        return rules, callbacks
+
+    for rule_text in _section_bullets(text, _RULES_SECTION_RE):
+        rules.append({"text": rule_text, "severity": _classify_rule(rule_text)})
+    callbacks = _section_bullets(text, _CALLBACKS_SECTION_RE)
+    return rules, callbacks
+
+
+# ---------------------------------------------------------------------------
+# Chapter directory helpers (inlined to avoid private imports)
+# ---------------------------------------------------------------------------
+
+_CHAPTER_NUM_RE = re.compile(r"^(\d{1,3})-")
+
+
+def _sorted_chapter_dirs(book_root: Path) -> list[tuple[int, Path]]:
+    """List all numbered chapter directories sorted by chapter number."""
+    chapters_dir = book_root / "chapters"
+    if not chapters_dir.is_dir():
+        return []
+    out: list[tuple[int, Path]] = []
+    for entry in chapters_dir.iterdir():
+        if not entry.is_dir():
+            continue
+        m = _CHAPTER_NUM_RE.match(entry.name)
+        if not m:
+            continue
+        out.append((int(m.group(1)), entry))
+    out.sort(key=lambda pair: pair[0])
+    return out
+
+
+def _find_previous_chapter_dir(book_root: Path, chapter_slug: str) -> Path | None:
+    """Return the chapter directory that immediately precedes chapter_slug."""
+    all_chapters = _sorted_chapter_dirs(book_root)
+    current_num: int | None = None
+    for num, path in all_chapters:
+        if path.name == chapter_slug:
+            current_num = num
+            break
+    if current_num is None:
+        return None
+    preceding = [p for num, p in all_chapters if num < current_num]
+    return preceding[-1] if preceding else None
+
+
+# ---------------------------------------------------------------------------
+# Public assembler
+# ---------------------------------------------------------------------------
+
+
+def build_review_brief(
+    *,
+    book_root: Path,
+    book_slug: str,
+    chapter_slug: str,
+) -> dict[str, Any]:
+    """Assemble the chapter-review brief — Issue #99.
+
+    Bundles timeline, travel matrix, canon log, tonal rules, and chapter
+    timeline sections into a single JSON-serializable dict.
+    ``chapter-reviewer`` calls this once instead of reading 6+ project-state
+    files by hand.
+
+    Args:
+        book_root: Absolute path to the book project directory.
+        book_slug: Book identifier.
+        chapter_slug: Target chapter identifier (e.g. "22-the-night-before").
+
+    Returns dict with:
+        chapter_timeline        — start/end/scenes for the target chapter
+        previous_chapter_timeline — same for the preceding chapter (or None)
+        canonical_timeline_entries — parsed plot/timeline.md events
+        travel_matrix           — parsed world/setting.md Travel Matrix rows
+        canon_log_facts         — parsed plot/canon-log.md Established Facts
+        tonal_rules             — non-negotiable rules, litmus, banned patterns
+        active_rules            — book CLAUDE.md ## Rules, structured
+        active_callbacks        — book CLAUDE.md ## Callback Register items
+        errors                  — component → error map for graceful degrade
+    """
+    recorder = _Recorder(errors=[])
+    chapters_dir = book_root / "chapters"
+    chapter_dir = chapters_dir / chapter_slug
+
+    # ----- chapter timeline -------------------------------------------------
+    chapter_timeline = recorder.run(
+        "chapter_timeline",
+        lambda: _chapter_grid_or_none(chapter_dir),
+        None,
+    )
+
+    # ----- previous chapter timeline ----------------------------------------
+    prev_dir = recorder.run(
+        "previous_chapter.find",
+        lambda: _find_previous_chapter_dir(book_root, chapter_slug),
+        None,
+    )
+    previous_chapter_timeline: dict[str, Any] | None = None
+    if prev_dir is not None:
+        previous_chapter_timeline = recorder.run(
+            "previous_chapter_timeline",
+            lambda d=prev_dir: _chapter_grid_or_none(d),
+            None,
+        )
+
+    # ----- canonical timeline entries ---------------------------------------
+    canonical_timeline_entries: list[dict[str, Any]] = []
+    calendar = recorder.run(
+        "canonical_timeline",
+        lambda: parse_plot_timeline(book_root),
+        None,
+    )
+    if calendar is not None:
+        canonical_timeline_entries = [e.to_dict() for e in calendar.events]
+
+    # ----- travel matrix ----------------------------------------------------
+    travel_matrix: list[dict[str, str]] = []
+    setting_path = book_root / "world" / "setting.md"
+    if setting_path.is_file():
+        setting_text = recorder.run(
+            "setting.read",
+            lambda: setting_path.read_text(encoding="utf-8"),
+            "",
+        )
+        if setting_text:
+            travel_matrix = recorder.run(
+                "travel_matrix",
+                lambda: _parse_travel_matrix(setting_text),
+                [],
+            )
+
+    # ----- canon log facts --------------------------------------------------
+    canon_log_facts: list[dict[str, str]] = []
+    canon_path = book_root / "plot" / "canon-log.md"
+    if canon_path.is_file():
+        canon_text = recorder.run(
+            "canon_log.read",
+            lambda: canon_path.read_text(encoding="utf-8"),
+            "",
+        )
+        if canon_text:
+            canon_log_facts = recorder.run(
+                "canon_log_facts",
+                lambda: _parse_canon_log_facts(canon_text),
+                [],
+            )
+
+    # ----- tonal rules ------------------------------------------------------
+    tonal_rules: dict[str, list[str]] = {}
+    tone_path = book_root / "plot" / "tone.md"
+    if tone_path.is_file():
+        tone_text = recorder.run(
+            "tone.read",
+            lambda: tone_path.read_text(encoding="utf-8"),
+            "",
+        )
+        if tone_text:
+            tonal_rules = recorder.run(
+                "tonal_rules",
+                lambda: _parse_tonal_rules(tone_text),
+                {},
+            )
+
+    # ----- rules + callbacks from book CLAUDE.md ----------------------------
+    active_rules, active_callbacks = _load_book_rules_and_callbacks(
+        book_root, recorder
+    )
+
+    return {
+        "book_slug": book_slug,
+        "chapter_slug": chapter_slug,
+        "chapter_timeline": chapter_timeline,
+        "previous_chapter_timeline": previous_chapter_timeline,
+        "canonical_timeline_entries": canonical_timeline_entries,
+        "travel_matrix": travel_matrix,
+        "canon_log_facts": canon_log_facts,
+        "tonal_rules": tonal_rules,
+        "active_rules": active_rules,
+        "active_callbacks": active_callbacks,
+        "errors": list(recorder.errors),
+    }
+
+
+def _chapter_grid_or_none(chapter_dir: Path) -> dict[str, Any] | None:
+    """Load a chapter's timeline grid as a dict, or None if not parseable."""
+    grid = parse_chapter_timeline_grid(chapter_dir)
+    return grid.to_dict() if grid is not None else None


### PR DESCRIPTION
## Summary

Implements [ADR-0001](docs/adr/0001-data-briefs-over-prompt-instructions.md) for the two remaining skills that still read project-state files directly.

- **get_review_brief(book_slug, chapter_slug)** — new MCP tool that bundles `chapter_timeline`, `previous_chapter_timeline`, `canonical_timeline_entries`, `travel_matrix`, `canon_log_facts`, `tonal_rules`, `active_rules`, and `active_callbacks` into one structured JSON payload
- **get_continuity_brief(book_slug)** — new MCP tool that bundles `canonical_calendar`, `travel_matrix`, `canon_log_facts`, `character_index`, and `chapter_timelines` (all statuses, no review-rank filter) into one payload
- **chapter-reviewer** refactored: 6+ direct file reads replaced with a single `get_review_brief()` call; chapter draft stays as a direct read (it is the content under review, not project-state metadata)
- **continuity-checker** refactored: direct timeline/setting/canon/character reads replaced with `get_continuity_brief()`; chapter drafts stay as direct reads per ADR-0001 rationale

## Architecture

Both tools follow the `get_chapter_writing_brief()` pattern (Issue #78):
- `_Recorder` for graceful partial-data delivery when files are missing
- Pure dicts/lists/strings — JSON-serializable without custom encoders
- No I/O outside the book root

New modules: `tools/state/review_brief.py`, `tools/state/continuity_brief.py`

## Test plan

- [x] 39 new tests in `test_review_brief.py` and `test_continuity_brief.py`
- [x] Parser unit tests: travel matrix, canon log facts (with domain), tonal rules (non-negotiable, litmus, banned patterns, warning signs from arc table)
- [x] Integration tests: correct fields returned, graceful degrade when optional files are missing, correct previous-chapter detection
- [x] Full suite: 633/633 passed, no regressions

Closes #99, closes #100. Part of epic #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)