### PR TITLE
feat: book_category field for memoir support (Path E Phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-StoryForge is a Claude Code plugin for writing fiction: from brainstorming through concept, plot, characters, world-building, chapter-by-chapter writing, to export as EPUB/PDF/MOBI. Author profiles ensure authentic voice — not generic AI output.
+StoryForge is a Claude Code plugin for writing fiction **and memoir**: from brainstorming through concept, plot, characters, world-building, chapter-by-chapter writing, to export as EPUB/PDF/MOBI. Author profiles ensure authentic voice — not generic AI output.
+
+Books carry a `book_category` field (`fiction` | `memoir`) that gates category-specific craft and skill behavior. See **Book Category** below.
 
 ## Configuration
 
@@ -18,6 +20,28 @@ StoryForge is a Claude Code plugin for writing fiction: from brainstorming throu
 Server name: `storyforge-mcp`
 
 Use MCP tools for ALL state operations. Direct file parsing in skills bypasses caching and validation — go through MCP.
+
+## Book Category
+
+Every book carries a `book_category` field in its README frontmatter:
+
+| Value | Meaning | Default |
+|-------|---------|---------|
+| `fiction` | Invented narrative, fiction-shaped craft | ✓ default for new books and for legacy books missing the field |
+| `memoir` | Personal narrative shaped from lived experience | Set explicitly via `create_book_structure(book_category="memoir")` |
+
+Category-specific knowledge lives at `{plugin_root}/book_categories/{category}/`:
+
+- `book_categories/fiction/README.md` — pointer to canonical fiction docs (this file, `reference/craft/`)
+- `book_categories/memoir/README.md` — memoir conventions, structure types, craft index
+- `book_categories/memoir/craft/` — five memoir-specific craft references (structure types, scene vs. summary, emotional truth, real-people ethics, memoir anti-AI patterns)
+- `book_categories/{fiction,memoir}/status-model.md` — per-category status interpretation
+
+Resolve the path from a skill via MCP `get_book_category_dir(category)`.
+
+`book_category` is **orthogonal** to `book_type` (length class: `short-story | novelette | novella | novel | epic`). A "memoir novella" is valid; the two fields don't constrain each other.
+
+Phase 1 (#54–#56, #67) adds the field plus knowledge scaffold. Skill branching by category lands in Phase 2+ (epic #97). Until those phases ship, all skills behave the same regardless of `book_category`.
 
 ## Skill Routing
 
@@ -104,6 +128,20 @@ Use MCP tools for ALL state operations. Direct file parsing in skills bypasses c
 13. `/storyforge:promo-writer` — Social media campaign (FB, Instagram, TikTok, X, Bluesky, Newsletter)
 14. `/storyforge:translator` — Translate to other languages
 
+### Memoir Workflows (Phase 2+ — forthcoming)
+
+Phase 1 ships memoir knowledge under `book_categories/memoir/` but does **not** yet branch the skills above. Memoir books currently flow through the same fiction workflows; skills will branch on `book_category` once Phase 2 (#57–#60, #63), Phase 3 (#61, #62, #65, #66) and Phase 4 (#64) land.
+
+The forthcoming memoir-specific routing (not yet wired):
+
+- `/storyforge:memoir-ethics-checker` — consent/defamation/anonymization scan (Issue #65)
+- `/storyforge:emotional-truth-prompt` — render-the-felt-sense pass (Issue #66)
+- `/storyforge:character-creator` (memoir mode) — real-people handler with consent tracking (Issue #59)
+- `/storyforge:plot-architect` (memoir mode) — narrative-arc shaping with structure-type selection (Issue #58)
+- `/storyforge:chapter-writer` (memoir mode) — loads memoir craft, scene-vs-summary discipline (Issue #57)
+
+Until those land, when working on a memoir book, manually load `book_categories/memoir/README.md` and the relevant `craft/` files at the start of any creative skill.
+
 ## Project Structure
 
 Books live at `{content_root}/projects/{slug}/`:
@@ -123,6 +161,8 @@ Books live at `{content_root}/projects/{slug}/`:
 ├── export/             # front-matter.md, back-matter.md, output/
 └── translations/       # {lang}/ with glossary.md + chapters/
 ```
+
+For `book_category: memoir` projects, the same paths carry **shifted meaning** (characters/ = real people; plot/outline.md = narrative arc shaped from truth, not invented; world/setting.md = real places + eras). See `book_categories/memoir/README.md` for the full mapping. The on-disk layout itself is unchanged in Phase 1 — Phase 2 (#59) may introduce a `people/` alias for memoir; until then `characters/` works for both categories.
 
 ## Status Progressions
 
@@ -163,6 +203,10 @@ Outline → Draft → Revision → Polished → Final
 Concept → Profile → Backstory → Arc Defined → Final
 ```
 
+### Memoir status interpretation
+
+The book status sequence is **identical** for `book_category: memoir`. Several stages carry shifted intent (e.g., `Plot Outlined` = narrative arc identified; `Characters Created` = people profiles drafted with consent decisions). Phase 3 quality gates (consent verification, emotional-truth pass) are documented in `book_categories/memoir/status-model.md` and will be enforced by `memoir-ethics-checker` (#65) once Phase 3 lands.
+
 ## Author Profiles
 
 Authors live at `~/.storyforge/authors/{slug}/`:
@@ -182,16 +226,21 @@ Books can combine 1-3 genres.
 
 ## Craft Knowledge Base
 
-`{plugin_root}/reference/craft/` contains 18 reference documents on writing craft.
-`{plugin_root}/reference/genre/` contains genre-specific craft guides.
+- `{plugin_root}/reference/craft/` — 19 universal/fiction-craft reference documents
+- `{plugin_root}/reference/genre/` — genre-specific craft guides
+- `{plugin_root}/book_categories/memoir/craft/` — 5 memoir-specific craft documents (structure types, scene vs. summary, emotional truth, real-people ethics, memoir anti-AI patterns)
 
-Skills MUST load relevant craft references before generating creative content:
-- `chapter-writer` → loads: chapter-construction, dialog-craft, show-dont-tell, pacing-guide, anti-ai-patterns, prose-style, simile-discipline + genre craft
-- `chapter-reviewer` → loads: dos-and-donts, anti-ai-patterns, chapter-construction, dialog-craft, show-dont-tell, simile-discipline
-- `plot-architect` → loads: story-structure, plot-craft, tension-and-suspense
-- `character-creator` → loads: character-creation, character-arcs
-- `world-builder` → loads: world-building
-- `voice-checker` → loads: anti-ai-patterns, prose-style, dos-and-donts
+Each doc in `reference/craft/` carries a `book_categories: [...]` frontmatter (Issue #56) that declares whether it applies to `[fiction]`, `[fiction, memoir]`, or other future categories. Most apply to both; the four pure-invention docs (`character-creation`, `character-arcs`, `plot-craft`, `world-building`) are tagged `[fiction]` because memoir handles those concerns differently (see `book_categories/memoir/craft/real-people-ethics.md`).
+
+Skills MUST load relevant craft references before generating creative content. Until Phase 2+ wires automatic filtering by `book_category`, skills should also manually skip docs whose frontmatter excludes the current category.
+
+- `chapter-writer` → loads: chapter-construction, dialog-craft, show-dont-tell, pacing-guide, anti-ai-patterns, prose-style, simile-discipline + genre craft (memoir mode adds: `book_categories/memoir/craft/scene-vs-summary.md`, `emotional-truth.md`, `memoir-anti-ai-patterns.md`)
+- `chapter-reviewer` → loads: dos-and-donts, anti-ai-patterns, chapter-construction, dialog-craft, show-dont-tell, simile-discipline (memoir mode adds: `book_categories/memoir/craft/memoir-anti-ai-patterns.md`)
+- `plot-architect` → loads: story-structure, plot-craft, tension-and-suspense (memoir mode loads `book_categories/memoir/craft/memoir-structure-types.md` instead of `plot-craft.md`)
+- `character-creator` → loads: character-creation, character-arcs (memoir mode loads `book_categories/memoir/craft/real-people-ethics.md` instead — Phase 2 #59 splits this into a dedicated `real-people-handler` skill)
+- `world-builder` → loads: world-building (memoir typically skips this skill — real settings are documented in `world/setting.md` via research, not invention)
+- `voice-checker` → loads: anti-ai-patterns, prose-style, dos-and-donts (memoir mode adds: `book_categories/memoir/craft/memoir-anti-ai-patterns.md`)
+- `manuscript-checker` → memoir mode adds memoir-specific patterns (Phase 3 #61)
 - `promo-writer` → loads: genre README(s) for blurb tone guidance, `reference/promo/platforms.md` for platform characteristics
 
 ## Important Rules
@@ -215,6 +264,7 @@ Skills MUST load relevant craft references before generating creative content:
 17. ALWAYS load the book's `CLAUDE.md` via MCP `get_book_claudemd()` before writing or reviewing a chapter — it contains persisted workflow rules and callbacks that survive session compaction
 18. Prefix grammar for persistence: messages starting with `Regel:`, `Workflow:`, or `Callback:` are extracted by the PreCompact hook and written to the book's CLAUDE.md. Unprefixed messages are never persisted automatically.
 19. **ALWAYS `Read` the full file when processing review comments** (GH#27). When the user signals that review comments (`{review_handle}:` blocks) are ready, call the `Read` tool on the full file first. The file-change `system-reminder` diff is truncated for long files — end-of-file comments get silently dropped. After reading, count the comments you see and report the count; re-read if the count mismatches expectation.
+20. **ALWAYS check `book_category` before creative work on a book** (Path E #54/#67). Read it from `get_book_full(slug).book_category`. For `memoir`, additionally load `book_categories/memoir/README.md` and the relevant `book_categories/memoir/craft/*.md` docs at the start of any creative skill. Phase 1 wires the field but does not yet auto-branch skills — the manual load is the bridge until Phase 2+ ships the automatic routing. For named living people in memoir scenes, surface `consent_status` decisions explicitly (Phase 3 #65 will enforce this automatically).
 
 ## Code Style
 

--- a/book_categories/fiction/README.md
+++ b/book_categories/fiction/README.md
@@ -1,0 +1,49 @@
+---
+book_category: fiction
+status: scaffold
+last_reviewed: 2026-04-27
+---
+
+# Fiction — Book Category
+
+Fiction is the **default book category** in StoryForge. It is the implicit
+category for every book whose `README.md` frontmatter has no
+`book_category` field, and the explicit value `book_category: fiction` for
+new books created since #54.
+
+This file exists for **symmetry** with `book_categories/memoir/README.md`.
+Most fiction-specific knowledge already lives in established places and is
+**not duplicated here**:
+
+| Topic | Canonical location |
+|-------|--------------------|
+| Skill routing for fiction workflows | `CLAUDE.md` (root) |
+| Fiction craft references (18 docs) | `reference/craft/` |
+| Genre-specific craft | `reference/genre/` and `genres/{name}/README.md` |
+| Status progressions (Book / Chapter / Character) | `CLAUDE.md` "Status Progressions" |
+| Project structure (plot/, characters/, world/, …) | `CLAUDE.md` "Project Structure" |
+| Workflows (Outliner / Discovery / Plantser) | `CLAUDE.md` "Workflow Pipeline" |
+
+## When to put something here
+
+Add a file under `book_categories/fiction/` only if it is:
+
+1. Specific to **fiction as a category**, not to a particular genre or skill
+2. A meaningful **counterpart** to a memoir-specific decision (e.g., if memoir
+   gets `craft/real-people-ethics.md`, fiction does **not** need
+   `craft/invented-people-ethics.md` — that's just craft, not category-specific)
+
+Most additions should go to `reference/craft/` instead, tagged with
+`book_categories: [fiction]` frontmatter (added in #56).
+
+## Status model
+
+Fiction uses the canonical status progression documented in `CLAUDE.md`. See
+`status-model.md` in this directory for a stable reference.
+
+## See also
+
+- `CLAUDE.md` — full skill routing, workflows, status progressions
+- `book_categories/memoir/README.md` — the asymmetric companion (memoir has more category-specific knowledge because it diverges from the fiction-shaped defaults)
+- `#54` — `book_category` field
+- `#97` — Path E epic

--- a/book_categories/fiction/status-model.md
+++ b/book_categories/fiction/status-model.md
@@ -1,0 +1,53 @@
+---
+book_category: fiction
+status: scaffold
+last_reviewed: 2026-04-27
+---
+
+# Fiction — Status Model
+
+This file mirrors `book_categories/memoir/status-model.md` for symmetry. The
+**canonical** definition of the fiction status progression lives in `CLAUDE.md`
+under "Status Progressions" — that is the source of truth for ranks, aliases,
+auto-sync rules, and the forward-only floor.
+
+## Book status progression
+
+```
+Idea → Concept → Research → Plot Outlined → Characters Created →
+World Built → Drafting → Revision → Editing → Proofread → Export Ready → Published
+```
+
+## Auto-derivation (Issue #21)
+
+The indexer derives an effective book status from chapter aggregates. It only
+ever escalates forward — never moves backward.
+
+| Book tier | Trigger |
+|-----------|---------|
+| `Drafting` | any chapter past `Outline` |
+| `Revision` | every chapter at Revision rank or higher (incl. alias `review`) |
+| `Proofread` | every chapter `Final` |
+
+`Editing`, `Export Ready`, and `Published` remain **explicit** — they require
+qualitative judgment beyond chapter-state aggregation.
+
+## Auto-sync to disk (Issue #25)
+
+`rebuild_state()` writes the derived status back to README frontmatter when
+it's a forward move from the on-disk value. Floor rule: a user-set higher
+tier (`Export Ready`, `Published`) is never silently downgraded.
+
+## Chapter-status aliases
+
+| Alias | Canonical rank |
+|-------|----------------|
+| `review`, `reviewed` | Revision |
+| `drafting` | Draft |
+| `polishing` | Polished |
+| `done` | Final |
+
+## See also
+
+- `CLAUDE.md` — canonical, authoritative version
+- `book_categories/memoir/status-model.md` — memoir-specific stage interpretations and quality gates

--- a/book_categories/memoir/README.md
+++ b/book_categories/memoir/README.md
@@ -1,0 +1,113 @@
+---
+book_category: memoir
+status: scaffold
+last_reviewed: 2026-04-27
+---
+
+# Memoir — Book Category
+
+Memoir is a **second-tier book category** in StoryForge alongside `fiction` (Path E in #49).
+It activates when a book's `README.md` frontmatter carries `book_category: memoir`.
+
+This file is the entry point for memoir-specific knowledge. Phase 2+ skills
+load it (and the craft docs under `craft/`) when working on a memoir project.
+
+## What memoir is — and is not
+
+Memoir is a **personal narrative** focused on a specific period, theme, or
+relationship in the author's own life. It is shaped from lived experience and
+held to the standard of **emotional truth**, not invented plot.
+
+Memoir is **not** autobiography (which aims for a complete life chronicle), and
+it is **not** non-fiction in the broad sense (history, biography, how-to,
+academic) — those subtypes are explicitly **out of scope** for v1 (see #49).
+
+| Memoir | Autobiography | Fiction |
+|--------|---------------|---------|
+| Slice of life around a theme | Whole life, chronological | Invented narrative |
+| Truth-shaped, scene-rendered | Comprehensive record | Plot-shaped, character-driven |
+| Real people, with consent care | Real people, by default | Invented characters |
+| ~50–80k words typical | ~80–150k words typical | Varies by `book_type` |
+
+## Structure types
+
+A memoir's structure is the **shape of the story being told** — independent of
+the lived chronology. Pick one in `plot/outline.md` (or its memoir-equivalent)
+during the conceptualization phase.
+
+### Chronological
+
+Events told in the order they happened. Simplest mental model. Risk: drifts
+into autobiography if every year demands equal weight. Discipline: cut
+sub-arcs that don't serve the central theme, even if they "really happened".
+
+### Thematic
+
+Chapters organized by topic (e.g., *Money / Faith / Bodies*) rather than
+timeline. Same period of life can recur across chapters from different angles.
+Strongest when the central question is conceptual, not temporal.
+
+### Braided
+
+Two or more parallel timelines or narrative threads interwoven (e.g., past
+trauma + present-day reckoning). High craft demand — each thread must earn
+its airtime, transitions must be deliberate. Cliché trap: lazy
+"meanwhile-back-then" cuts.
+
+### Vignette
+
+Short, self-contained scenes (3–8 pages each), loosely connected by theme or
+through-line rather than tight causal arc. Suits fragmented memory or
+non-linear emotional landscapes. Risk: collapses into anecdote-collection
+without a strong frame.
+
+## Project structure differences
+
+The fiction directory layout (`plot/`, `characters/`, `world/`) maps to memoir
+with the same paths but **shifted meaning**:
+
+| Fiction path | Memoir interpretation |
+|--------------|----------------------|
+| `characters/` | Real people who appear in the memoir. Consent + anonymization status tracked per person. |
+| `plot/outline.md` | Narrative arc — the *angle* on the lived material, not invented events. |
+| `plot/timeline.md` | Real chronology of events (memoir's "story bible"). |
+| `world/setting.md` | Real places + eras (often requires factual research, not invention). |
+| `world/rules.md` | Often empty for memoir (no magic system). May hold cultural/period rules instead. |
+
+Phase 2 skill branches will rename or shadow some paths (`characters/` →
+`people/` is under discussion in #59) — this README will be updated when those
+land.
+
+## Craft references
+
+Memoir-specific craft docs live under `book_categories/memoir/craft/`:
+
+- `memoir-structure-types.md` — chronological / thematic / braided / vignette (deeper than this overview)
+- `scene-vs-summary.md` — when to dramatize, when to reflect
+- `emotional-truth.md` — beyond facts, the felt sense
+- `real-people-ethics.md` — consent, defamation, anonymization patterns
+- `memoir-anti-ai-patterns.md` — hedging, "looking back I realize", reflective platitudes, tidy lessons
+
+Existing fiction-craft docs in `reference/craft/` will be tagged with a
+`book_categories: [fiction]` or `book_categories: [fiction, memoir]` frontmatter
+in #56 so skills can filter what to load.
+
+## Status progression
+
+Memoir uses the same status sequence as fiction (Idea → Concept → … → Published)
+but several stages carry **shifted intent** — see `status-model.md` in this
+directory for the per-stage notes.
+
+## Skill routing
+
+CLAUDE.md will document memoir-specific skill routing in #67. Until that lands,
+the existing fiction routing applies and skills do not yet branch on
+`book_category`.
+
+## See also
+
+- `#54` — `book_category` field
+- `#56` — memoir craft docs
+- `#67` — CLAUDE.md routing table for memoir mode
+- `#97` — Path E epic (full phase plan)
+- `reference/research/non-fiction-integration.md` — decision rationale (gitignored)

--- a/book_categories/memoir/craft/emotional-truth.md
+++ b/book_categories/memoir/craft/emotional-truth.md
@@ -1,0 +1,187 @@
+---
+book_categories: [memoir]
+craft_topic: voice-and-truth
+status: stable
+last_reviewed: 2026-04-27
+---
+
+# Emotional Truth
+
+The standard memoir is held to is **emotional truth**, not factual
+completeness. This is not a license to invent. It is a higher demand: tell
+what was felt, in the order and shape it was felt, with the specificity
+that belongs to feeling rather than to record-keeping.
+
+Factual truth is necessary but not sufficient. Two memoirists writing about
+the same Tuesday can both be factually correct and only one of them be
+emotionally true.
+
+## Definitions worth fighting over
+
+**Factual truth**: this happened, on this date, to these people, in this
+order. Verifiable from outside.
+
+**Emotional truth**: this is what it felt like to live through it — the
+weight, the dread, the small comedies, the embarrassments, the things you
+wanted to say and didn't, the things you said and shouldn't have. *The
+felt sense of being alive in that situation.*
+
+**Narrative truth**: the shape you give the lived material so that a reader
+who was not there can understand what it meant. This is craft choice; it
+is where memoir becomes art rather than diary.
+
+A memoir owes the reader **all three**, in that order of priority — but
+fails most often on the second.
+
+## The mistake of thoroughness
+
+Lived experience is dense. Every moment had texture. The new memoirist's
+instinct is to put it all in — every conversation remembered, every meal,
+every detail of every room. The result reads like a transcript of a
+deposition: factually impressive, emotionally inert.
+
+Emotional truth requires **selection**. The detail that survives is the one
+that **carried the feeling**. The shoes you remember are the shoes you
+remember because of what was happening when you were wearing them. The
+weather that survives is the weather that was inside you, not just outside.
+
+> *Fact*: It was raining. The diner had four other customers. He ordered
+> the western omelet.
+>
+> *Emotional truth*: The vinyl booth squeaked when I shifted my weight. I
+> kept watching the rain hit the diner window because if I looked at him I
+> would have to decide.
+
+The omelet does not survive the cut.
+
+## The mistake of avoidance
+
+The other failure mode: **factual hedging in service of emotional
+self-protection**. The narrator vaguely refers to "what happened" or "the
+incident" or "things he said". This is not respect for privacy — this is
+the writer protecting themselves from feeling what the reader needs to
+feel.
+
+If you cannot dramatize the moment, name what you are doing:
+
+> *Bad hedge*: After the things he said that night, I never went back to
+> the apartment.
+>
+> *Honest summary*: He said something that night I have never been able to
+> write down in twenty years of trying. I will not write it now. I never
+> went back to the apartment.
+
+The first is mush. The second is also a refusal — but a named refusal,
+which is itself emotionally true.
+
+## The retrospective vantage problem
+
+You are writing now about a self who lived then. The present-narrator knows
+things the past-self did not. The temptation is to give the past-self
+present knowledge — to make her wiser than she was, to telegraph what was
+about to happen, to treat her cluelessness with retrospective tenderness or
+contempt.
+
+**Resist all three.**
+
+- **Don't give the past-self foresight**: she did not know what was coming.
+  Honor the not-knowing. The reader will feel the dramatic irony if you
+  trust them.
+- **Don't be tender with her cluelessness**: condescension to your past
+  self reads as preening on the page ("oh, the things I did not yet
+  understand").
+- **Don't be contemptuous either**: the angry retrospective narrator who
+  judges every past decision is doing therapy on the page, not memoir.
+
+Stand with the past-self in the moment. Then, occasionally, in summary
+beats, the present-narrator can speak — but as a separate voice, marked,
+disciplined.
+
+## The dialogue problem
+
+You do not remember exact dialogue from twenty years ago. Nobody does.
+Memoir convention permits **reconstructed dialogue** — your honest best
+attempt at the substance and rhythm of what was said. It does not permit
+**invention** — putting words in someone's mouth they would not have said.
+
+The test: would the person reading this dialogue, if they could read it,
+recognize themselves in it? Not the literal words — the **register, the
+moves, the verbal habits, the way an argument went**.
+
+Some memoirists flag the convention in an author's note. Some don't. The
+convention is widely understood; the falsification of it is what gets
+people sued (or just disbelieved).
+
+## The composite problem
+
+A composite character — two or three real people merged into one for
+narrative economy — is a craft choice with ethical and legal weight. It
+**must be disclosed** in an author's note. Many readers and reviewers
+consider undisclosed composites a form of fabrication.
+
+If you can avoid composites, do. If you can't, disclose. See
+`real-people-ethics.md`.
+
+## The fact-checking question
+
+If a fact in the memoir is checkable — a date, a public event, a quoted
+public figure — **check it**. Memoir's standard for factual truth is the
+same as journalism's for anything verifiable. Get it right, or change it
+and disclose.
+
+What the memoir is *not* held to: the standard of a courtroom transcript
+for private moments only you experienced. There the standard is emotional
+truth, with the dialogue caveat above.
+
+## The "I was wrong" question
+
+Mature memoir often involves the present-narrator recognizing that the
+past-self was wrong about something — wrong about a person, wrong about
+themselves, wrong about what was happening. This is hard to render
+without it sounding like either:
+
+- **Penance porn** — the narrator beats themselves up for the reader's
+  reassurance. Performative regret is its own AI tell.
+- **Tidy redemption** — "I see now that…" followed by a clean lesson. The
+  memoir-anti-ai-patterns doc covers this; the short version is **don't**.
+
+The honest move: render the past-self's wrongness from inside the
+past-self's frame, then let the reader see what the past-self could not.
+The retrospective layer can name the wrongness briefly, in summary, without
+moralizing.
+
+## A working test for emotional truth
+
+Read your draft scene aloud to someone who knew you then but was not
+present at the event. Three things to listen for:
+
+1. **Do they recognize you in it?** Not the events — the *you*. If they
+   say "that doesn't sound like you", you have a voice problem.
+2. **Do they ask follow-up questions about the wrong details?** If they
+   want to know about the omelet, you over-included.
+3. **Are they quiet at the end?** The right reaction to emotional truth is
+   a beat of silence, not nodding agreement. Nodding means you told them
+   what to feel.
+
+## What this means for AI-assisted writing
+
+Generic AI prose drifts toward emotional consensus — toward what feeling
+sounds plausible in the abstract. Emotional truth is the opposite: the
+specific, the not-quite-shareable, the slightly-wrong, the embarrassing,
+the unflattering, the contradicted-by-what-came-after. The default of any
+LLM is to smooth this away.
+
+Defense:
+
+- Always pass output through `memoir-anti-ai-patterns.md` checks
+- Drag in **specifics that don't generalize** — the smell of a particular
+  hallway, the joke nobody else laughed at, the wrong thing you said
+- Refuse to **summarize the feeling**. Render the situation; let the
+  reader name the feeling
+
+## See also
+
+- `book_categories/memoir/craft/scene-vs-summary.md` — when to dramatize
+- `book_categories/memoir/craft/memoir-anti-ai-patterns.md` — the reflective platitude trap
+- `book_categories/memoir/craft/real-people-ethics.md` — dialogue convention, composites
+- `reference/craft/anti-ai-patterns.md` — the universal AI-tell catalog

--- a/book_categories/memoir/craft/memoir-anti-ai-patterns.md
+++ b/book_categories/memoir/craft/memoir-anti-ai-patterns.md
@@ -1,0 +1,236 @@
+---
+book_categories: [memoir]
+craft_topic: voice-and-truth
+status: stable
+last_reviewed: 2026-04-27
+---
+
+# Memoir Anti-AI Patterns
+
+This is the memoir-specific companion to `reference/craft/anti-ai-patterns.md`.
+That doc catalogs universal AI tells — generic vocabulary, smooth-but-flat
+rhythm, plausible-sounding-nothing. This doc covers the **memoir-specific
+failure modes** that LLM-assisted prose drifts toward and that fiction
+prompts do not catch.
+
+The forthcoming `voice-checker` in memoir mode (Phase 3 #62) and the
+chapter-writer in memoir mode (Phase 2 #57) load this file. Until those
+land, treat it as a manual revision pass.
+
+## The five memoir AI tells
+
+Each pattern below: what it is, why LLMs produce it, an example, and how
+to fix it.
+
+---
+
+### 1. Reflective platitude
+
+The narrator pauses to deliver a generic life-lesson in elegant cadence.
+The lesson is true the way fortune cookies are true — broad enough to
+apply to anyone, specific enough to apply to nobody.
+
+> *Bad*: I have come to understand that grief is not a destination but a
+> companion that walks beside us, sometimes quietly, sometimes loudly,
+> always present.
+
+The reflection sounds wise. It says nothing. It could close any grief
+memoir; therefore it closes none of them.
+
+**Why LLMs do this**: training data is full of grief-essay closings shaped
+exactly like this. The model interpolates toward consensus.
+
+**Fix**: replace the platitude with **a specific, slightly-wrong, slightly-
+embarrassing thing only this narrator would say**.
+
+> *Better*: Grief is not what people warn you about. Nobody warned me I
+> would still be writing the wrong year on checks four months later
+> because some part of me had not agreed to live in a year my mother had
+> not lived in.
+
+Specificity (checks, four months, a year not yet conceded) defeats the
+platitude. The reader believes it because no other narrator could have
+said it.
+
+---
+
+### 2. "Looking back, I now realize"
+
+The construction itself, with its cousins:
+
+- *Looking back, I now realize…*
+- *In hindsight, I see that…*
+- *Now, with the benefit of years, I understand…*
+- *Only later did I come to know…*
+- *What I did not yet know was…*
+
+These are the AI's go-to retrospective hinges. Each does the same thing:
+**announces** that the present-narrator is about to deliver wisdom about
+the past. The announcement is the problem — it tells the reader what is
+about to happen instead of just doing it.
+
+**Why LLMs do this**: retrospective wisdom is a memoir convention; LLMs
+default to the most-rehearsed phrasing of any convention.
+
+**Fix options**:
+
+- **Cut the hinge entirely**. Move directly into the realization;
+  trust the tense shift to do the work.
+- **Move the realization into a scene** so the past-self comes to it
+  rather than the present-narrator delivering it.
+- **Replace with a more idiosyncratic move**: "It took me a decade to
+  understand…" / "I was wrong about him for years. I am still occasionally
+  wrong." The voice betrays a specific narrator, not a generic one.
+
+> *Bad*: Looking back, I now realize that my mother had been afraid for
+> years.
+>
+> *Better*: It took her death for the fear to make sense. She had been
+> rehearsing it for years.
+
+---
+
+### 3. Tidy lessons / earned wisdom
+
+The chapter ends with a clean takeaway. The narrator has Learned Something.
+The reader nods. The book has done its job.
+
+> *Bad*: I left the apartment that day understanding, finally, that love
+> was not the same as obligation. It was a lesson I would carry with me.
+
+The lesson is too clean. Real change is not legible at the moment of
+change; it is partial, contradicted by next week's behavior, slowly
+reversed and re-reversed. A lesson that announces itself as final almost
+certainly wasn't.
+
+**Why LLMs do this**: chapter-ending wisdom is a strong training pattern;
+the model converges on it.
+
+**Fix**: end the chapter on **the moment, not the meaning**. The reader
+will extract the lesson if it's there. If you have to deliver it, deliver
+it slant — partial, self-undermining, contradicted by the next chapter.
+
+> *Better*: I left the apartment that day. Six weeks later I went back to
+> get a sweater I had not actually forgotten. He was not home. I sat on
+> the steps for an hour pretending I was waiting for him.
+
+The non-tidy ending tells the reader the lesson was not learned. That is
+emotional truth.
+
+---
+
+### 4. Hedging as humility
+
+The narrator softens every claim with qualifiers — *perhaps*, *I think*,
+*maybe*, *some part of me*, *in a sense*, *in some way*, *to a certain
+extent* — until the prose is upholstered in cotton.
+
+> *Bad*: I think perhaps in some way I had always known, on some level,
+> that the marriage was, in a sense, over.
+
+The narrator is doing **performative humility**. The reader does not
+believe the narrator's uncertainty; they correctly read it as the writer's
+fear of commitment to the claim.
+
+**Why LLMs do this**: AI safety training rewards hedging. Memoir prose
+suffers under it.
+
+**Fix**: remove every qualifier on the first pass. Add back the one or
+two that mark genuine uncertainty. The rest were upholstery.
+
+> *Better*: I had always known the marriage was over. Knowing was the
+> easy part.
+
+If the second sentence ("knowing was the easy part") is false, the
+narrator can replace it with a more accurate hard-edged claim. But the
+hedging version concedes nothing real.
+
+---
+
+### 5. The therapeutic reframe
+
+The narrator interprets a past experience through a present-day vocabulary
+of therapy, trauma, attachment styles, somatics, parts work, nervous-system
+language. The reframe is intelligent. It is also **anachronistic** —
+imposing a current frame on a past that did not have it.
+
+> *Bad*: I see now that my body was holding the trauma of those years in
+> my fascia, my breath patterns, my dysregulated nervous system, manifesting
+> as the chronic tension that twenty-year-old me did not yet have the
+> language to name.
+
+The vocabulary is twenty-five years more advanced than the past-self's
+experience. The retrospective frame is plausible — and may even be true —
+but it occupies the page where the **felt sense at the time** should live.
+
+**Why LLMs do this**: therapeutic language has saturated memoir-adjacent
+training data; the model defaults to the contemporary lexicon.
+
+**Fix options**:
+
+- **Render the past-self's experience in the past-self's vocabulary**.
+  "My back hurt all the time and I couldn't sleep" is more honest and
+  more dramatic than "my dysregulated nervous system was holding…"
+- **If the contemporary frame matters, mark it as retrospective**, in a
+  short summary beat, not a scene-disrupting interruption: "What I
+  would now call dissociation, I then called 'spacing out.' I spaced out
+  through most of that year."
+- **Trust the reader to bring their own contemporary frame** to the
+  rendered experience. They will name it. You don't have to.
+
+---
+
+## The reflexive AI-tell pattern: explanation-after-image
+
+A subtler tell, common when LLMs assist with sentence-by-sentence
+composition: every concrete image is **immediately followed by an
+explanation of its meaning**.
+
+> *Bad*: He set down the coffee mug very carefully on the saucer, the
+> small ceremony of a man trying to control what he could because so much
+> else had slipped through his hands.
+
+The image (careful coffee mug) does work. The explanation (because so
+much else had slipped through his hands) **eats the work**. The reader
+no longer has to feel anything; they have been told what the image meant.
+
+**Fix**: **strip the explanation**. Trust the image. If you cannot trust
+the image, the image is not strong enough — make it stronger, don't
+gloss it.
+
+> *Better*: He set down the coffee mug very carefully on the saucer.
+
+The reader does the work. Memoir respects the reader.
+
+---
+
+## A revision pass for AI-tells
+
+When revising any memoir chapter — whether AI-assisted or not — run this
+pass:
+
+- [ ] Search for *looking back*, *in hindsight*, *now I see*, *now I realize*, *what I did not yet know* — kill or rewrite
+- [ ] Search for *perhaps*, *in some way*, *to a certain extent*, *some part of me*, *in a sense* — strip on first pass, restore only if genuine uncertainty
+- [ ] Search for therapy-vocabulary anachronisms (*nervous system*, *dysregulated*, *attachment*, *somatic*, *trauma response*, *parts work*) — verify each was contemporaneous or marked retrospective
+- [ ] Read each chapter ending — does it deliver a tidy lesson? Cut the lesson; end on the moment
+- [ ] Read each scene — is every concrete image followed by an explanation of its meaning? Strip the explanation; trust the image
+- [ ] Read aloud to a person who knew you then — do they recognize you, or do they recognize "memoir voice"?
+
+## What this means for AI-assisted drafting
+
+LLMs are useful for drafting in memoir mode under two conditions:
+
+1. **The author profile carries strong voice constraints** that are loaded
+   before any prose generation (the standard StoryForge pattern).
+2. **Output passes through this anti-pattern check** before being treated
+   as drafted — manually in Phase 1, automatically once
+   `voice-checker` learns memoir mode (Phase 3).
+
+Without those guards, AI-drafted memoir reads as memoir-shaped consensus.
+The reader can feel it. They will close the book.
+
+## See also
+
+- `reference/craft/anti-ai-patterns.md` — universal AI tells (apply here too)
+- `book_categories/memoir/craft/emotional-truth.md` — what the page should be doing instead
+- `book_categories/memoir/craft/scene-vs-summary.md` — the scene/summary discipline that prevents many of these

--- a/book_categories/memoir/craft/memoir-structure-types.md
+++ b/book_categories/memoir/craft/memoir-structure-types.md
@@ -1,0 +1,216 @@
+---
+book_categories: [memoir]
+craft_topic: structure
+status: stable
+last_reviewed: 2026-04-27
+---
+
+# Memoir Structure Types
+
+The structural shape of a memoir is **independent of the chronology of the
+lived events**. Pick the structure that serves the story you are telling, not
+the one that mirrors what actually happened. Lived life is shapeless until you
+shape it.
+
+This doc covers the four working types StoryForge supports:
+**chronological**, **thematic**, **braided**, **vignette**. Pick one before
+you draft. Hybrids are possible but harder — earn them.
+
+## Chronological
+
+Events told in the order they happened.
+
+### When it works
+
+- The transformation is **time-bound** and **causal** — what happened in March
+  determined what happened in May, and the reader needs to feel that sequence.
+- The period is **bounded and short** (a year of grief, a season of treatment,
+  the months between two deaths). Contained time gives chronology its weight.
+- The reader needs the **suspense of not-yet-knowing** what comes next, in
+  the order the narrator didn't know either.
+
+### When it fails
+
+- You try to cover decades chronologically — every year demands equal weight
+  and the result feels like a CV with feelings.
+- Lived events have no causal momentum, so the chronology becomes a bag of
+  anecdotes pretending to be a narrative.
+- You hide the central question behind "what happens next" — readers tire of
+  not knowing why they're reading.
+
+### Discipline required
+
+- **Cut sub-arcs that don't serve the central theme**, even if they really
+  happened. The boyfriend you forgot to mention from spring of '98 is fine to
+  leave out.
+- **Compress aggressively**. Two months of tedium become one paragraph; one
+  hinge afternoon becomes twenty pages.
+- **Decide where to begin**. The narrative beginning is rarely the
+  chronological beginning. *In medias res* is your friend.
+
+### Examples in the wild
+
+- *The Year of Magical Thinking* (Joan Didion) — bounded year of grief
+- *When Breath Becomes Air* (Paul Kalanithi) — bounded by terminal illness
+- *Wild* (Cheryl Strayed) — bounded by the hike, with selective flashback
+
+---
+
+## Thematic
+
+Chapters organized by topic — *Money*, *Faith*, *Bodies*, *Hunger* — rather
+than by timeline. The same period of life can recur across chapters from
+different angles.
+
+### When it works
+
+- The central question is **conceptual**, not temporal — "what does it mean
+  to leave a faith?" rather than "what happened to me in 2019?"
+- You want to honor the **non-linear way memory actually works** — themes
+  cluster events; chronology dissipates them.
+- Multiple decades of life inform the question, and forcing chronology would
+  flatten what's interesting.
+
+### When it fails
+
+- Themes are too abstract to anchor scenes (*Truth*, *Beauty*, *Love* — kill
+  these and pick concrete substitutes).
+- The chapters don't talk to each other — feels like a connected essay
+  collection, not a memoir.
+- Reader can't track the narrator across chapters because there's no thread.
+
+### Discipline required
+
+- **Each chapter still needs scene work**. Thematic doesn't mean
+  essay-with-anecdotes — it means the dramatic spine is conceptual instead of
+  temporal.
+- **Plant a through-line**. A relationship, a recurring object, a question
+  that escalates. Without a through-line, themes feel modular.
+- **Think about chapter order as argument**. The reader should feel that
+  Chapter 7 needs to come after Chapter 6 — not because of time, but because
+  of how the question evolves.
+
+### Examples in the wild
+
+- *I Know Why the Caged Bird Sings* (Maya Angelou) — themes of voice,
+  silence, displacement layered across childhood
+- *The Argonauts* (Maggie Nelson) — themes of family-making, gender, the
+  body, in fragments
+- *H is for Hawk* (Helen Macdonald) — grief, falconry, T.H. White, woven
+  thematically
+
+---
+
+## Braided
+
+Two or more parallel threads — typically **then** and **now**, or **two
+narrative timelines** — interwoven scene by scene.
+
+### When it works
+
+- Past and present **comment on each other**. The cuts are the meaning. A
+  scene of childhood obedience next to a scene of adult rebellion does
+  rhetorical work no single timeline could.
+- The narrator's **current vantage point is part of the story** — what they
+  now understand about what they then experienced.
+- You want **dramatic irony**: the reader knows where it leads; the past-self
+  doesn't.
+
+### When it fails
+
+- The braid becomes a **convenience for transitions** — you cut to the other
+  timeline whenever the current one runs out of energy. Lazy.
+- Both threads are weak; braiding doesn't strengthen weak material, it
+  multiplies it.
+- The "now" thread is just **commentary** — meta-reflection without scene.
+  That's not braiding; that's interrupting.
+
+### Discipline required
+
+- **Each thread must earn its airtime**. If one thread is doing 80% of the
+  emotional work, drop the other and make it linear.
+- **Transitions must be deliberate** — image, theme, or echo carries the
+  reader across the cut. "Meanwhile, decades later" is the cliché trap.
+- **Decide your cadence**. Strict alternation? Weighted toward one thread?
+  Variable? The pattern is itself a craft choice.
+
+### Examples in the wild
+
+- *Negroland* (Margo Jefferson) — past and present-day reflection braided
+- *The Liars' Club* (Mary Karr) — past chronology with adult-narrator
+  intrusions
+- *Fun Home* (Alison Bechdel) — graphic memoir, multiple timelines braided
+  visually and verbally
+
+---
+
+## Vignette
+
+Short, self-contained scenes (3–8 pages each), loosely connected by theme
+or through-line rather than tight causal arc.
+
+### When it works
+
+- The lived material is **fragmented in memory** — childhood, trauma,
+  estrangement, neurodivergent experience — and forcing tight causality
+  would falsify the felt sense.
+- Each scene can **bear weight on its own**. A vignette memoir is closer to
+  a poetry collection than a novel.
+- The cumulative effect is **mosaic** — meaning emerges from
+  juxtaposition, not from progression.
+
+### When it fails
+
+- Vignettes are not **strong enough individually** — without a tight arc to
+  pull the reader through, weak scenes stop the read.
+- The connecting tissue is too thin — the reader isn't sure what they're
+  reading or why they should keep going.
+- It collapses into an **anecdote collection**. Anecdotes amuse; vignettes
+  accumulate.
+
+### Discipline required
+
+- **Each vignette is a complete unit**. Beginning, middle, end. Earned
+  ending, not just a stop.
+- **A through-line still exists**: a recurring image, a place, a relationship,
+  an unanswered question. Make it visible by Chapter 3 or the reader bails.
+- **Order matters**. Vignettes are arranged, not just collected. The order
+  is part of the argument.
+
+### Examples in the wild
+
+- *Bluets* (Maggie Nelson) — 240 numbered fragments around the color blue
+- *The Chronology of Water* (Lidia Yuknavitch) — fragmentary scenes of body,
+  swimming, addiction
+- *Brother, I'm Dying* (Edwidge Danticat) — episodes around two brothers,
+  loosely chronological
+
+---
+
+## Hybrid structures
+
+Most published memoirs are **mostly one type with disciplined departures**.
+*Wild* is chronological with selective flashback. *Negroland* is braided but
+each braid is internally chronological. *The Argonauts* is thematic but uses
+some scene chronology within chapters.
+
+**Earn the hybrid.** If you can't name your dominant structure in one word,
+you don't have a structure — you have a draft.
+
+## Choosing — a decision tree
+
+| Ask yourself | If yes → consider |
+|--------------|-------------------|
+| Is the period bounded and the causality tight? | Chronological |
+| Is the central question conceptual, not temporal? | Thematic |
+| Does the present-self vantage point add meaning to the past events? | Braided |
+| Is the lived experience fragmented or non-narrative by nature? | Vignette |
+
+If two answers are yes, pick the one whose **failure modes you can avoid**.
+The right structure is the one whose discipline you can sustain.
+
+## See also
+
+- `book_categories/memoir/craft/scene-vs-summary.md` — within any structure, dramatize vs. reflect
+- `book_categories/memoir/craft/emotional-truth.md` — what shape serves
+- `book_categories/memoir/README.md` — overview

--- a/book_categories/memoir/craft/real-people-ethics.md
+++ b/book_categories/memoir/craft/real-people-ethics.md
@@ -1,0 +1,225 @@
+---
+book_categories: [memoir]
+craft_topic: ethics-and-legal
+status: stable
+last_reviewed: 2026-04-27
+---
+
+# Real People in Memoir — Ethics and Legal
+
+Memoir puts real people on the page. Some consent. Some can't. Some won't
+like it. A few may sue. This doc covers the practical ethics and the
+working legal categories. **It is not legal advice.** When the stakes are
+high — a named living person, a damaging claim, a powerful subject —
+consult an actual publishing lawyer before you publish.
+
+This doc is the working framework that StoryForge skills (especially the
+forthcoming `memoir-ethics-checker`, #65) use to flag risk and prompt
+consent decisions.
+
+## The four-category model
+
+Every named real person in a memoir falls into one of these:
+
+| Category | Defines | Typical risk | Consent posture |
+|----------|---------|--------------|-----------------|
+| **Public figure** | Politician, celebrity, named author of a public work | Lower — public conduct is fair game; private life is not | Not required for public conduct; required for private claims |
+| **Private living person** | Anyone not a public figure | Highest — defamation + privacy claims live here | Strongly recommended; sometimes mandatory |
+| **Deceased person** | Person no longer living | Lower — defamation typically does not survive death | Not required, but consider survivors' feelings |
+| **Anonymized / composite** | Person whose identity you have actively obscured or merged | Lower if anonymization holds | Disclose convention in author's note |
+
+Tag each person in `characters/` (or `people/`, post-#59) with their
+category and a `consent_status` field:
+
+- `confirmed-consent` — you have asked, they have said yes (ideally in
+  writing for a high-stakes portrayal)
+- `pending` — you intend to ask before publication; not yet asked
+- `not-required` — public figure on public matters, deceased, or fully
+  anonymized
+- `refused` — you asked, they said no — see "When consent is refused"
+- `not-asking` — deliberate choice not to ask (estranged relationship,
+  abuser, etc.) — see "When you're not asking"
+
+## Defamation, in two paragraphs
+
+A defamation claim in most common-law jurisdictions requires: (1) a false
+statement of fact (2) about an identifiable person (3) communicated to a
+third party (4) causing harm. Opinion is generally protected; truth is
+generally a complete defense; substantial truth (the gist is true even if
+details differ) is usually enough.
+
+The traps for memoirists:
+
+- **Compressed time** can convert a defensible characterization into an
+  indefensible one. "He drank too much, that year" is different from "He
+  was an alcoholic". Be precise about scope.
+- **Reconstructed dialogue** that puts a defamatory statement in someone's
+  mouth they did not actually make is invention dressed as fact. Don't.
+- **Mind-reading**: "He hated me" is opinion if framed as your perception;
+  it can read as fact. Frame perceptions as perceptions.
+- **Imputation of crime, professional incompetence, or sexual misconduct**
+  raises the legal bar. These are *per se* defamatory in many
+  jurisdictions if false. Verify, document, or strongly consider
+  anonymization.
+
+## Anonymization patterns that work
+
+Light anonymization (changed name only) **often does not protect you** if
+the person is identifiable from context — relationship, location,
+occupation, distinctive events. Real anonymization changes enough that the
+person could not be identified by anyone who knew them well.
+
+Effective patterns:
+
+- **Change the name plus 2–3 identifying facts** (occupation, city, hair
+  color, age range, distinguishing physical detail). Pick ones that don't
+  change the meaning of the story.
+- **Conflate timing**. Move events by months or compress two encounters
+  into one if it doesn't distort the felt sense.
+- **Use "a friend" or "a colleague"** in summary if the person doesn't
+  need to be on the page as a character. The reader doesn't need every
+  name.
+- **Disclose in an author's note** that "some names and identifying details
+  have been changed" — this is standard memoir convention and does not
+  weaken the work.
+
+What does **not** count as anonymization:
+
+- Changing only the first name when the person is your sister and you've
+  said you have one sister.
+- Calling someone "my boss" when you've named the small company in
+  Chapter 2.
+- Using initials.
+- Vaguely distorting age or gender while keeping every other identifier.
+
+## Composite characters
+
+Merging two or more real people into one fictional character is **a
+fabrication if undisclosed** in many readers' eyes (and increasingly in
+publishers' contracts). The convention is:
+
+- Use composites only when **necessary for narrative economy** (the story
+  has six minor characters who collectively played one role; merge them
+  into one).
+- Never composite when the merged character carries **moral weight** the
+  individuals did not. Don't merge a difficult-but-decent ex with an
+  abusive ex into one character readers will read as the abuser.
+- **Always disclose** in an author's note. "Some characters are composites
+  of two or more people I knew" is standard.
+
+If you are tempted to composite to obscure identity rather than for
+narrative economy, you are anonymizing badly. Do real anonymization
+instead.
+
+## Consent in practice
+
+When asking consent for a high-stakes portrayal of a private living
+person:
+
+1. **Show them the relevant passages**, not just describe them.
+2. **Tell them what you cannot change** — the events as you remember
+   them, the felt sense, the meaning. Tell them what you can — name,
+   identifying details, dialogue specifics.
+3. **Get it in writing if the portrayal is sensitive**. A simple "I have
+   read the attached pages and consent to publication as written" email
+   is enough for most cases.
+4. **Don't promise approval rights over the whole book**. You retain
+   editorial control; they are consenting to their portrayal.
+
+When asking consent feels like it would damage the relationship:
+
+- **Ask anyway** if you would not be okay publishing without consent.
+- **Anonymize** if you would publish without consent but can render the
+  story without identifying them.
+- **Reconsider whether the story needs them on the page** if neither.
+
+## When consent is refused
+
+You have three ethical paths:
+
+- **Honor the refusal**: cut or anonymize the portrayal.
+- **Publish anyway because the story requires it and you accept the
+  consequences**: relationship damage, possible legal exposure, possible
+  reputational damage to you. Be clear-eyed about this; don't pretend
+  you're being heroic.
+- **Re-frame**: render the story from a different angle, summary instead
+  of scene, perception instead of fact, in a way that no longer requires
+  the disputed material.
+
+Whichever path: **document the request and refusal**. If you publish
+against refusal, you should be able to demonstrate that you considered
+the harm.
+
+## When you're not asking
+
+There are situations — abuse, estrangement, ongoing harm — where asking
+consent is itself unsafe or absurd. You don't owe consent to every
+real person on every page. You do owe yourself clarity about why you
+are not asking.
+
+Working test: would a reasonable reader who learned why you didn't ask
+agree it was a defensible choice? If yes, document the reasoning in your
+project notes (not the book) and proceed. If no, ask anyway, even if
+they refuse.
+
+## Special cases
+
+### Children
+Particularly your own children. They cannot meaningfully consent to a
+portrayal that will outlive their childhood. Anonymize aggressively, or
+wait until they're old enough to consent.
+
+### Therapists, doctors, lawyers
+Their interactions with you are legally privileged from their side. From
+your side, you can write what you want — but be precise. Quoting a
+therapist saying something they did not say is the same defamation
+problem as anyone else, with extra reputational weight.
+
+### Public figures on private matters
+Public figures' private lives are not "fair game" simply because they're
+public. The First-Amendment protections that loosen defamation standards
+on their public conduct don't extend to their private conduct.
+
+### Group portraits — religion, family, ethnicity
+You can write critically about the group you came from. You will hear
+about it. This is not a legal matter; it is an emotional one. Decide in
+advance whether you can sustain the response.
+
+## The author's note
+
+A memoir author's note typically covers:
+
+- **Anonymization disclosure**: "Some names and identifying details have
+  been changed."
+- **Composite disclosure**: "X is a composite of two friends from that
+  period" — or, more general, "Some characters are composites."
+- **Time-compression disclosure**: "I have compressed events that took
+  place over several months into a single chapter for narrative clarity."
+- **Reconstructed dialogue**: "Dialogue is reconstructed from memory; it
+  is the substance of conversations as I remember them, not a verbatim
+  record."
+
+These are not cop-outs. They are the conventions that make memoir
+trustworthy. Skipping them does not make the work more honest; it makes
+it less.
+
+## What StoryForge skills enforce
+
+Phase 1 (#54–#56, #67) does not yet branch on category. From Phase 3 on:
+
+- `memoir-ethics-checker` (#65) flags named living people without
+  `consent_status`, scans for *per se* defamation triggers, and warns on
+  thin anonymization.
+- `chapter-writer` in memoir mode (Phase 2 #57) prompts for consent
+  status before drafting any scene with a named living person.
+- The author's-note generation in `export-engineer` (Phase 4 #64)
+  assembles the disclosure paragraphs from per-person `consent_status`
+  values.
+
+Until those land, this doc is your manual checklist.
+
+## See also
+
+- `book_categories/memoir/craft/emotional-truth.md` — dialogue convention, composites in context
+- `book_categories/memoir/status-model.md` — consent gates between status transitions
+- `book_categories/memoir/README.md` — overview

--- a/book_categories/memoir/craft/scene-vs-summary.md
+++ b/book_categories/memoir/craft/scene-vs-summary.md
@@ -1,0 +1,154 @@
+---
+book_categories: [memoir]
+craft_topic: scene-craft
+status: stable
+last_reviewed: 2026-04-27
+---
+
+# Scene vs. Summary in Memoir
+
+The first decision on every page of a memoir: **dramatize or reflect**.
+Scene puts the reader in the moment with the past-self. Summary speeds
+across time and pulls back to the narrator's vantage point. Both are
+necessary. The mistake is picking by default instead of by intent.
+
+Fiction has the same choice but answers it differently. Fiction defaults to
+scene because invented stories live or die by dramatic immediacy. Memoir
+defaults to a **mix** — too much scene becomes a novel pretending to be
+true; too much summary becomes an essay pretending to be a memoir.
+
+## What scene is
+
+A scene is a moment **rendered in real time** with sensory specificity and
+the past-self at the center. The reader is present. Dialogue happens.
+Things are seen, smelled, felt. Time slows.
+
+> The phone rang while I was washing rice. I dried my hands on the dishcloth
+> and let it ring four times before I picked up. My sister's voice was very
+> small. "Mom fell." I leaned my forehead against the cabinet. The rice
+> water was still running.
+
+That's a scene. Twenty-five seconds rendered in five sentences. The reader
+is in the kitchen.
+
+## What summary is
+
+Summary **compresses time** and lets the narrator (often the present-day
+narrator looking back) speak directly about what happened, what it meant,
+or what came next.
+
+> In the months after the fall, I drove down on weekends. The hospital, then
+> rehab, then the assisted-living place that smelled like institutional
+> applesauce. I learned the names of three different physical therapists and
+> forgot two of them.
+
+That's summary. Three months in three sentences. The reader is told, not
+shown. That's appropriate here — the actual content of those months is not
+where the meaning lives.
+
+## When to dramatize
+
+| Use scene when… | Why |
+|----------------|-----|
+| The moment changed something | The reader needs to feel the hinge |
+| Dialogue carries the meaning | What was said, said-back, not-said matters |
+| Sensory specificity carries the meaning | Place, body, weather, object are the point |
+| The reader needs to **decide for themselves** what's happening | Scene resists pre-digestion |
+| The narrator's vantage point would distort | Stay with the past-self's not-yet-knowing |
+
+The hinge moments — first kiss, last conversation, the room where the
+diagnosis was given — must be scene. Skipping them is cheating.
+
+## When to summarize
+
+| Use summary when… | Why |
+|----------------|-----|
+| Time needs to pass without consequence | Don't bore the reader with months of nothing |
+| The narrator's reflection is the point | Some meaning is *only* available retrospectively |
+| You're connecting two scenes | Bridge fast; the scenes are doing the work |
+| The information is necessary but not dramatic | Backstory, context, who-was-who |
+| Showing it would take 40 pages | Pick your battles |
+
+## The bad default: summary disguised as scene
+
+The most common memoir failure is **scene-shaped summary**: present-tense
+or past-tense rendering that has no sensory ground, no dialogue specificity,
+no present moment. It looks like scene because it's narrated forward, but
+it's actually telling.
+
+> *Bad scene-shaped summary:*
+>
+> I started seeing a therapist that fall. We talked about my mother and my
+> father and how they had loved me badly. Slowly I began to understand that
+> I was not responsible for their pain.
+
+That's a summary in scene's clothing. It tells the reader the journey rather
+than dramatizing one therapy session that opened the door. Either:
+
+- **Dramatize one session** — the chair, the kleenex box, the specific
+  thing you said and the silence that followed it; or
+- **Be honestly summary** — "Therapy that year did the work I had been
+  postponing for two decades." One sentence, then move on.
+
+Don't render a year of therapy as scene. Pick a moment.
+
+## The other bad default: reflective interruption
+
+The mirror-image failure: **scene interrupted by retrospective commentary**.
+You're in the moment, then suddenly the present-day narrator steps in to
+explain what it meant.
+
+> *Bad reflective interruption:*
+>
+> I sat across from him at the diner. He stirred sugar into his coffee.
+> *Looking back, I now understand that this was the moment I knew the
+> marriage was over.* He asked about my mother.
+
+The italicized line breaks the spell. The reader is yanked from the diner
+to the writing desk. If the moment is doing its work, the reader will
+arrive at "the marriage was over" without being told. If they won't, the
+scene isn't strong enough — fix the scene, don't add narration.
+
+The exception: braided structures (see `memoir-structure-types.md`) make
+present-narrator commentary explicit and rhythmic. There the cuts are the
+craft. Here we're talking about un-earned interruption inside a scene.
+
+## Pacing: the scene/summary ratio
+
+A rough working ratio for full-length memoir:
+
+- **40–60% scene** — the moments that earned the reader's time
+- **30–50% summary** — connective tissue, time-passage, necessary backstory
+- **5–15% reflection** — present-narrator commentary, when it does work
+  scene cannot
+
+These are not rules. They are warnings. If you're outside the band, ask why.
+
+- **<30% scene**: are you writing memoir or essay? If essay, embrace it.
+- **>70% scene**: are you writing memoir or auto-fiction? If a novel,
+  embrace it.
+- **>20% reflection**: the present-narrator is hogging the mic. Trust the
+  scenes more.
+
+## A working test
+
+For each chapter you've drafted, mark every paragraph as **S** (scene),
+**Σ** (summary), or **R** (reflection). Look at the pattern.
+
+- All S: too much real-time, reader is exhausted
+- All Σ: nothing happens; reader is bored
+- All R: this is an essay, not a memoir
+- Long S blocks broken by short Σ pivots and rare R: usually working
+
+## Specific to memoir, not fiction
+
+Fiction can sustain very long scene blocks because invention generates
+energy on demand. Memoir cannot — lived material has the rhythm it has,
+and pretending an unremarkable Wednesday was full of dramatic compression
+falsifies it. Be honest about which moments earned scene and which didn't.
+
+## See also
+
+- `book_categories/memoir/craft/emotional-truth.md` — what reflection actually is
+- `book_categories/memoir/craft/memoir-anti-ai-patterns.md` — the reflective platitude trap
+- `reference/craft/show-dont-tell.md` — the fiction-side companion

--- a/book_categories/memoir/status-model.md
+++ b/book_categories/memoir/status-model.md
@@ -1,0 +1,82 @@
+---
+book_category: memoir
+status: scaffold
+last_reviewed: 2026-04-27
+---
+
+# Memoir — Status Model
+
+Memoir uses the **same status sequence** as fiction (defined in `CLAUDE.md`
+under "Status Progressions"). The progression strings, ranks, and auto-sync
+behavior (Issues #19, #21, #25) are unchanged.
+
+What differs is the **meaning** of each stage when the book's `book_category`
+is `memoir`. Skills branching on category in Phase 2+ will use these
+interpretations to drive different prompts, checks, and quality gates.
+
+## Stage interpretations
+
+| Status | Fiction meaning | Memoir meaning |
+|--------|-----------------|----------------|
+| `Idea` | A premise / what-if hook | A piece of life worth examining (theme, period, relationship) |
+| `Concept` | Premise + logline + comp titles | Theme + central question + intended angle on the material |
+| `Research` | World-building research, source material | Factual research: dates, places, public record, fact-checking |
+| `Plot Outlined` | Acts, beats, scenes invented | **Narrative arc identified** — the shape imposed on lived events |
+| `Characters Created` | Invented characters with arcs | **People profiles drafted**, with consent + anonymization decisions |
+| `World Built` | Setting, magic, rules invented | Setting + era documented (usually researched, not invented) |
+| `Drafting` | Same — chapters being written | Same |
+| `Revision` | Same — structural and prose passes | Same, plus emotional-truth pass and consent re-check |
+| `Editing` | Same | Same |
+| `Proofread` | Same | Same |
+| `Export Ready` | Same | Same |
+| `Published` | Same | Same |
+
+## Memoir-specific quality gates
+
+These are **not** new statuses — they are checklists that gate transitions
+between existing statuses. Phase 3 skills (#65 `memoir-ethics-checker`, #66
+`emotional-truth-prompt`) will enforce them.
+
+### Before `Plot Outlined → Characters Created`
+
+- [ ] Theme is explicit and falsifiable (not "growing up was hard")
+- [ ] Central question is named (the one the memoir is trying to answer)
+- [ ] Structure type chosen (chronological / thematic / braided / vignette)
+
+### Before `Characters Created → World Built`
+
+- [ ] Every named real person in `characters/` has a consent status:
+  `confirmed-consent` / `pending` / `anonymized` / `composite` / `public-figure`
+- [ ] Anonymized people have a documented anonymization strategy
+- [ ] Composite characters (multiple real people merged) are flagged in author's note plan
+
+### Before `Drafting → Revision`
+
+- [ ] No factual claim about a living named person without source or consent
+- [ ] Emotional-truth pass complete (the felt sense, not just the events)
+- [ ] Memoir-anti-ai patterns checked (hedging, tidy lessons, reflective platitudes)
+
+### Before `Revision → Editing`
+
+- [ ] Real-people-ethics review complete
+- [ ] Defamation risk scan (#65 will automate)
+- [ ] Author's note drafted (anonymization, composite, time-compression disclosures)
+
+## Auto-sync behavior
+
+Auto-sync rules (Issue #25) are **unchanged** for memoir. The forward-only
+floor still applies — a user-set higher tier (`Export Ready`, `Published`)
+is never silently downgraded by chapter-state aggregates.
+
+## Open questions (for Phase 2/3)
+
+- Should memoir add a sub-state `Consent Verified` between `Characters Created`
+  and `World Built`? Decision deferred to #65 implementation.
+- Should `world/` be renamed to `setting/` for memoir projects, or kept aliased
+  like #17 did for `worldbuilding/`? Decision deferred to #59 implementation.
+
+## See also
+
+- `book_categories/memoir/README.md` — overview
+- `CLAUDE.md` — canonical fiction status model + auto-sync semantics
+- `book_categories/memoir/craft/real-people-ethics.md` — consent + defamation patterns (Phase 1.6)

--- a/reference/craft/anti-ai-patterns.md
+++ b/reference/craft/anti-ai-patterns.md
@@ -1,3 +1,10 @@
+---
+book_categories: [fiction, memoir]
+craft_topic: voice-and-truth
+status: stable
+last_reviewed: 2026-04-27
+---
+
 # Anti-AI Patterns: A Writer's Guide to Authentic Fiction
 
 When artificial intelligence generates narrative, it leaves footprints. These aren't accidents—they're artifacts of how language models work. They process statistical probability rather than human emotion. They optimize for coherence over character. They speak in the voice of the internet average.

--- a/reference/craft/chapter-construction.md
+++ b/reference/craft/chapter-construction.md
@@ -1,3 +1,10 @@
+---
+book_categories: [fiction, memoir]
+craft_topic: structure
+status: stable
+last_reviewed: 2026-04-27
+---
+
 # Chapter Construction: The Architecture of Narrative Progression
 
 ## Introduction

--- a/reference/craft/character-arcs.md
+++ b/reference/craft/character-arcs.md
@@ -1,3 +1,10 @@
+---
+book_categories: [fiction]
+craft_topic: character
+status: stable
+last_reviewed: 2026-04-27
+---
+
 # Character Arcs: Transforming Characters Through Story
 
 A character arc is the trajectory of change (or lack of change) a character undergoes from the beginning to the end of a story. While character creation establishes who a character is, character arcs determine how they transform—or fail to transform—through the pressures of the narrative.

--- a/reference/craft/character-creation.md
+++ b/reference/craft/character-creation.md
@@ -1,3 +1,10 @@
+---
+book_categories: [fiction]
+craft_topic: character
+status: stable
+last_reviewed: 2026-04-27
+---
+
 # Character Creation: A Comprehensive Guide to Building Believable, Compelling Characters
 
 Creating authentic, multi-dimensional characters is the foundation of compelling fiction. A well-crafted character doesn't just populate your story; they drive it forward through their contradictions, desires, and internal conflicts. This guide provides practical frameworks for building characters that readers will care about.

--- a/reference/craft/conflict-types.md
+++ b/reference/craft/conflict-types.md
@@ -1,3 +1,10 @@
+---
+book_categories: [fiction, memoir]
+craft_topic: structure
+status: stable
+last_reviewed: 2026-04-27
+---
+
 # Conflict Types: The Engine of Story
 
 Every story is built on conflict. Not necessarily violence or overt hostility, but the fundamental collision of opposing forces, desires, or values. Conflict is what makes narrative possible. Without it, there's no story—just a sequence of events.

--- a/reference/craft/dialog-craft.md
+++ b/reference/craft/dialog-craft.md
@@ -1,3 +1,10 @@
+---
+book_categories: [fiction, memoir]
+craft_topic: scene-craft
+status: stable
+last_reviewed: 2026-04-27
+---
+
 # Dialogue Craft: The Art of Meaningful Conversation
 
 A comprehensive guide to writing dialogue that reveals character, advances plot, and creates authenticity. In fiction, dialogue is not how people actually speak—it's how people speak *in story*.

--- a/reference/craft/dos-and-donts.md
+++ b/reference/craft/dos-and-donts.md
@@ -1,3 +1,10 @@
+---
+book_categories: [fiction, memoir]
+craft_topic: general
+status: stable
+last_reviewed: 2026-04-27
+---
+
 # Fiction Writing: 50 Essential Do's and Don'ts
 
 This guide distills the core principles of narrative craft into actionable rules. These aren't laws—they're tools. Each can be broken. But break them intentionally, understanding what you're sacrificing.

--- a/reference/craft/openings-and-endings.md
+++ b/reference/craft/openings-and-endings.md
@@ -1,3 +1,10 @@
+---
+book_categories: [fiction, memoir]
+craft_topic: scene-craft
+status: stable
+last_reviewed: 2026-04-27
+---
+
 # Openings and Endings: The Art of First and Last Impressions
 
 The opening and closing of a story are the two most critical passages you will ever write. Readers decide whether to continue in the first line. Readers decide whether to recommend your book to others in the last line. Everything else is just the middle.

--- a/reference/craft/pacing-guide.md
+++ b/reference/craft/pacing-guide.md
@@ -1,3 +1,10 @@
+---
+book_categories: [fiction, memoir]
+craft_topic: structure
+status: stable
+last_reviewed: 2026-04-27
+---
+
 # Pacing Guide: Controlling the Reader's Experience of Time
 
 ## Introduction

--- a/reference/craft/plot-craft.md
+++ b/reference/craft/plot-craft.md
@@ -1,3 +1,10 @@
+---
+book_categories: [fiction]
+craft_topic: structure
+status: stable
+last_reviewed: 2026-04-27
+---
+
 # Plot Craft: A Comprehensive Reference
 
 ## Introduction

--- a/reference/craft/point-of-view.md
+++ b/reference/craft/point-of-view.md
@@ -1,3 +1,10 @@
+---
+book_categories: [fiction, memoir]
+craft_topic: voice-and-truth
+status: stable
+last_reviewed: 2026-04-27
+---
+
 # Point of View: Mastering Narrative Perspective in Fiction
 
 ## Introduction: POV as a Fundamental Tool

--- a/reference/craft/prose-style.md
+++ b/reference/craft/prose-style.md
@@ -1,3 +1,10 @@
+---
+book_categories: [fiction, memoir]
+craft_topic: scene-craft
+status: stable
+last_reviewed: 2026-04-27
+---
+
 # Prose Style: The Architecture of Sentences
 
 Prose style is how you say something, distinct from what you're saying. It's the difference between "The old man was angry" and "The old man's face had gone the color of raw liver." Both convey rage, but one lands like a punch and the other lands like a statistical report. Mastering prose style means learning to control the reader's experience at the sentence level—their pace, their attention, their emotional response.

--- a/reference/craft/revision-process.md
+++ b/reference/craft/revision-process.md
@@ -1,3 +1,10 @@
+---
+book_categories: [fiction, memoir]
+craft_topic: general
+status: stable
+last_reviewed: 2026-04-27
+---
+
 # The Revision Process: From Draft to Manuscript
 
 The first draft is discovery. Revision is craft.

--- a/reference/craft/show-dont-tell.md
+++ b/reference/craft/show-dont-tell.md
@@ -1,3 +1,10 @@
+---
+book_categories: [fiction, memoir]
+craft_topic: scene-craft
+status: stable
+last_reviewed: 2026-04-27
+---
+
 # Show, Don't Tell: The Cornerstone of Vivid Fiction
 
 ## The Core Principle

--- a/reference/craft/simile-discipline.md
+++ b/reference/craft/simile-discipline.md
@@ -1,3 +1,10 @@
+---
+book_categories: [fiction, memoir]
+craft_topic: scene-craft
+status: stable
+last_reviewed: 2026-04-27
+---
+
 # Simile Discipline: When Comparisons Work and When They Don't
 
 Similes are among the most abused tools in fiction. Used well, a simile sharpens an image the reader couldn't otherwise picture, reveals character through the comparison itself, or lands a tonal beat that bare description misses. Used badly, it is decoration — pretty-sounding placeholder prose that tells the reader nothing, and worse, that trains their eye to skim.

--- a/reference/craft/story-structure.md
+++ b/reference/craft/story-structure.md
@@ -1,3 +1,10 @@
+---
+book_categories: [fiction, memoir]
+craft_topic: structure
+status: stable
+last_reviewed: 2026-04-27
+---
+
 # Story Structure: A Comprehensive Reference Guide
 
 A well-crafted story structure is the skeleton upon which all narrative flesh hangs. Whether you're writing a literary novel, a thriller, or a romance, understanding the underlying patterns of storytelling will give you both the freedom and the framework to tell compelling stories. This reference document covers the major story structures used in fiction writing, when to use each, and practical guidance for implementation.

--- a/reference/craft/tension-and-suspense.md
+++ b/reference/craft/tension-and-suspense.md
@@ -1,3 +1,10 @@
+---
+book_categories: [fiction, memoir]
+craft_topic: structure
+status: stable
+last_reviewed: 2026-04-27
+---
+
 # Tension and Suspense in Fiction
 
 A comprehensive guide to creating and maintaining tension at every level of your narrative. Tension is what keeps readers turning pages—it's the promise that something matters and something will be revealed or resolved.

--- a/reference/craft/theme-development.md
+++ b/reference/craft/theme-development.md
@@ -1,3 +1,10 @@
+---
+book_categories: [fiction, memoir]
+craft_topic: voice-and-truth
+status: stable
+last_reviewed: 2026-04-27
+---
+
 # Theme Development: The Hidden Argument
 
 Every story makes an argument. Not a preachy, explicit argument with a moral tagged on the end, but a fundamental argument about how the world works, what matters, what's worth suffering for, whether redemption is possible, whether love survives betrayal. That argument is the theme.

--- a/reference/craft/world-building.md
+++ b/reference/craft/world-building.md
@@ -1,3 +1,10 @@
+---
+book_categories: [fiction]
+craft_topic: world
+status: stable
+last_reviewed: 2026-04-27
+---
+
 # World-Building: Creating Worlds That Feel Real
 
 World-building is the craft of creating a fictional world so detailed, consistent, and alive that readers believe in it. But it's not just detail—it's the *selective* detail. The iceberg principle: show 10%, know 100%.

--- a/reference/state-schema.md
+++ b/reference/state-schema.md
@@ -19,6 +19,7 @@
       "author": "dark-narrator",
       "genres": ["horror", "supernatural"],
       "book_type": "novel",
+      "book_category": "fiction",
       "status": "Drafting",
       "language": "en",
       "target_word_count": 80000,

--- a/servers/storyforge-server/server.py
+++ b/servers/storyforge-server/server.py
@@ -20,7 +20,7 @@ if plugin_root not in sys.path:
 
 from mcp.server.fastmcp import FastMCP
 
-from tools.shared.config import load_config, get_content_root, get_genres_dir, get_reference_dir, get_review_handle
+from tools.shared.config import load_config, get_content_root, get_genres_dir, get_reference_dir, get_review_handle, get_book_categories_dir
 from tools.shared.paths import slugify, resolve_project_path, resolve_chapter_path, resolve_character_path, resolve_author_path, find_chapters, resolve_series_path, resolve_world_dir
 from tools.state.indexer import StateCache, rebuild
 from tools.state.parsers import parse_frontmatter, count_words_in_file, is_chapter_drafted, parse_chapter_readme
@@ -77,6 +77,7 @@ def list_books() -> str:
             "genres": book.get("genres", []),
             "author": book.get("author", ""),
             "book_type": book.get("book_type", "novel"),
+            "book_category": book.get("book_category", "fiction"),
             "chapter_count": book.get("chapter_count", 0),
             "total_words": book.get("total_words", 0),
         })
@@ -786,12 +787,19 @@ def update_author(slug: str, field: str, value: str) -> str:
 # ============================================================
 
 
+# Path E (#54): allowed book_category values for create_book_structure.
+# Phase 1 only ships fiction + memoir. Other non-fiction subtypes
+# (biography, how-to, academic, history) are deferred per #49 / #97.
+_ALLOWED_BOOK_CATEGORIES = ("fiction", "memoir")
+
+
 @mcp.tool()
 def create_book_structure(
     title: str,
     author: str = "",
     genres: str = "",
     book_type: str = "novel",
+    book_category: str = "fiction",
     language: str = "en",
     target_word_count: int = 80000,
 ) -> str:
@@ -801,10 +809,20 @@ def create_book_structure(
         title: Book title
         author: Author profile slug
         genres: Comma-separated genres (e.g. "horror, supernatural")
-        book_type: Type (short-story, novelette, novella, novel, epic)
+        book_type: Length class (short-story, novelette, novella, novel, epic)
+        book_category: Broad category (fiction, memoir). Default: fiction.
         language: Writing language
         target_word_count: Target word count
     """
+    if book_category not in _ALLOWED_BOOK_CATEGORIES:
+        allowed = ", ".join(_ALLOWED_BOOK_CATEGORIES)
+        return json.dumps({
+            "error": (
+                f"Invalid book_category '{book_category}'. "
+                f"Allowed values: {allowed}."
+            )
+        })
+
     config = load_config()
     slug = slugify(title)
     project_dir = resolve_project_path(config, slug)
@@ -829,6 +847,7 @@ slug: "{slug}"
 author: "{author}"
 genres: {json.dumps(genre_list)}
 book_type: "{book_type}"
+book_category: "{book_category}"
 status: "Idea"
 language: "{language}"
 target_word_count: {target_word_count}
@@ -1189,6 +1208,36 @@ def resolve_path(book_slug: str, component: str = "", sub_path: str = "") -> str
         base = base / sub_path
 
     return json.dumps({"path": str(base), "exists": base.exists()})
+
+
+@mcp.tool()
+def get_book_category_dir(category: str) -> str:
+    """Resolve the plugin-relative path to a book category's knowledge dir.
+
+    Path E (#55): skills loading category-specific knowledge (memoir craft
+    docs, status models) call this to get the canonical directory under
+    ``{plugin_root}/book_categories/{category}/``.
+
+    Args:
+        category: One of the allowed book categories (fiction, memoir).
+
+    Returns JSON with ``category``, ``path``, and ``exists`` (bool).
+    """
+    if category not in _ALLOWED_BOOK_CATEGORIES:
+        allowed = ", ".join(_ALLOWED_BOOK_CATEGORIES)
+        return json.dumps({
+            "error": (
+                f"Unknown book_category '{category}'. "
+                f"Allowed: {allowed}."
+            )
+        })
+
+    base = get_book_categories_dir() / category
+    return json.dumps({
+        "category": category,
+        "path": str(base),
+        "exists": base.exists(),
+    })
 
 
 # ============================================================

--- a/skills/configure/SKILL.md
+++ b/skills/configure/SKILL.md
@@ -38,6 +38,7 @@ user-invocable: true
 | Authors directory | `paths.authors_root` | Any valid path |
 | Default language | `defaults.language` | en, de, es, fr, etc. |
 | Default book type | `defaults.book_type` | short-story, novelette, novella, novel, epic |
+| Default book category | `defaults.book_category` | fiction, memoir |
 | Review comment handle | `defaults.review_handle` | Your name/identifier for inline draft.md annotations |
 | Export format | `export.default_format` | epub, pdf, mobi |
 | PDF engine | `export.pdf_engine` | xelatex, pdflatex, wkhtmltopdf |

--- a/templates/book.md
+++ b/templates/book.md
@@ -4,6 +4,7 @@ slug: "{{slug}}"
 author: "{{author}}"
 genres: {{genres}}
 book_type: "{{book_type}}"
+book_category: "{{book_category}}"
 status: "Idea"
 language: "{{language}}"
 target_word_count: {{target_word_count}}

--- a/tests/test_book_category.py
+++ b/tests/test_book_category.py
@@ -1,0 +1,257 @@
+"""Tests for the ``book_category`` field (Issue #54, Path E memoir support).
+
+The field distinguishes broad book categories (`fiction`, `memoir`) and gates
+category-specific knowledge under `book_categories/{category}/`. It is
+**orthogonal** to the existing ``book_type`` length classification
+(short-story/novelette/novella/novel/epic) — both fields coexist.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools.state.parsers import parse_book_readme
+
+
+# ---------------------------------------------------------------------------
+# Parser-level tests — backwards compatibility + read-through
+# ---------------------------------------------------------------------------
+
+
+class TestParseBookCategory:
+    """parse_book_readme must expose book_category with a fiction default."""
+
+    def test_missing_field_defaults_to_fiction(self, tmp_path: Path):
+        # Existing books written before #54 have no book_category — must not break.
+        book_dir = tmp_path / "legacy-book"
+        book_dir.mkdir()
+        (book_dir / "README.md").write_text(
+            '---\ntitle: "Legacy Book"\nbook_type: "novel"\n---\n# Legacy\n',
+            encoding="utf-8",
+        )
+
+        result = parse_book_readme(book_dir / "README.md")
+
+        assert result["book_category"] == "fiction", (
+            "Missing book_category must default to 'fiction' for backwards compat"
+        )
+
+    def test_explicit_fiction_reads_through(self, tmp_path: Path):
+        book_dir = tmp_path / "explicit-fiction"
+        book_dir.mkdir()
+        (book_dir / "README.md").write_text(
+            '---\ntitle: "Test"\nbook_category: "fiction"\n---\n# T\n',
+            encoding="utf-8",
+        )
+
+        result = parse_book_readme(book_dir / "README.md")
+        assert result["book_category"] == "fiction"
+
+    def test_explicit_memoir_reads_through(self, tmp_path: Path):
+        book_dir = tmp_path / "memoir-book"
+        book_dir.mkdir()
+        (book_dir / "README.md").write_text(
+            '---\ntitle: "My Memoir"\nbook_category: "memoir"\n---\n# M\n',
+            encoding="utf-8",
+        )
+
+        result = parse_book_readme(book_dir / "README.md")
+        assert result["book_category"] == "memoir"
+
+    def test_book_category_independent_of_book_type(self, tmp_path: Path):
+        # book_type = length classification; book_category = fiction/memoir.
+        # Both must coexist without interfering.
+        book_dir = tmp_path / "memoir-novella"
+        book_dir.mkdir()
+        (book_dir / "README.md").write_text(
+            '---\ntitle: "Short Memoir"\n'
+            'book_type: "novella"\n'
+            'book_category: "memoir"\n---\n# X\n',
+            encoding="utf-8",
+        )
+
+        result = parse_book_readme(book_dir / "README.md")
+        assert result["book_type"] == "novella"
+        assert result["book_category"] == "memoir"
+
+
+# ---------------------------------------------------------------------------
+# create_book_structure tool — schema + validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def content_root(tmp_path: Path) -> Path:
+    root = tmp_path / "content"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def mock_config(content_root: Path):
+    fake_config = {
+        "paths": {
+            "content_root": str(content_root),
+            "authors_root": str(content_root / "authors"),
+        },
+        "defaults": {
+            "language": "en",
+            "book_type": "novel",
+            "book_category": "fiction",
+        },
+    }
+
+    import server as server_mod  # noqa: WPS433
+    from tools.state import indexer as indexer_mod  # noqa: WPS433
+
+    # Patch both server_mod (create_book_structure path) and indexer_mod
+    # (cache rebuild path) so the cache scan sees the test content_root.
+    with patch.object(server_mod, "load_config", return_value=fake_config), \
+         patch.object(server_mod, "get_content_root", return_value=content_root), \
+         patch.object(indexer_mod, "load_config", return_value=fake_config):
+        server_mod._cache.invalidate()
+        yield fake_config
+
+
+@pytest.fixture
+def server_module(mock_config):
+    import server as server_mod  # noqa: WPS433
+    return server_mod
+
+
+def _read_book_frontmatter(content_root: Path, slug: str) -> dict:
+    import yaml
+    readme = content_root / "projects" / slug / "README.md"
+    text = readme.read_text(encoding="utf-8")
+    # naive frontmatter extraction: text between first two "---" lines
+    parts = text.split("---", 2)
+    assert len(parts) >= 3, "README must have YAML frontmatter"
+    return yaml.safe_load(parts[1]) or {}
+
+
+class TestCreateBookStructureBookCategory:
+    """create_book_structure must accept and persist book_category."""
+
+    def test_default_book_category_is_fiction(
+        self, server_module, content_root: Path
+    ):
+        # No book_category param → default "fiction" lands in README.
+        result = json.loads(
+            server_module.create_book_structure(title="Default Cat Book")
+        )
+        assert result.get("success") is True
+
+        meta = _read_book_frontmatter(content_root, "default-cat-book")
+        assert meta["book_category"] == "fiction"
+
+    def test_explicit_memoir_category_persisted(
+        self, server_module, content_root: Path
+    ):
+        result = json.loads(
+            server_module.create_book_structure(
+                title="My Memoir Project",
+                book_category="memoir",
+            )
+        )
+        assert result.get("success") is True
+
+        meta = _read_book_frontmatter(content_root, "my-memoir-project")
+        assert meta["book_category"] == "memoir"
+
+    def test_invalid_book_category_rejected(
+        self, server_module, content_root: Path
+    ):
+        # Phase 1 only supports fiction|memoir. Other non-fiction subtypes
+        # (biography, how-to, academic, history) are explicitly out of scope
+        # per #49 / #97.
+        result = json.loads(
+            server_module.create_book_structure(
+                title="Biography Attempt",
+                book_category="biography",
+            )
+        )
+        assert "error" in result
+        assert "book_category" in result["error"].lower()
+
+        # No directory must be created on rejection.
+        assert not (content_root / "projects" / "biography-attempt").exists()
+
+    def test_book_category_orthogonal_to_book_type(
+        self, server_module, content_root: Path
+    ):
+        # Memoir + novella length is a valid combo.
+        result = json.loads(
+            server_module.create_book_structure(
+                title="Short Memoir",
+                book_type="novella",
+                book_category="memoir",
+            )
+        )
+        assert result.get("success") is True
+
+        meta = _read_book_frontmatter(content_root, "short-memoir")
+        assert meta["book_type"] == "novella"
+        assert meta["book_category"] == "memoir"
+
+
+# ---------------------------------------------------------------------------
+# list_books projection — book_category surfaces in cache
+# ---------------------------------------------------------------------------
+
+
+class TestListBooksBookCategory:
+    """list_books MCP tool must expose book_category in each entry."""
+
+    def test_list_books_includes_book_category(
+        self, server_module, content_root: Path
+    ):
+        # Create one fiction, one memoir.
+        json.loads(server_module.create_book_structure(title="Fiction One"))
+        json.loads(
+            server_module.create_book_structure(
+                title="Memoir One", book_category="memoir"
+            )
+        )
+
+        # Force cache rebuild so list_books sees fresh state.
+        server_module._cache.invalidate()
+
+        result = json.loads(server_module.list_books())
+        by_slug = {b["slug"]: b for b in result["books"]}
+
+        assert by_slug["fiction-one"]["book_category"] == "fiction"
+        assert by_slug["memoir-one"]["book_category"] == "memoir"
+
+
+# ---------------------------------------------------------------------------
+# get_book_category_dir tool — Issue #55 path resolution
+# ---------------------------------------------------------------------------
+
+
+class TestGetBookCategoryDir:
+    """Skills must be able to resolve book_categories/{category}/ via MCP."""
+
+    def test_resolves_fiction_category(self, server_module):
+        result = json.loads(server_module.get_book_category_dir("fiction"))
+
+        assert result["category"] == "fiction"
+        assert result["path"].endswith("book_categories/fiction")
+        # The fiction scaffold ships with the plugin, so it must exist.
+        assert result["exists"] is True
+
+    def test_resolves_memoir_category(self, server_module):
+        result = json.loads(server_module.get_book_category_dir("memoir"))
+
+        assert result["category"] == "memoir"
+        assert result["path"].endswith("book_categories/memoir")
+        assert result["exists"] is True
+
+    def test_rejects_unknown_category(self, server_module):
+        result = json.loads(server_module.get_book_category_dir("biography"))
+
+        assert "error" in result
+        assert "biography" in result["error"]

--- a/tools/shared/config.py
+++ b/tools/shared/config.py
@@ -49,6 +49,7 @@ def _default_config() -> dict[str, Any]:
         "defaults": {
             "language": "en",
             "book_type": "novel",
+            "book_category": "fiction",
             "review_handle": "Author",
         },
         "export": {
@@ -104,6 +105,15 @@ def get_plugin_root() -> Path:
 def get_genres_dir() -> Path:
     """Return the genres directory path."""
     return get_plugin_root() / "genres"
+
+
+def get_book_categories_dir() -> Path:
+    """Return the book categories directory path (Path E, Issue #55).
+
+    Houses category-specific knowledge (e.g. memoir craft docs, status models)
+    under ``book_categories/{category}/``.
+    """
+    return get_plugin_root() / "book_categories"
 
 
 def get_reference_dir() -> Path:

--- a/tools/state/parsers.py
+++ b/tools/state/parsers.py
@@ -41,6 +41,9 @@ def parse_book_readme(path: Path) -> dict[str, Any]:
         "author": meta.get("author", ""),
         "genres": meta.get("genres", []),
         "book_type": meta.get("book_type", "novel"),
+        # Path E (#54): broad category orthogonal to book_type length class.
+        # Default "fiction" preserves backwards compat for books written pre-#54.
+        "book_category": meta.get("book_category", "fiction"),
         "status": _normalize_book_status(meta.get("status", "Idea")),
         "language": meta.get("language", "en"),
         "target_word_count": meta.get("target_word_count", 0),


### PR DESCRIPTION
## Summary

Phase 1 of [#97 (Path E — Memoir as second `book_category`)](https://github.com/markus-michalski/storyforge/issues/97). Foundation only — adds the `book_category: fiction | memoir` field, scaffolds memoir knowledge under `book_categories/`, ships 5 new memoir craft docs, annotates the existing 19 fiction craft docs, and updates CLAUDE.md.

**Skill branching by category does NOT happen yet** — that's Phase 2-4 (#57–#66). Until those land, all skills behave the same regardless of `book_category`. Phase 1 just wires the schema and the docs so later phases have something to branch on.

Closes #54, #55, #56, #67.

### Naming-history note

The original Issue #54 proposed `book_type: fiction | memoir`, but `book_type` was already taken by the length classification (`short-story | novelette | novella | novel | epic`). To avoid an in-place rename + migration, the new field is `book_category` and the on-disk knowledge directory is `book_categories/{category}/`. Issue bodies #54, #55, #56, #67 were updated to reflect the new naming **before** implementation.

### What ships in this PR

**#54 — Field & MCP plumbing**
- `book_category` in book README YAML frontmatter, default `"fiction"` for backwards compat
- Parser fallback (`tools/state/parsers.py`) returns `"fiction"` when frontmatter is missing the field — existing books work without migration
- `create_book_structure` accepts `book_category=…` with explicit allowlist validation (`_ALLOWED_BOOK_CATEGORIES = ("fiction", "memoir")`)
- `list_books` MCP projection exposes `book_category` per book
- Default config gains `defaults.book_category: "fiction"`
- Documented in `templates/book.md`, `reference/state-schema.md`, `skills/configure/SKILL.md`

**#55 — Knowledge scaffold**
- `book_categories/fiction/README.md` + `status-model.md` (short, symmetry-only — points at canonical CLAUDE.md and `reference/craft/`)
- `book_categories/memoir/README.md` + `status-model.md` (substantial — covers what memoir is, structure types, project-structure mapping, status interpretation, quality gates)
- New MCP tool `get_book_category_dir(category)` for skill path resolution

**#56 — Craft docs**
- 5 new memoir craft docs under `book_categories/memoir/craft/`:
  - `memoir-structure-types.md` — chronological / thematic / braided / vignette
  - `scene-vs-summary.md` — when to dramatize, when to reflect
  - `emotional-truth.md` — beyond facts, the felt sense
  - `real-people-ethics.md` — consent, defamation, anonymization patterns
  - `memoir-anti-ai-patterns.md` — hedging, "looking back I realize", reflective platitudes, tidy lessons
- 19 existing `reference/craft/*.md` docs annotated with `book_categories: [...]` frontmatter:
  - **Fiction-only (4):** `character-creation`, `character-arcs`, `plot-craft`, `world-building` — memoir handles these concerns through the new memoir-craft docs
  - **Both (15):** everything else — universal craft applies to either category

**#67 — CLAUDE.md routing**
- Overview mentions memoir
- New **Book Category** section with field semantics, default, and MCP-tool pointer
- New **Memoir Workflows (Phase 2+ — forthcoming)** section listing the not-yet-wired memoir-specific skills
- Project Structure section: shifted-meaning note for memoir
- Status Progressions: memoir interpretation pointer
- Craft Knowledge Base: per-skill list of memoir-mode additional/replacement docs
- New **Important Rule #20**: check `book_category` before creative work; for memoir, manually load category-specific docs (manual bridge until Phase 2+ auto-routes)

### Backwards compatibility

- Existing books **without** `book_category` in their frontmatter: parser defaults to `"fiction"`. Zero migration required.
- Existing `create_book_structure` callers without the new param: get `book_category="fiction"`. No breakage.
- Existing `book_type` (length class) field: untouched. Tests with `book_type: novel` still pass.

### Test plan

- [x] `pytest` passes (645/645 currently green; +12 new in `test_book_category.py`)
- [x] Create a fiction book via `create_book_structure(title="Test Fiction")` → README has `book_category: "fiction"`
- [x] Create a memoir via `create_book_structure(title="Test Memoir", book_category="memoir")` → README has `book_category: "memoir"`
- [x] Try `book_category="biography"` → error, no directory created
- [x] `list_books()` returns `book_category` per book
- [x] `get_book_category_dir("memoir")` returns the path with `exists: true`
- [x] An existing book without `book_category` frontmatter: `get_book_full(slug)` shows `book_category: "fiction"` without crash
- [x] Read `book_categories/memoir/README.md` and `book_categories/memoir/craft/*.md` for craft-quality review
- [x] CLAUDE.md reads coherently and the new sections don't contradict the existing fiction workflow

### Out of scope

- Skill branching by `book_category` — Phase 2 (#57–#60, #63), Phase 3 (#61, #62, #65, #66), Phase 4 (#64)
- New memoir skills `memoir-ethics-checker` (#65) and `emotional-truth-prompt` (#66) — Phase 3
- `characters/` → `people/` rename for memoir — deferred to #59
- Wiki documentation update — will land once the full epic is done (avoids three intermediate updates)
- Other non-fiction subtypes (biography, how-to, academic, history) — explicitly deferred per #49 / #97