### PR TITLE
feat: new-book + book-dashboard for book_category (#63)

### DIFF
--- a/servers/storyforge-server/server.py
+++ b/servers/storyforge-server/server.py
@@ -142,6 +142,7 @@ def get_book_progress(slug: str) -> str:
         # Indexer already derived this from chapter state (Issue #19).
         "status": book.get("status", "Idea"),
         "status_disk": book.get("status_disk", book.get("status", "Idea")),
+        "book_category": book.get("book_category", "fiction"),
         "chapters_total": total,
         "chapters_drafted": drafted,
         "chapters_final": final,
@@ -832,12 +833,17 @@ def create_book_structure(
 
     genre_list = [g.strip() for g in genres.split(",") if g.strip()] if genres else []
     today = date.today().isoformat()
+    is_memoir = book_category == "memoir"
 
-    # Create directory structure
-    for subdir in [
-        "plot", "characters", "world", "research/notes",
-        "chapters", "cover/art", "export/output", "translations",
-    ]:
+    # Create directory structure. Memoir scaffolds `people/` instead of
+    # `characters/` and skips `world/` entirely (per #63 spec) — real-life
+    # settings are documented via research, not invented.
+    common_subdirs = ["plot", "research/notes", "chapters", "cover/art", "export/output", "translations"]
+    if is_memoir:
+        subdirs = common_subdirs + ["people"]
+    else:
+        subdirs = common_subdirs + ["characters", "world"]
+    for subdir in subdirs:
         (project_dir / subdir).mkdir(parents=True, exist_ok=True)
 
     # Book README
@@ -876,21 +882,56 @@ updated: "{today}"
     (project_dir / "README.md").write_text(readme, encoding="utf-8")
     (project_dir / "synopsis.md").write_text(f"# {title} — Synopsis\n\n*To be written after plot is outlined.*\n", encoding="utf-8")
 
-    # Plot files
-    (project_dir / "plot" / "outline.md").write_text(f"# {title} — Plot Outline\n\n## Act 1: Setup\n\n## Act 2: Confrontation\n\n## Act 3: Resolution\n", encoding="utf-8")
-    (project_dir / "plot" / "acts.md").write_text(f"# {title} — Act Structure\n\n*Use /storyforge:plot-architect to develop.*\n", encoding="utf-8")
+    # Plot files. Memoir uses structure-types instead of three-act / character
+    # arcs; fiction keeps the existing scaffold.
     (project_dir / "plot" / "timeline.md").write_text(f"# {title} — Timeline\n\n*Chronological events.*\n", encoding="utf-8")
     (project_dir / "plot" / "tone.md").write_text(f"# {title} — Tonal Document\n\n*Use /storyforge:plot-architect to develop after plot outline is complete.*\n", encoding="utf-8")
-    (project_dir / "plot" / "arcs.md").write_text(f"# {title} — Character Arcs\n\n*Use /storyforge:character-creator to develop.*\n", encoding="utf-8")
+    if is_memoir:
+        (project_dir / "plot" / "outline.md").write_text(
+            f"# {title} — Narrative Arc\n\n"
+            "*The angle on the lived material — not invented events. "
+            "Use /storyforge:plot-architect (memoir mode) to develop.*\n\n"
+            "## Structure type\n\n"
+            "*Pick one: chronological / thematic / braided / vignette. "
+            "See `book_categories/memoir/craft/memoir-structure-types.md`.*\n\n"
+            "## Through-line\n\n"
+            "*The unifying question or theme that ties the chosen scenes together.*\n",
+            encoding="utf-8",
+        )
+        (project_dir / "plot" / "structure.md").write_text(
+            f"# {title} — Memoir Structure\n\n"
+            "*Selected structure type and its scaffolding (chapter spine, "
+            "thematic chapters, braid threads, or vignette index). "
+            "Use /storyforge:plot-architect (memoir mode) to develop.*\n",
+            encoding="utf-8",
+        )
+    else:
+        (project_dir / "plot" / "outline.md").write_text(f"# {title} — Plot Outline\n\n## Act 1: Setup\n\n## Act 2: Confrontation\n\n## Act 3: Resolution\n", encoding="utf-8")
+        (project_dir / "plot" / "acts.md").write_text(f"# {title} — Act Structure\n\n*Use /storyforge:plot-architect to develop.*\n", encoding="utf-8")
+        (project_dir / "plot" / "arcs.md").write_text(f"# {title} — Character Arcs\n\n*Use /storyforge:character-creator to develop.*\n", encoding="utf-8")
 
-    # Characters
-    (project_dir / "characters" / "INDEX.md").write_text(f"# {title} — Characters\n\n## Protagonists\n\n## Antagonists\n\n## Supporting\n", encoding="utf-8")
+    # Characters / People
+    if is_memoir:
+        (project_dir / "people" / "INDEX.md").write_text(
+            f"# {title} — Real People\n\n"
+            "*Real people who appear in this memoir. Track consent and "
+            "anonymization status per person. See "
+            "`book_categories/memoir/craft/real-people-ethics.md`.*\n\n"
+            "## Family\n\n"
+            "## Friends & relationships\n\n"
+            "## Public figures\n\n"
+            "## Pseudonymized / composite\n",
+            encoding="utf-8",
+        )
+    else:
+        (project_dir / "characters" / "INDEX.md").write_text(f"# {title} — Characters\n\n## Protagonists\n\n## Antagonists\n\n## Supporting\n", encoding="utf-8")
 
-    # World
-    (project_dir / "world" / "setting.md").write_text(f"# {title} — Setting\n\n*Where and when does the story take place?*\n", encoding="utf-8")
-    (project_dir / "world" / "rules.md").write_text(f"# {title} — Rules\n\n*Magic system, physics, society rules.*\n", encoding="utf-8")
-    (project_dir / "world" / "history.md").write_text(f"# {title} — History\n\n*Background history of the world.*\n", encoding="utf-8")
-    (project_dir / "world" / "glossary.md").write_text(f"# {title} — Glossary\n\n*Terms, places, concepts.*\n", encoding="utf-8")
+    # World — fiction only. Memoir documents real settings via research.
+    if not is_memoir:
+        (project_dir / "world" / "setting.md").write_text(f"# {title} — Setting\n\n*Where and when does the story take place?*\n", encoding="utf-8")
+        (project_dir / "world" / "rules.md").write_text(f"# {title} — Rules\n\n*Magic system, physics, society rules.*\n", encoding="utf-8")
+        (project_dir / "world" / "history.md").write_text(f"# {title} — History\n\n*Background history of the world.*\n", encoding="utf-8")
+        (project_dir / "world" / "glossary.md").write_text(f"# {title} — Glossary\n\n*Terms, places, concepts.*\n", encoding="utf-8")
 
     # Research
     (project_dir / "research" / "sources.md").write_text(f"# {title} — Sources\n\n*Research materials and references.*\n", encoding="utf-8")

--- a/skills/book-dashboard/SKILL.md
+++ b/skills/book-dashboard/SKILL.md
@@ -14,14 +14,15 @@ argument-hint: "[book-slug]"
 
 ### If book slug provided (or active book in session):
 
-1. **Load book progress** — MCP `get_book_progress()`
-2. **Load book full** — MCP `get_book_full()` for characters and details
+1. **Load book progress** — MCP `get_book_progress()` (carries `book_category`)
+2. **Load book full** — MCP `get_book_full()` for characters/people and details
 3. **Display detailed dashboard:**
 
 ```
 === [Book Title] ===
 Status: [status]
-Author: [author] | Genres: [genres] | Type: [book_type]
+Category: [book_category]   ← fiction or memoir
+Author: [author] | Genres: [genres] | Length: [book_type]
 
 Words: [current]/[target] [████████░░░░] [%]%
 
@@ -32,7 +33,7 @@ Chapters ([final]/[total] final):
 | 2  | Into the Dark  | Draft    | 2,800 |
 | 3  | —              | Outline  | 0     |
 
-Characters ([count]):
+Characters ([count]):  ← header reads "Real People" when book_category == "memoir"
 | Name      | Role        | Status      |
 |-----------|-------------|-------------|
 | Alex      | Protagonist | Arc Defined |
@@ -41,9 +42,15 @@ Characters ([count]):
 Next: /storyforge:chapter-writer [slug] 2
 ```
 
+Memoir-aware adjustments:
+
+- Header says **Length:** instead of **Type:** so `book_type` (length class) and `book_category` are not confused.
+- Characters table header reads **Real People** for memoir (Phase 2 #59 will move the underlying data to `people/`; until then the indexer still scans `characters/` for both categories).
+- Suggest the matching memoir-mode next-step skill once Phase 2 lands; for now mirror the fiction routing.
+
 ### If no specific book:
 
-1. **List all books** — MCP `list_books()`
+1. **List all books** — MCP `list_books()` (each entry carries `book_category`)
 2. **List all authors** — MCP `list_authors()`
 3. **Show overview:**
 
@@ -51,10 +58,11 @@ Next: /storyforge:chapter-writer [slug] 2
 === StoryForge Dashboard ===
 
 Books ([count]):
-| Title          | Status   | Words  | Chapters |
-|----------------|----------|--------|----------|
-| My Horror Novel| Drafting | 24,000 | 8/25     |
-| Short Story    | Concept  | 0      | 0/1      |
+| Title          | Category | Status   | Words  | Chapters |
+|----------------|----------|----------|--------|----------|
+| My Horror Novel| fiction  | Drafting | 24,000 | 8/25     |
+| Year of Glass  | memoir   | Concept  | 0      | 0/12     |
+| Short Story    | fiction  | Concept  | 0      | 0/1      |
 
 Authors ([count]):
 | Name           | Genres          | Studied |
@@ -63,3 +71,5 @@ Authors ([count]):
 
 Ideas: [count] in backlog
 ```
+
+When the user passes `--category fiction` or `--category memoir`, filter the books table to that category before rendering. With no flag, show all and group by category if there are entries in both.

--- a/skills/new-book/SKILL.md
+++ b/skills/new-book/SKILL.md
@@ -22,8 +22,9 @@ argument-hint: "[title]"
 ### Standard flow
 1. **Gather information** — Ask the user (use AskUserQuestion):
    - **Title** — What's the working title?
-   - **Genre(s)** — Show available genres via MCP `list_genres()`. Allow 1-3 selections. Mention genre-mixing.
-   - **Book type** — short-story, novelette, novella, novel, epic
+   - **Book category** — `fiction` (default) or `memoir`. Memoir branches scaffold and several skills (Path E #97). Skip the question only when the user has already stated the category in their request.
+   - **Genre(s)** — Show available genres via MCP `list_genres()`. Allow 1-3 selections. Mention genre-mixing. For memoir, frame genres as **thematic tags** (memoir-of-illness, memoir-of-place, etc.) — memoir does not use plot-genre conventions.
+   - **Book type** — short-story, novelette, novella, novel, epic. Length is independent of category — a "memoir novella" is valid.
    - **Author profile** — Show available authors via MCP `list_authors()`. If none exist, suggest `/storyforge:create-author` first.
    - **Language** — Default: English
    - **Target word count** — Suggest based on book type:
@@ -50,7 +51,7 @@ argument-hint: "[title]"
    - `plantser` → suggest `/storyforge:plot-architect` (user will choose minimal outline or Snowflake there)
    - `discovery` → suggest `/storyforge:rolling-planner` instead of `plot-architect`
 
-3. **Create project** — Use MCP `create_book_structure()` with collected info
+3. **Create project** — Use MCP `create_book_structure()` with collected info. ALWAYS pass `book_category` explicitly (fiction or memoir) — the server branches the scaffold on this field (memoir uses `people/` instead of `characters/` and skips `world/`).
 
 4. **Create CLAUDE.md** — Use MCP `init_book_claudemd(book_slug, book_title, pov, tense, genre, writing_mode)` to scaffold the per-book context file. Ask the user for `writing_mode` if not obvious: `scene-by-scene` (default), `chapter`, or `book`. Note: this `writing_mode` controls how Claude composes chapters — it is different from `author_writing_mode` which controls the planning workflow.
 
@@ -58,13 +59,22 @@ argument-hint: "[title]"
 
 6. **Load genre README(s)** — Use MCP `get_genre()` for each selected genre. Show key conventions to the user.
 
-7. **Suggest next steps** — Based on effective `author_writing_mode`:
+7. **Suggest next steps** — Based on `book_category` and effective `author_writing_mode`:
+
+   **Fiction:**
    - **Outliner:** "Start with `/storyforge:book-conceptualizer` → then `/storyforge:plot-architect` for the full outline"
    - **Plantser:** "Start with `/storyforge:book-conceptualizer` → then `/storyforge:plot-architect` (choose minimal outline or Snowflake)"
    - **Discovery:** "Start with `/storyforge:book-conceptualizer` (concept only, no plot) → then `/storyforge:rolling-planner` before each writing session"
 
+   **Memoir:**
+   - Mention that memoir-aware skills land in Phase 2+ (#97). Until then, manually load `book_categories/memoir/README.md` and the relevant `craft/*.md` docs at the start of each creative skill.
+   - **Outliner:** "Start with `/storyforge:book-conceptualizer` → then `/storyforge:plot-architect` to pick a structure type (chronological / thematic / braided / vignette)"
+   - **Plantser:** "Start with `/storyforge:book-conceptualizer` → then `/storyforge:plot-architect` for a chapter spine matching your structure type"
+   - **Discovery:** "Start with `/storyforge:book-conceptualizer` (concept only) → then `/storyforge:rolling-planner` before each writing session. Skip `plot-architect`."
+
 ## Rules
 - ALWAYS create the author profile BEFORE the book if none exists
 - NEVER skip genre selection — it drives the entire writing process
+- ALWAYS pass `book_category` explicitly to `create_book_structure()` — never rely on the default for memoir
 - If the user provides a title as argument, use it directly
 - Lazy migration in step 2a is idempotent — only ask if `author_writing_mode` is truly missing/empty

--- a/tests/test_book_category.py
+++ b/tests/test_book_category.py
@@ -228,6 +228,179 @@ class TestListBooksBookCategory:
 
 
 # ---------------------------------------------------------------------------
+# Scaffold layout — Issue #63 (Phase 2): fiction vs. memoir directory tree
+# ---------------------------------------------------------------------------
+
+
+class TestScaffoldFictionLayout:
+    """Fiction scaffold preserves the historical layout (regression guard)."""
+
+    def test_fiction_creates_characters_and_world(
+        self, server_module, content_root: Path
+    ):
+        result = json.loads(
+            server_module.create_book_structure(title="Fiction Layout")
+        )
+        assert result.get("success") is True
+
+        project = content_root / "projects" / "fiction-layout"
+        assert (project / "characters").is_dir()
+        assert (project / "characters" / "INDEX.md").is_file()
+        assert (project / "world").is_dir()
+        assert (project / "world" / "setting.md").is_file()
+        assert (project / "world" / "rules.md").is_file()
+        assert (project / "world" / "history.md").is_file()
+        assert (project / "world" / "glossary.md").is_file()
+        assert not (project / "people").exists()
+
+    def test_fiction_plot_files_are_three_act(
+        self, server_module, content_root: Path
+    ):
+        json.loads(server_module.create_book_structure(title="Fiction Plot"))
+
+        outline = (content_root / "projects" / "fiction-plot" / "plot" / "outline.md").read_text(
+            encoding="utf-8"
+        )
+        assert "Act 1: Setup" in outline
+        assert "Act 2: Confrontation" in outline
+        assert "Act 3: Resolution" in outline
+
+        # Fiction keeps acts.md and arcs.md
+        plot_dir = content_root / "projects" / "fiction-plot" / "plot"
+        assert (plot_dir / "acts.md").is_file()
+        assert (plot_dir / "arcs.md").is_file()
+        assert not (plot_dir / "structure.md").exists()
+
+
+class TestScaffoldMemoirLayout:
+    """Memoir scaffold swaps characters→people, drops world/, drops plot/arcs."""
+
+    def test_memoir_creates_people_not_characters(
+        self, server_module, content_root: Path
+    ):
+        result = json.loads(
+            server_module.create_book_structure(
+                title="Memoir Layout", book_category="memoir"
+            )
+        )
+        assert result.get("success") is True
+
+        project = content_root / "projects" / "memoir-layout"
+        assert (project / "people").is_dir()
+        assert (project / "people" / "INDEX.md").is_file()
+        # No fiction-shaped characters/ scaffolded for memoir.
+        assert not (project / "characters").exists()
+
+    def test_memoir_skips_world_directory(
+        self, server_module, content_root: Path
+    ):
+        # Memoir documents real settings via research, not invented worlds.
+        json.loads(
+            server_module.create_book_structure(
+                title="No World Memoir", book_category="memoir"
+            )
+        )
+
+        project = content_root / "projects" / "no-world-memoir"
+        assert not (project / "world").exists(), (
+            "Memoir scaffold must skip world/ entirely (#63 spec)"
+        )
+
+    def test_memoir_people_index_mentions_consent(
+        self, server_module, content_root: Path
+    ):
+        # The INDEX must hint at memoir-specific concerns
+        # (consent, anonymization) so users know real-people ethics applies.
+        json.loads(
+            server_module.create_book_structure(
+                title="Consent Memoir", book_category="memoir"
+            )
+        )
+
+        index = (content_root / "projects" / "consent-memoir" / "people" / "INDEX.md").read_text(
+            encoding="utf-8"
+        )
+        assert "consent" in index.lower() or "anonymization" in index.lower()
+        # Sections should be people-shaped, not character-shaped.
+        assert "Protagonists" not in index
+        assert "Antagonists" not in index
+
+    def test_memoir_plot_uses_structure_types_not_acts(
+        self, server_module, content_root: Path
+    ):
+        # Memoir's outline.md must point at structure types
+        # (chronological/thematic/braided/vignette), not three-act structure.
+        json.loads(
+            server_module.create_book_structure(
+                title="Structure Memoir", book_category="memoir"
+            )
+        )
+
+        plot_dir = content_root / "projects" / "structure-memoir" / "plot"
+        outline = (plot_dir / "outline.md").read_text(encoding="utf-8")
+
+        assert "Act 1" not in outline
+        assert "structure type" in outline.lower() or "chronological" in outline.lower()
+
+        # Memoir adds structure.md, drops arcs.md (no character arcs in memoir)
+        # and acts.md (no three-act).
+        assert (plot_dir / "structure.md").is_file()
+        assert not (plot_dir / "arcs.md").exists()
+        assert not (plot_dir / "acts.md").exists()
+
+    def test_memoir_keeps_shared_dirs(
+        self, server_module, content_root: Path
+    ):
+        # Shared infrastructure (chapters/, research/, cover/, export/, plot/timeline+tone)
+        # must remain identical across categories.
+        json.loads(
+            server_module.create_book_structure(
+                title="Shared Dirs Memoir", book_category="memoir"
+            )
+        )
+
+        project = content_root / "projects" / "shared-dirs-memoir"
+        assert (project / "chapters").is_dir()
+        assert (project / "research" / "notes").is_dir()
+        assert (project / "cover" / "art").is_dir()
+        assert (project / "export" / "output").is_dir()
+        assert (project / "translations").is_dir()
+        assert (project / "plot" / "timeline.md").is_file()
+        assert (project / "plot" / "tone.md").is_file()
+
+
+# ---------------------------------------------------------------------------
+# get_book_progress — surface book_category for the dashboard
+# ---------------------------------------------------------------------------
+
+
+class TestGetBookProgressBookCategory:
+    """get_book_progress must expose book_category so book-dashboard can render it."""
+
+    def test_progress_includes_book_category_for_fiction(
+        self, server_module, content_root: Path
+    ):
+        json.loads(server_module.create_book_structure(title="Progress Fiction"))
+        server_module._cache.invalidate()
+
+        result = json.loads(server_module.get_book_progress("progress-fiction"))
+        assert result["book_category"] == "fiction"
+
+    def test_progress_includes_book_category_for_memoir(
+        self, server_module, content_root: Path
+    ):
+        json.loads(
+            server_module.create_book_structure(
+                title="Progress Memoir", book_category="memoir"
+            )
+        )
+        server_module._cache.invalidate()
+
+        result = json.loads(server_module.get_book_progress("progress-memoir"))
+        assert result["book_category"] == "memoir"
+
+
+# ---------------------------------------------------------------------------
 # get_book_category_dir tool — Issue #55 path resolution
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Phase 2 of the Memoir support epic (#97). Wires `book_category` through the user-facing entry points:

- **new-book** asks for `fiction | memoir` up front and passes it explicitly to `create_book_structure`
- **book-dashboard** surfaces `Category:` and `Length:` as distinct fields, re-labels the people table for memoir
- **create_book_structure** branches the scaffold tree per category:
  - Memoir: `people/` (not `characters/`), no `world/`, `plot/structure.md` + memoir-shaped `outline.md`
  - Fiction: unchanged (regression-guarded by tests)
- **get_book_progress** now carries `book_category` so the dashboard skill does not need a second call to `get_book_full`

Closes #63.

## Acceptance from #63

- [x] new-book asks for `book_category`
- [x] Correct scaffold per category (memoir: `people/`, no `world/`)
- [x] Dashboard surfaces category
- [x] Tests for both categories

## Test plan

- [x] `/storyforge:new-book` for a fiction book — expect `characters/`, `world/`, three-act `outline.md`
- [x] `/storyforge:new-book` for a memoir book — expect `people/`, no `world/`, structure-types `outline.md`, `plot/structure.md`
- [ ] `/storyforge:book-dashboard` for both books — expect `Category:` and `Length:` lines distinct, memoir lists "Real People"
- [x] `/storyforge:book-dashboard` (no slug) — expect `Category` column in the books table
- [x] Existing fiction project (Blood & Binary) still renders correctly — no regression

## Caveat

`people/` is scaffolded but downstream tools (indexer, continuity, tactical_checker) still read `characters/` only. Issue **#59** owns the people/ alias / persistence-path work. Memoir person files written before #59 lands won't appear in `get_book_full().characters` — that's expected and tracked.

## Quality gates

- pytest: 654 passed (8 new in `test_book_category.py`)
- ruff: clean