### PR TITLE
feat: real-people-handler for memoir character-creator (#59)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,12 +137,12 @@ Memoir-aware skills already wired:
 - `/storyforge:new-book` — scaffolds memoir-shaped tree (`people/` instead of `characters/`, no `world/`, structure-types outline) when `book_category: memoir` is selected (Issue #63)
 - `/storyforge:book-dashboard` — surfaces `Category` and `Length` separately, re-labels people table for memoir (Issue #63)
 - `/storyforge:book-conceptualizer` (memoir mode) — runs the 5-phase concept with Phase 3 *Scope* (time window / cast / deliberate exclusions) instead of Phase 3 *Conflict*, memoir-blurb conventions in Phase 5 (Issue #60)
+- `/storyforge:character-creator` (memoir mode) — real-people handler that captures relationship, person_category (4-category model), consent_status, and anonymization decisions; writes to `people/{slug}.md` via `create_person` MCP tool (Issue #59)
 
 The forthcoming memoir-specific routing (not yet wired):
 
 - `/storyforge:memoir-ethics-checker` — consent/defamation/anonymization scan (Issue #65)
 - `/storyforge:emotional-truth-prompt` — render-the-felt-sense pass (Issue #66)
-- `/storyforge:character-creator` (memoir mode) — real-people handler with consent tracking (Issue #59)
 - `/storyforge:plot-architect` (memoir mode) — narrative-arc shaping with structure-type selection (Issue #58)
 - `/storyforge:chapter-writer` (memoir mode) — loads memoir craft, scene-vs-summary discipline (Issue #57)
 
@@ -168,7 +168,13 @@ Books live at `{content_root}/projects/{slug}/`:
 └── translations/       # {lang}/ with glossary.md + chapters/
 ```
 
-For `book_category: memoir` projects, the same paths carry **shifted meaning** (characters/ = real people; plot/outline.md = narrative arc shaped from truth, not invented; world/setting.md = real places + eras). See `book_categories/memoir/README.md` for the full mapping. The on-disk layout itself is unchanged in Phase 1 — Phase 2 (#59) may introduce a `people/` alias for memoir; until then `characters/` works for both categories.
+For `book_category: memoir` projects, the layout differs at scaffold time (#63 / #59):
+
+- `people/` replaces `characters/` — real-person profiles with `person_category`, `consent_status`, `anonymization`, `real_name` fields. Created via MCP `create_person()`.
+- `world/` is omitted — real settings live in `research/sources.md` and the chapters' own setting prose.
+- `plot/` ships `structure.md` instead of `acts.md` + `arcs.md`.
+
+The indexer projects `book["people"]` for memoir books and `book["characters"]` for fiction; both keys exist on every book so consumers can ask without a category check (the irrelevant key is `{}`). Legacy memoir books that pre-date #59 fall back to `characters/` automatically — `resolve_people_dir` in `tools/shared/paths.py` handles the lookup.
 
 ## Status Progressions
 
@@ -244,7 +250,7 @@ Skills MUST load relevant craft references before generating creative content. U
 - `chapter-writer` → loads: chapter-construction, dialog-craft, show-dont-tell, pacing-guide, anti-ai-patterns, prose-style, simile-discipline + genre craft (memoir mode adds: `book_categories/memoir/craft/scene-vs-summary.md`, `emotional-truth.md`, `memoir-anti-ai-patterns.md`)
 - `chapter-reviewer` → loads: dos-and-donts, anti-ai-patterns, chapter-construction, dialog-craft, show-dont-tell, simile-discipline (memoir mode adds: `book_categories/memoir/craft/memoir-anti-ai-patterns.md`)
 - `plot-architect` → loads: story-structure, plot-craft, tension-and-suspense (memoir mode loads `book_categories/memoir/craft/memoir-structure-types.md` instead of `plot-craft.md`)
-- `character-creator` → loads: character-creation, character-arcs (memoir mode loads `book_categories/memoir/craft/real-people-ethics.md` instead — Phase 2 #59 splits this into a dedicated `real-people-handler` skill)
+- `character-creator` → fiction loads: character-creation, character-arcs, dialog-craft + genre. Memoir branches to a 6-step real-people handler (#59) that loads `book_categories/memoir/craft/real-people-ethics.md`, `emotional-truth.md`, `memoir-anti-ai-patterns.md`; writes to `people/{slug}.md` via `create_person` MCP tool with the four-category ethics schema.
 - `world-builder` → loads: world-building (memoir typically skips this skill — real settings are documented in `world/setting.md` via research, not invention)
 - `voice-checker` → loads: anti-ai-patterns, prose-style, dos-and-donts (memoir mode adds: `book_categories/memoir/craft/memoir-anti-ai-patterns.md`)
 - `manuscript-checker` → memoir mode adds memoir-specific patterns (Phase 3 #61)

--- a/servers/storyforge-server/server.py
+++ b/servers/storyforge-server/server.py
@@ -21,9 +21,20 @@ if plugin_root not in sys.path:
 from mcp.server.fastmcp import FastMCP
 
 from tools.shared.config import load_config, get_content_root, get_genres_dir, get_reference_dir, get_review_handle, get_book_categories_dir
-from tools.shared.paths import slugify, resolve_project_path, resolve_chapter_path, resolve_character_path, resolve_author_path, find_chapters, resolve_series_path, resolve_world_dir
+from tools.shared.paths import slugify, resolve_project_path, resolve_chapter_path, resolve_character_path, resolve_author_path, find_chapters, resolve_series_path, resolve_world_dir, resolve_person_path
 from tools.state.indexer import StateCache, rebuild
-from tools.state.parsers import parse_frontmatter, count_words_in_file, is_chapter_drafted, parse_chapter_readme
+from tools.state.parsers import (
+    parse_frontmatter,
+    count_words_in_file,
+    is_chapter_drafted,
+    parse_chapter_readme,
+    is_valid_person_category,
+    is_valid_consent_status,
+    is_valid_anonymization,
+    _ALLOWED_PERSON_CATEGORIES,
+    _ALLOWED_CONSENT_STATUSES,
+    _ALLOWED_ANONYMIZATION_LEVELS,
+)
 from tools.analysis.callback_validator import verify_callbacks as _verify_callbacks_impl
 from tools.analysis.manuscript_checker import scan_repetitions, render_report
 from tools.analysis.timeline_validator import validate_timeline
@@ -1018,7 +1029,10 @@ word_count_target: 3000
 
 @mcp.tool()
 def create_character(book_slug: str, name: str, role: str = "supporting", description: str = "") -> str:
-    """Create a new character file in a book project.
+    """Create a new character file in a book project (fiction mode).
+
+    For memoir books (`book_category: memoir`), use `create_person` instead —
+    the schema is different (no role/arc, instead relationship/consent_status).
 
     Args:
         book_slug: Book project slug
@@ -1091,6 +1105,154 @@ description: "{description}"
         "slug": slug,
         "path": str(char_path),
         "message": f"Character '{name}' created",
+    })
+
+
+@mcp.tool()
+def create_person(
+    book_slug: str,
+    name: str,
+    relationship: str,
+    person_category: str,
+    consent_status: str = "pending",
+    anonymization: str = "none",
+    real_name: str = "",
+    description: str = "",
+) -> str:
+    """Create a real-person profile in a memoir book project (Path E #59).
+
+    Memoir-mode counterpart to ``create_character``. Writes to
+    ``people/{slug}.md`` with the four-category ethics schema documented
+    in ``book_categories/memoir/craft/real-people-ethics.md``.
+
+    Args:
+        book_slug: Book project slug. The book must exist and carry
+            ``book_category: memoir`` — fiction books reject this call.
+        name: How the person appears in the manuscript (real or pseudonym).
+        relationship: Free-text relationship to the memoirist
+            (e.g. "sister", "former boss", "third-grade teacher").
+        person_category: One of the four ethics categories — public-figure,
+            private-living-person, deceased, anonymized-or-composite.
+        consent_status: One of confirmed-consent, pending, not-required,
+            refused, not-asking. Defaults to ``pending``.
+        anonymization: One of none, partial, pseudonym, composite.
+            Defaults to ``none``.
+        real_name: Real name when ``anonymization != "none"``. Stored in
+            frontmatter so the memoirist retains the mapping; never
+            rendered into prose by downstream skills.
+        description: Brief description / notes.
+    """
+    # Required field — memoir person profiles without a relationship are
+    # ambiguous (is this the protagonist? a stranger? a public figure?).
+    if not relationship.strip():
+        return json.dumps({
+            "error": "relationship is required for memoir person profiles"
+        })
+
+    if not is_valid_person_category(person_category):
+        allowed = ", ".join(_ALLOWED_PERSON_CATEGORIES)
+        return json.dumps({
+            "error": (
+                f"Invalid person_category '{person_category}'. "
+                f"Allowed values: {allowed}."
+            )
+        })
+
+    if not is_valid_consent_status(consent_status):
+        allowed = ", ".join(_ALLOWED_CONSENT_STATUSES)
+        return json.dumps({
+            "error": (
+                f"Invalid consent_status '{consent_status}'. "
+                f"Allowed values: {allowed}."
+            )
+        })
+
+    if not is_valid_anonymization(anonymization):
+        allowed = ", ".join(_ALLOWED_ANONYMIZATION_LEVELS)
+        return json.dumps({
+            "error": (
+                f"Invalid anonymization '{anonymization}'. "
+                f"Allowed values: {allowed}."
+            )
+        })
+
+    # Verify book exists and is memoir. Reading from cache; if the book
+    # was just created this session, fall back to disk lookup so the
+    # cache miss does not produce a misleading "not found".
+    state = _cache.get()
+    book = state.get("books", {}).get(book_slug)
+    if not book:
+        # Cache may be stale for a freshly scaffolded book; rebuild once.
+        _cache.invalidate()
+        state = _cache.get()
+        book = state.get("books", {}).get(book_slug)
+    if not book:
+        return json.dumps({"error": f"Book '{book_slug}' not found"})
+    if book.get("book_category") != "memoir":
+        return json.dumps({
+            "error": (
+                f"Book '{book_slug}' is not a memoir "
+                f"(book_category: {book.get('book_category', 'fiction')}). "
+                "Use create_character for fiction books."
+            )
+        })
+
+    config = load_config()
+    slug = slugify(name)
+    person_path = resolve_person_path(config, book_slug, slug, "memoir")
+
+    if person_path.exists():
+        return json.dumps({"error": f"Person '{slug}' already exists"})
+
+    person_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # YAML frontmatter quoting: pass user-supplied strings through json.dumps
+    # so embedded quotes do not break the block.
+    person_file = f"""---
+name: {json.dumps(name)}
+relationship: {json.dumps(relationship)}
+person_category: "{person_category}"
+consent_status: "{consent_status}"
+anonymization: "{anonymization}"
+real_name: {json.dumps(real_name)}
+status: "Concept"
+description: {json.dumps(description)}
+---
+
+# {name}
+
+## Relationship
+
+*{relationship}*
+
+## Why this person is in the memoir
+
+*What role do they play in the story you are telling? What would the memoir lose without them on the page?*
+
+## Consent and ethics notes
+
+- **Category:** {person_category}
+- **Consent status:** {consent_status}
+- **Anonymization:** {anonymization}
+
+*If consent is `pending` or `not-asking`, document the reasoning here. If `refused`, note the path forward (cut / anonymize / re-frame). See `book_categories/memoir/craft/real-people-ethics.md`.*
+
+## Memory anchors
+
+*Specific scenes, conversations, gestures, or sensory details that fix this person on the page. Avoid reflective summary — anchor in moments.*
+
+## Notes for the memoirist
+
+*Private notes — never rendered into the manuscript. Background on real-life context, what you know vs. remember vs. infer, ethical questions still open.*
+"""
+    person_path.write_text(person_file, encoding="utf-8")
+
+    _cache.invalidate()
+    return json.dumps({
+        "success": True,
+        "slug": slug,
+        "path": str(person_path),
+        "message": f"Person '{name}' created",
     })
 
 

--- a/skills/character-creator/SKILL.md
+++ b/skills/character-creator/SKILL.md
@@ -1,18 +1,32 @@
 ---
 name: character-creator
 description: |
-  Develop deep, three-dimensional characters with arcs, voice, and motivation.
-  Use when: (1) User says "Charakter", "character", "Figur",
-  (2) After plot is outlined, to populate the story.
+  Fiction: develop deep, three-dimensional characters with arcs, voice, motivation.
+  Memoir: capture real people with relationship, consent status, and anonymization decisions.
+  Use when: (1) User says "Charakter", "character", "Figur", "Person", "real people",
+  (2) After plot/structure is outlined, to populate the story.
 model: claude-opus-4-7
 user-invocable: true
-argument-hint: "<book-slug> [character-name]"
+argument-hint: "<book-slug> [name]"
 ---
 
 # Character Creator
 
+This skill branches on `book_category` (Path E #97 Phase 2 #59). Fiction runs the historical 14-step character workflow producing files at `characters/{slug}.md`. Memoir runs the **real-people handler** flow producing files at `people/{slug}.md` with the four-category ethics schema from `book_categories/memoir/craft/real-people-ethics.md`.
+
+## Step 0 — Resolve book category
+
+Before any other prerequisite load:
+
+1. **Load book data** via MCP `get_book_full(slug)`.
+2. Read `book_category` from the result. Treat missing as `fiction`.
+3. Branch the entire workflow on `book_category`. **Never** mix the two flows — a memoir book gets the people handler, period.
+
+If `book_category == "memoir"`, surface a one-line note: *"Working in memoir mode — capturing a real person, not inventing a character. The questions and the saved schema are different."*
+
 ## Prerequisites — MANDATORY LOADS
-- **Book data** via MCP `get_book_full()`. **Why:** Existing characters, plot, theme — the new character must fit the ensemble and serve the theme.
+
+### Fiction mode (`book_category == "fiction"`)
 - **Craft references** via MCP `get_craft_reference()`:
   - `character-creation` — **Why:** GMC, archetypes, wants vs. needs, flaws, motivation chains — the depth-test framework Step 5 enforces.
   - `character-arcs` — **Why:** Positive/negative/flat arc patterns — Step 12 maps the character to one of them.
@@ -20,7 +34,15 @@ argument-hint: "<book-slug> [character-name]"
 - **Genre README(s)** for genre-specific character expectations. **Why:** Romance protagonists ≠ horror protagonists ≠ literary protagonists — genre dictates expected archetypes and arc patterns.
 - Read `{project}/plot/outline.md` and `{project}/plot/arcs.md` for story context.
 
-## Workflow
+### Memoir mode (`book_category == "memoir"`)
+- **Memoir craft** from `book_categories/memoir/craft/` (resolve via MCP `get_book_category_dir("memoir")`):
+  - `real-people-ethics.md` — **Why:** the four-category model and the consent decisions are the schema this skill writes. Read this before asking the user anything.
+  - `emotional-truth.md` — **Why:** keeps the "Memory anchors" prompt grounded in specific moments rather than reflective summary.
+  - `memoir-anti-ai-patterns.md` — **Why:** prevents the description from drifting into "looking back I realize" platitudes.
+- Read `{project}/plot/outline.md` and `{project}/plot/structure.md` for which people the chosen narrative arc actually needs on the page.
+- Read `{project}/README.md` `## Scope` section (created by `book-conceptualizer` in memoir mode, #60). **Why:** Phase 3 of the conceptualizer already identified the structural cast and consent posture per person — this skill operationalizes those decisions, not re-decides them.
+
+## Workflow — Fiction (14 steps)
 
 ### Step 1: Character Role
 Ask the user:
@@ -143,7 +165,92 @@ Update `{project}/characters/INDEX.md` with the new character.
 
 After all major characters are created, update book status to "Characters Created".
 
+## Workflow — Memoir (real-people handler)
+
+The fiction workflow does not apply. Real people are not invented; they are **captured** with care for relationship, consent, and ethics. Skip GMC, want/need, fatal flaw, ghost, and arc — those concepts belong to invented characters. The memoir-mode flow has six steps and produces a people file with the schema from `real-people-ethics.md`.
+
+### Step M1: Identification
+
+Ask the user (use AskUserQuestion when the answers branch downstream choices):
+
+- **Name on the page**: How does this person appear in the manuscript? (Their real name, or a pseudonym?)
+- **Real name**: If a pseudonym, what is the real name? (Stored privately in frontmatter; never rendered into prose.)
+- **Relationship to the memoirist**: Free-text. *"My sister. My third-grade teacher. The neighbor who watched me on Saturdays. The doctor who gave me the diagnosis."* Specificity here drives every other decision.
+
+### Step M2: Person category
+
+Reference `real-people-ethics.md` four-category model. Pick one:
+
+| Category | Defines |
+|----------|---------|
+| `public-figure` | Politician, celebrity, named author of a public work — public conduct is fair game; private life is not |
+| `private-living-person` | Anyone not a public figure — highest legal exposure (defamation + privacy) |
+| `deceased` | Person no longer living — defamation typically does not survive death |
+| `anonymized-or-composite` | Identity actively obscured or merged across multiple real people |
+
+If the user is unsure between `private-living-person` and `anonymized-or-composite`, that is itself a flag — push them to commit before continuing. A person whose category is undecided cannot be ethically rendered.
+
+### Step M3: Consent decision
+
+Pick one of five consent statuses:
+
+| Status | When to choose |
+|--------|----------------|
+| `confirmed-consent` | You have asked and they have said yes — ideally in writing for sensitive portrayals |
+| `pending` | You intend to ask before publication; not yet asked |
+| `not-required` | Public figure on public conduct, deceased, or fully anonymized in a way that even people who know them well could not identify |
+| `refused` | You asked, they said no — see `real-people-ethics.md` "When consent is refused" |
+| `not-asking` | Deliberate choice not to ask (estranged, abuser, ongoing harm) — document the reasoning |
+
+If `refused` or `not-asking`, ask the user the follow-up: *"What is the path forward — cut, anonymize, or re-frame?"* Capture the answer in the people file's "Consent and ethics notes" section.
+
+### Step M4: Anonymization decision
+
+Pick one:
+
+| Level | Meaning |
+|-------|---------|
+| `none` | The person appears as themselves under their real name |
+| `partial` | Name changed; some identifying details preserved (occupation, location, age range) |
+| `pseudonym` | Name changed plus 2–3 identifying details changed; person not identifiable to people who know them well |
+| `composite` | This entry merges two or more real people into one; disclose in author's note |
+
+If anonymization is not `none`, surface the test from `real-people-ethics.md`: *would someone who knew the real person still identify them from the rendered details?* If yes, the anonymization is too thin — push the user to change another identifier or move to `composite`.
+
+### Step M5: Memory anchors
+
+The memoir-specific replacement for fiction's Voice + Quirks + Human Texture. Ask:
+
+- *"What is one specific moment with this person you remember in detail — sensory, gestural, dialogue-fragments-level detail?"*
+- *"What is something about how they spoke, moved, or reacted that was uniquely them — not a generalization, an anchor?"*
+- *"What is a contradiction in them that you noticed? Real people contain multitudes."*
+
+Capture these as the seed material for scenes that involve this person. Reference `emotional-truth.md` and `scene-vs-summary.md` — the goal is anchors that earn dramatization, not summaries that pretend to be character development.
+
+### Step M6: Write people file
+
+Call MCP `create_person()` with:
+
+- `book_slug`, `name`, `relationship`
+- `person_category` (one of the four)
+- `consent_status` (one of the five)
+- `anonymization` (one of `none` / `partial` / `pseudonym` / `composite`)
+- `real_name` (only if anonymization != none)
+- `description` (one-line summary)
+
+The MCP tool validates each enum value and refuses to write the file on unknown values — surfacing what the four allowed sets are. If validation fails, fix and retry; do not work around by writing the file directly.
+
+After creation, expand the file body with the Memory anchors from Step M5. Update `{project}/people/INDEX.md` to list the new person under their relationship category (Family / Friends & relationships / Public figures / Pseudonymized / composite).
+
+After all structural-cast people are captured, update book status to "Characters Created" (the status label is shared with fiction; the meaning shifts per `book_categories/memoir/status-model.md`).
+
 ## Rules
+
+### Universal
+- Resolve `book_category` in Step 0 before any prerequisite load. Never default silently to fiction.
+- The fiction and memoir flows are non-overlapping — don't blend them. A memoir person does not need a Fatal Flaw; a fiction character does not need a `consent_status`.
+
+### Fiction
 - Build characters with flaws — flaws drive stories. A "perfect" character has no engine.
 - Antagonists must believe they're RIGHT — no mustache-twirling villains.
 - Every character needs their own voice — run the "cover the name" test on Step 11 sample dialogue.
@@ -152,3 +259,11 @@ After all major characters are created, update book status to "Characters Create
 - If you can describe the character in one word, dig further — the character is not deep enough yet.
 - The Ghost must connect to the Lie, which must connect to the Flaw — if the chain breaks, the character psychology is not coherent.
 - Contradictions are not inconsistencies — they are the mark of a real human being.
+
+### Memoir
+- Real people are captured, not invented. Imposing GMC / want-need / fatal-flaw frames on a real person produces fictionalization — which is the failure mode memoir avoids.
+- Every named living person needs a `consent_status` decision before they appear in any scene. `pending` is acceptable during drafting; `unknown` is not.
+- Anonymization that does not actually anonymize is worse than no anonymization — it provides legal exposure with the appearance of safety. Apply the "would someone who knew them identify them" test.
+- The `real_name` field stays in frontmatter only. Never render it into prose. Downstream skills (chapter-writer in memoir mode, #57) read the on-page `name`, not `real_name`.
+- Composites must be disclosed in the export's author's note (#64). Don't composite to obscure identity — that's anonymizing badly. Composite for narrative economy only.
+- For your own children, anonymize aggressively or wait until they can consent — see `real-people-ethics.md` "Special cases".

--- a/tests/test_real_people_handler.py
+++ b/tests/test_real_people_handler.py
@@ -1,0 +1,543 @@
+"""Tests for the memoir real-people handler (Issue #59, Path E Phase 2).
+
+`character-creator` branches on `book_category`. Memoir books store real
+people in `people/{slug}.md` with the four-category ethics schema from
+`book_categories/memoir/craft/real-people-ethics.md`. This module covers:
+
+- `resolve_people_dir` / `resolve_person_path` path resolution
+- `parse_person_file` schema parsing
+- `create_person` MCP tool (validation, file layout, memoir-only gate)
+- Indexer projection — `book["people"]` for memoir, `book["characters"]`
+  unchanged for fiction
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools.shared.paths import (
+    resolve_people_dir,
+    resolve_person_path,
+)
+from tools.state.parsers import (
+    is_valid_anonymization,
+    is_valid_consent_status,
+    is_valid_person_category,
+    parse_person_file,
+)
+
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePeopleDir:
+    """resolve_people_dir branches on book_category."""
+
+    def test_fiction_always_returns_characters(self, tmp_path: Path):
+        project = tmp_path / "fiction-book"
+        project.mkdir()
+        result = resolve_people_dir(project, "fiction")
+        assert result == project / "characters"
+
+    def test_memoir_prefers_people(self, tmp_path: Path):
+        project = tmp_path / "memoir-book"
+        project.mkdir()
+        (project / "people").mkdir()
+        result = resolve_people_dir(project, "memoir")
+        assert result == project / "people"
+
+    def test_memoir_falls_back_to_characters_when_only_legacy_exists(
+        self, tmp_path: Path
+    ):
+        # A memoir book scaffolded before #63 may have characters/ but no
+        # people/ — the resolver must find the existing dir, not return a
+        # phantom path.
+        project = tmp_path / "legacy-memoir"
+        project.mkdir()
+        (project / "characters").mkdir()
+        result = resolve_people_dir(project, "memoir")
+        assert result == project / "characters"
+
+    def test_memoir_returns_canonical_when_neither_exists(self, tmp_path: Path):
+        # Brand-new memoir before any scaffold — return the canonical
+        # `people/` so the caller can mkdir it.
+        project = tmp_path / "fresh-memoir"
+        project.mkdir()
+        result = resolve_people_dir(project, "memoir")
+        assert result == project / "people"
+
+    def test_default_category_is_fiction(self, tmp_path: Path):
+        project = tmp_path / "default-book"
+        project.mkdir()
+        result = resolve_people_dir(project)  # no book_category arg
+        assert result == project / "characters"
+
+
+class TestResolvePersonPath:
+    """resolve_person_path returns the file inside the right directory."""
+
+    def test_fiction_writes_under_characters(self, tmp_path: Path):
+        config = {"paths": {"content_root": str(tmp_path)}}
+        path = resolve_person_path(config, "my-novel", "alex", "fiction")
+        assert path == tmp_path / "projects" / "my-novel" / "characters" / "alex.md"
+
+    def test_memoir_writes_under_people(self, tmp_path: Path):
+        config = {"paths": {"content_root": str(tmp_path)}}
+        # Pre-create the project + people/ so resolve_people_dir picks people.
+        (tmp_path / "projects" / "my-memoir" / "people").mkdir(parents=True)
+        path = resolve_person_path(config, "my-memoir", "maria", "memoir")
+        assert path == tmp_path / "projects" / "my-memoir" / "people" / "maria.md"
+
+
+# ---------------------------------------------------------------------------
+# Schema validators
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaValidators:
+    """The four-category ethics model is enforced by enum validators."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "public-figure",
+            "private-living-person",
+            "deceased",
+            "anonymized-or-composite",
+        ],
+    )
+    def test_valid_person_categories_accepted(self, value: str):
+        assert is_valid_person_category(value)
+
+    @pytest.mark.parametrize("value", ["villain", "protagonist", "", "PUBLIC-FIGURE"])
+    def test_invalid_person_categories_rejected(self, value: str):
+        assert not is_valid_person_category(value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "confirmed-consent",
+            "pending",
+            "not-required",
+            "refused",
+            "not-asking",
+        ],
+    )
+    def test_valid_consent_statuses_accepted(self, value: str):
+        assert is_valid_consent_status(value)
+
+    @pytest.mark.parametrize("value", ["maybe", "yes", "approved", ""])
+    def test_invalid_consent_statuses_rejected(self, value: str):
+        assert not is_valid_consent_status(value)
+
+    @pytest.mark.parametrize(
+        "value", ["none", "partial", "pseudonym", "composite"]
+    )
+    def test_valid_anonymization_accepted(self, value: str):
+        assert is_valid_anonymization(value)
+
+    @pytest.mark.parametrize("value", ["full", "yes", "anonymous", ""])
+    def test_invalid_anonymization_rejected(self, value: str):
+        assert not is_valid_anonymization(value)
+
+
+# ---------------------------------------------------------------------------
+# parse_person_file
+# ---------------------------------------------------------------------------
+
+
+class TestParsePersonFile:
+    """parse_person_file extracts the memoir schema from a markdown file."""
+
+    def test_minimal_person_file(self, tmp_path: Path):
+        path = tmp_path / "maria.md"
+        path.write_text(
+            "---\n"
+            'name: "Maria"\n'
+            'relationship: "sister"\n'
+            'person_category: "private-living-person"\n'
+            'consent_status: "pending"\n'
+            'anonymization: "none"\n'
+            "---\n# Maria\n",
+            encoding="utf-8",
+        )
+
+        result = parse_person_file(path)
+        assert result["slug"] == "maria"
+        assert result["name"] == "Maria"
+        assert result["relationship"] == "sister"
+        assert result["person_category"] == "private-living-person"
+        assert result["consent_status"] == "pending"
+        assert result["anonymization"] == "none"
+
+    def test_pseudonymized_person_carries_real_name(self, tmp_path: Path):
+        path = tmp_path / "the-doctor.md"
+        path.write_text(
+            "---\n"
+            'name: "The doctor"\n'
+            'relationship: "diagnosing physician"\n'
+            'person_category: "anonymized-or-composite"\n'
+            'consent_status: "not-asking"\n'
+            'anonymization: "pseudonym"\n'
+            'real_name: "Dr. Henrik Lassen"\n'
+            "---\n# The doctor\n",
+            encoding="utf-8",
+        )
+
+        result = parse_person_file(path)
+        assert result["anonymization"] == "pseudonym"
+        # real_name stays available for the memoirist's records
+        assert result["real_name"] == "Dr. Henrik Lassen"
+
+    def test_unknown_values_pass_through_for_ethics_checker(self, tmp_path: Path):
+        # The parser must not silently coerce — memoir-ethics-checker (#65)
+        # depends on seeing exactly what's on disk so it can flag invalid
+        # values for the user.
+        path = tmp_path / "bad.md"
+        path.write_text(
+            "---\n"
+            'name: "Bad"\n'
+            'relationship: "?"\n'
+            'person_category: "neighbor"\n'
+            "---\n# Bad\n",
+            encoding="utf-8",
+        )
+        result = parse_person_file(path)
+        assert result["person_category"] == "neighbor"  # unchanged
+
+
+# ---------------------------------------------------------------------------
+# create_person MCP tool — validation + file layout
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def content_root(tmp_path: Path) -> Path:
+    root = tmp_path / "content"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def mock_config(content_root: Path):
+    fake_config = {
+        "paths": {
+            "content_root": str(content_root),
+            "authors_root": str(content_root / "authors"),
+        },
+        "defaults": {
+            "language": "en",
+            "book_type": "novel",
+            "book_category": "fiction",
+        },
+    }
+
+    import server as server_mod  # noqa: WPS433
+    from tools.state import indexer as indexer_mod  # noqa: WPS433
+
+    with patch.object(server_mod, "load_config", return_value=fake_config), \
+         patch.object(server_mod, "get_content_root", return_value=content_root), \
+         patch.object(indexer_mod, "load_config", return_value=fake_config):
+        server_mod._cache.invalidate()
+        yield fake_config
+
+
+@pytest.fixture
+def server_module(mock_config):
+    import server as server_mod  # noqa: WPS433
+    return server_mod
+
+
+class TestCreatePersonValidation:
+    """create_person enforces required fields and enum validity."""
+
+    def test_relationship_required(self, server_module, content_root: Path):
+        # Set up a memoir book so we get past the book-existence check.
+        json.loads(
+            server_module.create_book_structure(
+                title="Test Memoir", book_category="memoir"
+            )
+        )
+
+        result = json.loads(
+            server_module.create_person(
+                book_slug="test-memoir",
+                name="Anonymous",
+                relationship="",  # empty
+                person_category="private-living-person",
+            )
+        )
+        assert "error" in result
+        assert "relationship" in result["error"].lower()
+
+    def test_invalid_person_category_rejected(
+        self, server_module, content_root: Path
+    ):
+        json.loads(
+            server_module.create_book_structure(
+                title="Memoir Two", book_category="memoir"
+            )
+        )
+
+        result = json.loads(
+            server_module.create_person(
+                book_slug="memoir-two",
+                name="Maria",
+                relationship="sister",
+                person_category="protagonist",  # fiction concept, invalid here
+            )
+        )
+        assert "error" in result
+        assert "person_category" in result["error"]
+
+    def test_invalid_consent_status_rejected(
+        self, server_module, content_root: Path
+    ):
+        json.loads(
+            server_module.create_book_structure(
+                title="Memoir Three", book_category="memoir"
+            )
+        )
+
+        result = json.loads(
+            server_module.create_person(
+                book_slug="memoir-three",
+                name="Maria",
+                relationship="sister",
+                person_category="private-living-person",
+                consent_status="approved",  # not in the allowed set
+            )
+        )
+        assert "error" in result
+        assert "consent_status" in result["error"]
+
+    def test_invalid_anonymization_rejected(
+        self, server_module, content_root: Path
+    ):
+        json.loads(
+            server_module.create_book_structure(
+                title="Memoir Four", book_category="memoir"
+            )
+        )
+
+        result = json.loads(
+            server_module.create_person(
+                book_slug="memoir-four",
+                name="Maria",
+                relationship="sister",
+                person_category="private-living-person",
+                anonymization="full",  # not in the allowed set
+            )
+        )
+        assert "error" in result
+        assert "anonymization" in result["error"]
+
+
+class TestCreatePersonMemoirGate:
+    """create_person rejects fiction books — schema mismatch."""
+
+    def test_rejects_fiction_book(self, server_module, content_root: Path):
+        json.loads(
+            server_module.create_book_structure(
+                title="Fiction Book", book_category="fiction"
+            )
+        )
+        server_module._cache.invalidate()
+
+        result = json.loads(
+            server_module.create_person(
+                book_slug="fiction-book",
+                name="Maria",
+                relationship="sister",
+                person_category="private-living-person",
+            )
+        )
+        assert "error" in result
+        assert "memoir" in result["error"].lower()
+
+    def test_rejects_unknown_book(self, server_module):
+        result = json.loads(
+            server_module.create_person(
+                book_slug="does-not-exist",
+                name="Maria",
+                relationship="sister",
+                person_category="private-living-person",
+            )
+        )
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+
+class TestCreatePersonFileLayout:
+    """Successful create_person writes to people/{slug}.md with the schema."""
+
+    def test_writes_to_people_dir_with_frontmatter(
+        self, server_module, content_root: Path
+    ):
+        json.loads(
+            server_module.create_book_structure(
+                title="Year of Glass", book_category="memoir"
+            )
+        )
+
+        result = json.loads(
+            server_module.create_person(
+                book_slug="year-of-glass",
+                name="Maria",
+                relationship="sister",
+                person_category="private-living-person",
+                consent_status="pending",
+                anonymization="none",
+                description="The sister who stayed.",
+            )
+        )
+        assert result.get("success") is True
+        assert result["slug"] == "maria"
+
+        person_file = (
+            content_root / "projects" / "year-of-glass" / "people" / "maria.md"
+        )
+        assert person_file.exists()
+        # No phantom characters/maria.md.
+        assert not (
+            content_root / "projects" / "year-of-glass" / "characters" / "maria.md"
+        ).exists()
+
+        text = person_file.read_text(encoding="utf-8")
+        assert 'relationship: "sister"' in text
+        assert 'person_category: "private-living-person"' in text
+        assert 'consent_status: "pending"' in text
+        assert 'anonymization: "none"' in text
+
+    def test_pseudonymized_person_persists_real_name(
+        self, server_module, content_root: Path
+    ):
+        json.loads(
+            server_module.create_book_structure(
+                title="The Diagnosis", book_category="memoir"
+            )
+        )
+
+        json.loads(
+            server_module.create_person(
+                book_slug="the-diagnosis",
+                name="The doctor",
+                relationship="diagnosing physician",
+                person_category="anonymized-or-composite",
+                consent_status="not-asking",
+                anonymization="pseudonym",
+                real_name="Dr. Henrik Lassen",
+            )
+        )
+
+        person_file = (
+            content_root / "projects" / "the-diagnosis" / "people" / "the-doctor.md"
+        )
+        assert person_file.exists()
+        text = person_file.read_text(encoding="utf-8")
+        assert 'real_name: "Dr. Henrik Lassen"' in text
+
+    def test_duplicate_person_rejected(self, server_module, content_root: Path):
+        json.loads(
+            server_module.create_book_structure(
+                title="Duplicate Memoir", book_category="memoir"
+            )
+        )
+
+        first = json.loads(
+            server_module.create_person(
+                book_slug="duplicate-memoir",
+                name="Maria",
+                relationship="sister",
+                person_category="private-living-person",
+            )
+        )
+        assert first.get("success") is True
+
+        second = json.loads(
+            server_module.create_person(
+                book_slug="duplicate-memoir",
+                name="Maria",
+                relationship="sister",
+                person_category="private-living-person",
+            )
+        )
+        assert "error" in second
+        assert "already exists" in second["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Indexer projection
+# ---------------------------------------------------------------------------
+
+
+class TestIndexerScansPeopleForMemoir:
+    """The indexer populates book['people'] for memoir, characters for fiction."""
+
+    def test_memoir_book_exposes_people_count(
+        self, server_module, content_root: Path
+    ):
+        json.loads(
+            server_module.create_book_structure(
+                title="Indexer Memoir", book_category="memoir"
+            )
+        )
+        json.loads(
+            server_module.create_person(
+                book_slug="indexer-memoir",
+                name="Maria",
+                relationship="sister",
+                person_category="private-living-person",
+            )
+        )
+        json.loads(
+            server_module.create_person(
+                book_slug="indexer-memoir",
+                name="Father",
+                relationship="father",
+                person_category="deceased",
+                consent_status="not-required",
+            )
+        )
+
+        server_module._cache.invalidate()
+        result = json.loads(server_module.get_book_full("indexer-memoir"))
+
+        assert result["book_category"] == "memoir"
+        assert result["people_count"] == 2
+        assert "maria" in result["people"]
+        assert "father" in result["people"]
+        # characters/ stays empty for memoir.
+        assert result["character_count"] == 0
+
+    def test_fiction_book_does_not_populate_people(
+        self, server_module, content_root: Path
+    ):
+        json.loads(
+            server_module.create_book_structure(
+                title="Indexer Fiction", book_category="fiction"
+            )
+        )
+        json.loads(
+            server_module.create_character(
+                book_slug="indexer-fiction",
+                name="Alex",
+                role="protagonist",
+            )
+        )
+
+        server_module._cache.invalidate()
+        result = json.loads(server_module.get_book_full("indexer-fiction"))
+
+        assert result["book_category"] == "fiction"
+        assert result["character_count"] == 1
+        assert "alex" in result["characters"]
+        # Fiction books carry an empty people projection — never populated.
+        assert result["people_count"] == 0
+        assert result["people"] == {}

--- a/tools/shared/paths.py
+++ b/tools/shared/paths.py
@@ -56,6 +56,51 @@ def resolve_character_path(
     return resolve_project_path(config, book_slug) / "characters" / f"{character_slug}.md"
 
 
+# Path E #59: memoir books store real-people profiles under `people/`
+# instead of `characters/`. Scaffolded by `new-book` (#63), populated by
+# the memoir-mode branch of `character-creator`. The candidate list runs
+# `people/` first so memoir books resolve there even when a stray legacy
+# `characters/` directory exists alongside it.
+PEOPLE_DIR_CANDIDATES: tuple[str, ...] = ("people", "characters")
+
+
+def resolve_people_dir(project_dir: Path, book_category: str = "fiction") -> Path:
+    """Return the directory holding character / real-person profile files.
+
+    For memoir books, prefers ``people/`` and falls back to ``characters/``
+    when the memoir layout has not been scaffolded yet (legacy memoir books
+    written before #63 / #59 land). For fiction, always returns
+    ``characters/``.
+
+    The returned path may not exist — callers decide whether to create it
+    or treat absence as an empty cast.
+    """
+    if book_category == "memoir":
+        for name in PEOPLE_DIR_CANDIDATES:
+            candidate = project_dir / name
+            if candidate.exists():
+                return candidate
+        # Neither exists yet — return the canonical memoir path.
+        return project_dir / "people"
+    return project_dir / "characters"
+
+
+def resolve_person_path(
+    config: dict[str, Any],
+    book_slug: str,
+    person_slug: str,
+    book_category: str = "fiction",
+) -> Path:
+    """Resolve path for a person / character file within a book.
+
+    Memoir books resolve to ``people/{slug}.md``; fiction books to
+    ``characters/{slug}.md``.
+    """
+    return resolve_people_dir(
+        resolve_project_path(config, book_slug), book_category
+    ) / f"{person_slug}.md"
+
+
 def resolve_series_path(config: dict[str, Any], series_slug: str) -> Path:
     """Resolve path for a series directory."""
     return Path(config["paths"]["content_root"]) / "series" / series_slug

--- a/tools/state/indexer.py
+++ b/tools/state/indexer.py
@@ -22,6 +22,7 @@ from tools.state.parsers import (
     parse_chapter_readme,
     parse_character_file,
     parse_frontmatter,
+    parse_person_file,
     parse_series_readme,
 )
 
@@ -221,7 +222,11 @@ def _scan_books(
             book["status_disk"] = disk_status
         book["status"] = derived_status
 
-        # Scan characters
+        # Scan characters / people. Path E #59: memoir books carry their
+        # cast under `people/` with a real-person schema; fiction stays at
+        # `characters/` with the historical schema. Both keys exist on
+        # every book so consumers can ask without checking book_category
+        # first — the irrelevant key is just empty.
         chars_dir = book_dir / "characters"
         if chars_dir.exists():
             book["characters"] = _scan_characters(chars_dir)
@@ -229,6 +234,18 @@ def _scan_books(
         else:
             book["characters"] = {}
             book["character_count"] = 0
+
+        if book.get("book_category") == "memoir":
+            people_dir = book_dir / "people"
+            if people_dir.exists():
+                book["people"] = _scan_people(people_dir)
+                book["people_count"] = len(book["people"])
+            else:
+                book["people"] = {}
+                book["people_count"] = 0
+        else:
+            book["people"] = {}
+            book["people_count"] = 0
 
         books[slug] = book
 
@@ -307,6 +324,19 @@ def _scan_characters(chars_dir: Path) -> dict[str, Any]:
         characters[char["slug"]] = char
 
     return characters
+
+
+def _scan_people(people_dir: Path) -> dict[str, Any]:
+    """Scan all real-person files within a memoir book (Path E #59)."""
+    people = {}
+
+    for person_file in sorted(people_dir.glob("*.md")):
+        if person_file.name == "INDEX.md":
+            continue
+        person = parse_person_file(person_file)
+        people[person["slug"]] = person
+
+    return people
 
 
 def _scan_authors(authors_dir: Path) -> dict[str, Any]:

--- a/tools/state/parsers.py
+++ b/tools/state/parsers.py
@@ -110,6 +110,77 @@ def parse_character_file(path: Path) -> dict[str, Any]:
     }
 
 
+# Path E #59: real-person schema for memoir books. Distinct from the fiction
+# character schema — there is no ``role`` (no protagonist/antagonist), no
+# arc fields. Instead: relationship to the memoirist, ethics-relevant
+# category, consent posture, and anonymization decision. Mirrors the
+# four-category model in book_categories/memoir/craft/real-people-ethics.md.
+
+# Allowed values — kept here so parsers, validators, and the create_person
+# MCP tool stay aligned. memoir-ethics-checker (#65) consumes these too.
+_ALLOWED_PERSON_CATEGORIES: tuple[str, ...] = (
+    "public-figure",
+    "private-living-person",
+    "deceased",
+    "anonymized-or-composite",
+)
+_ALLOWED_CONSENT_STATUSES: tuple[str, ...] = (
+    "confirmed-consent",
+    "pending",
+    "not-required",
+    "refused",
+    "not-asking",
+)
+_ALLOWED_ANONYMIZATION_LEVELS: tuple[str, ...] = (
+    "none",
+    "partial",
+    "pseudonym",
+    "composite",
+)
+
+
+def is_valid_person_category(value: str) -> bool:
+    return value in _ALLOWED_PERSON_CATEGORIES
+
+
+def is_valid_consent_status(value: str) -> bool:
+    return value in _ALLOWED_CONSENT_STATUSES
+
+
+def is_valid_anonymization(value: str) -> bool:
+    return value in _ALLOWED_ANONYMIZATION_LEVELS
+
+
+def parse_person_file(path: Path) -> dict[str, Any]:
+    """Parse a real-person markdown file (memoir mode) into structured data.
+
+    Schema lives in `book_categories/memoir/craft/real-people-ethics.md`:
+    - relationship: free-text relationship to the memoirist
+    - person_category: one of ``_ALLOWED_PERSON_CATEGORIES``
+    - consent_status: one of ``_ALLOWED_CONSENT_STATUSES``
+    - anonymization: one of ``_ALLOWED_ANONYMIZATION_LEVELS``
+    - real_name: only set when anonymization != "none" (kept private)
+
+    Unknown values are passed through as-is so memoir-ethics-checker (#65)
+    can flag them. The parser does not reject malformed files — it only
+    surfaces what is on disk.
+    """
+    text = path.read_text(encoding="utf-8")
+    meta, body = parse_frontmatter(text)
+
+    return {
+        "slug": path.stem,
+        "name": meta.get("name", path.stem),
+        "relationship": meta.get("relationship", ""),
+        "person_category": meta.get("person_category", ""),
+        "consent_status": meta.get("consent_status", ""),
+        "anonymization": meta.get("anonymization", "none"),
+        "real_name": meta.get("real_name", ""),
+        "status": _normalize_character_status(meta.get("status", "Concept")),
+        "description": meta.get("description", ""),
+    }
+
+
 def parse_author_profile(path: Path) -> dict[str, Any]:
     """Parse an author profile.md into structured data."""
     text = path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Phase 2 of the Memoir support epic (#97). Branches `character-creator` on `book_category` so memoir books capture **real people** with the four-category ethics schema instead of running the fiction GMC / want-need / fatal-flaw workflow.

**Schema (memoir):**

| Field | Allowed values |
|-------|----------------|
| `person_category` | `public-figure` / `private-living-person` / `deceased` / `anonymized-or-composite` |
| `consent_status` | `confirmed-consent` / `pending` / `not-required` / `refused` / `not-asking` |
| `anonymization` | `none` / `partial` / `pseudonym` / `composite` |
| `real_name` | populated only when `anonymization != "none"`; never rendered into prose |
| `relationship` | free text, required |

The schema mirrors `book_categories/memoir/craft/real-people-ethics.md` exactly so `memoir-ethics-checker` (#65) can consume it later.

**New MCP tool:** `create_person()` — validates each enum, refuses fiction books, writes to `people/{slug}.md`.

**Path resolution:** `resolve_people_dir(project, book_category)` returns `people/` for memoir (with a `characters/` legacy fallback) and `characters/` for fiction. Closes the `people/` aliasing caveat from PR #105.

**Indexer:** projects `book["people"]` for memoir (with `people_count`) and `book["characters"]` for fiction. Both keys exist on every book so downstream consumers do not need to category-check before reading.

**Skill:** Step 0 resolves `book_category` first, then branches into either the 14-step fiction flow (verbatim) or a 6-step memoir real-people handler. Memoir flow consumes the `## Scope` section that `book-conceptualizer` (#60) already wrote — Step M2/M3 operationalize Phase 3's cast decisions, not re-decide them.

Closes #59. Unblocks #65 (memoir-ethics-checker) which depends on the schema.

## Acceptance from #59

- [x] `character-creator` detects `book_category` and switches to people-handler in memoir mode
- [x] Real-person profile schema documented (in `real-people-ethics.md` + enforced by `create_person` validators)
- [x] `consent_status` validated downstream by `memoir-ethics-checker` (#65) — schema is the contract; #65 will consume it
- [x] Fiction-mode `character-creator` unchanged (verbatim 14-step flow preserved; new tests assert `create_character` still writes to `characters/`)

## Test plan

- [ ] `/storyforge:character-creator` on a fiction book — expect 14-step flow, `characters/{slug}.md` produced
- [ ] `/storyforge:character-creator` on a memoir book — expect the memoir intro line and 6-step flow (Identification → Person Category → Consent → Anonymization → Memory anchors → Write)
- [ ] Calling `create_person` with `person_category: protagonist` returns an error listing the four valid values
- [ ] Calling `create_person` on a fiction book returns an error suggesting `create_character`
- [ ] `/storyforge:book-dashboard` on a memoir book with people files renders the people-count
- [ ] Existing fiction project (Blood & Binary) — `create_character` still works; `book["characters"]` populated; `book["people"]` empty

## Quality gates

- pytest: 700 passed (46 new in `test_real_people_handler.py`)
- ruff: clean

## Related

- Closes the `people/` indexer caveat from PR #105 (#63)
- Schema-aligned with `book_categories/memoir/craft/real-people-ethics.md`
- Unblocks #65 (memoir-ethics-checker), #57 (chapter-writer memoir mode)