### PR TITLE
feat: plot-architect for memoir structure types (#58)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,12 +138,12 @@ Memoir-aware skills already wired:
 - `/storyforge:book-dashboard` — surfaces `Category` and `Length` separately, re-labels people table for memoir (Issue #63)
 - `/storyforge:book-conceptualizer` (memoir mode) — runs the 5-phase concept with Phase 3 *Scope* (time window / cast / deliberate exclusions) instead of Phase 3 *Conflict*, memoir-blurb conventions in Phase 5 (Issue #60)
 - `/storyforge:character-creator` (memoir mode) — real-people handler that captures relationship, person_category (4-category model), consent_status, and anonymization decisions; writes to `people/{slug}.md` via `create_person` MCP tool (Issue #59)
+- `/storyforge:plot-architect` (memoir mode) — narrative-arc shaping; user picks one of four structure types (chronological / thematic / braided / vignette), persisted via `set_memoir_structure_type`; chapter spine, timeline anchor, and tonal document still apply (Issue #58)
 
 The forthcoming memoir-specific routing (not yet wired):
 
 - `/storyforge:memoir-ethics-checker` — consent/defamation/anonymization scan (Issue #65)
 - `/storyforge:emotional-truth-prompt` — render-the-felt-sense pass (Issue #66)
-- `/storyforge:plot-architect` (memoir mode) — narrative-arc shaping with structure-type selection (Issue #58)
 - `/storyforge:chapter-writer` (memoir mode) — loads memoir craft, scene-vs-summary discipline (Issue #57)
 
 Until those land, when working on a memoir book, manually load `book_categories/memoir/README.md` and the relevant `craft/` files at the start of any creative skill.
@@ -249,7 +249,7 @@ Skills MUST load relevant craft references before generating creative content. U
 - `book-conceptualizer` → loads: theme-development for both modes; fiction adds story-structure + plot-craft; memoir adds (via `book_categories/memoir/craft/`) memoir-structure-types, emotional-truth, scene-vs-summary, real-people-ethics, memoir-anti-ai-patterns. Memoir replaces Phase 3 (Conflict) with Phase 3 (Scope).
 - `chapter-writer` → loads: chapter-construction, dialog-craft, show-dont-tell, pacing-guide, anti-ai-patterns, prose-style, simile-discipline + genre craft (memoir mode adds: `book_categories/memoir/craft/scene-vs-summary.md`, `emotional-truth.md`, `memoir-anti-ai-patterns.md`)
 - `chapter-reviewer` → loads: dos-and-donts, anti-ai-patterns, chapter-construction, dialog-craft, show-dont-tell, simile-discipline (memoir mode adds: `book_categories/memoir/craft/memoir-anti-ai-patterns.md`)
-- `plot-architect` → loads: story-structure, plot-craft, tension-and-suspense (memoir mode loads `book_categories/memoir/craft/memoir-structure-types.md` instead of `plot-craft.md`)
+- `plot-architect` → fiction loads: story-structure, plot-craft, tension-and-suspense, conflict-types. Memoir branches to a 6-step narrative-arc workflow (#58) that loads `book_categories/memoir/craft/memoir-structure-types.md`, `scene-vs-summary.md`, `emotional-truth.md`, `memoir-anti-ai-patterns.md`; the user picks one of four structure types (chronological / thematic / braided / vignette), persisted via `set_memoir_structure_type` MCP tool to `plot/structure.md` frontmatter.
 - `character-creator` → fiction loads: character-creation, character-arcs, dialog-craft + genre. Memoir branches to a 6-step real-people handler (#59) that loads `book_categories/memoir/craft/real-people-ethics.md`, `emotional-truth.md`, `memoir-anti-ai-patterns.md`; writes to `people/{slug}.md` via `create_person` MCP tool with the four-category ethics schema.
 - `world-builder` → loads: world-building (memoir typically skips this skill — real settings are documented in `world/setting.md` via research, not invention)
 - `voice-checker` → loads: anti-ai-patterns, prose-style, dos-and-donts (memoir mode adds: `book_categories/memoir/craft/memoir-anti-ai-patterns.md`)

--- a/servers/storyforge-server/server.py
+++ b/servers/storyforge-server/server.py
@@ -31,9 +31,11 @@ from tools.state.parsers import (
     is_valid_person_category,
     is_valid_consent_status,
     is_valid_anonymization,
+    is_valid_memoir_structure_type,
     _ALLOWED_PERSON_CATEGORIES,
     _ALLOWED_CONSENT_STATUSES,
     _ALLOWED_ANONYMIZATION_LEVELS,
+    _ALLOWED_MEMOIR_STRUCTURE_TYPES,
 )
 from tools.analysis.callback_validator import verify_callbacks as _verify_callbacks_impl
 from tools.analysis.manuscript_checker import scan_repetitions, render_report
@@ -1253,6 +1255,97 @@ description: {json.dumps(description)}
         "slug": slug,
         "path": str(person_path),
         "message": f"Person '{name}' created",
+    })
+
+
+@mcp.tool()
+def set_memoir_structure_type(book_slug: str, structure_type: str) -> str:
+    """Persist the memoir's chosen structure type (Path E #58).
+
+    Validates against the four allowed types from
+    ``book_categories/memoir/craft/memoir-structure-types.md``:
+    chronological / thematic / braided / vignette.
+
+    Writes to ``plot/structure.md`` frontmatter so downstream skills
+    (``chapter-writer`` in memoir mode #57, ``rolling-planner``) can read
+    the choice without parsing the body. The body of the file is
+    preserved if it already exists; missing frontmatter is prepended.
+
+    Memoir-only — fiction books are rejected. Use ``plot-architect``
+    Step 2's standard structure catalog for fiction.
+
+    Args:
+        book_slug: Book project slug.
+        structure_type: One of chronological, thematic, braided, vignette.
+    """
+    if not is_valid_memoir_structure_type(structure_type):
+        allowed = ", ".join(_ALLOWED_MEMOIR_STRUCTURE_TYPES)
+        return json.dumps({
+            "error": (
+                f"Invalid structure_type '{structure_type}'. "
+                f"Allowed values: {allowed}."
+            )
+        })
+
+    # Memoir-only gate — same pattern as create_person.
+    state = _cache.get()
+    book = state.get("books", {}).get(book_slug)
+    if not book:
+        _cache.invalidate()
+        state = _cache.get()
+        book = state.get("books", {}).get(book_slug)
+    if not book:
+        return json.dumps({"error": f"Book '{book_slug}' not found"})
+    if book.get("book_category") != "memoir":
+        return json.dumps({
+            "error": (
+                f"Book '{book_slug}' is not a memoir "
+                f"(book_category: {book.get('book_category', 'fiction')}). "
+                "Memoir structure types only apply to book_category: memoir."
+            )
+        })
+
+    config = load_config()
+    project_dir = resolve_project_path(config, book_slug)
+    structure_path = project_dir / "plot" / "structure.md"
+
+    # If the file does not exist (legacy memoir scaffolded before #63),
+    # create it with frontmatter + a stub body. Otherwise, parse and
+    # preserve the body — only the frontmatter is rewritten.
+    if structure_path.exists():
+        existing = structure_path.read_text(encoding="utf-8")
+        meta, body = parse_frontmatter(existing)
+        meta["structure_type"] = structure_type
+        # YAML round-trip via inline strings so the file stays diff-friendly
+        # for the user's editor.
+        fm = "\n".join(f'{k}: "{v}"' if isinstance(v, str) else f"{k}: {v}"
+                       for k, v in meta.items())
+        new_text = f"---\n{fm}\n---\n{body if body else ''}"
+        if not body:
+            # Existing file had no frontmatter and no body — write a stub.
+            new_text = (
+                f'---\nstructure_type: "{structure_type}"\n---\n\n'
+                f"# {book.get('title', book_slug)} — Memoir Structure\n\n"
+                f"*Structure type: {structure_type}. "
+                "See `book_categories/memoir/craft/memoir-structure-types.md`.*\n"
+            )
+    else:
+        structure_path.parent.mkdir(parents=True, exist_ok=True)
+        new_text = (
+            f'---\nstructure_type: "{structure_type}"\n---\n\n'
+            f"# {book.get('title', book_slug)} — Memoir Structure\n\n"
+            f"*Structure type: {structure_type}. "
+            "See `book_categories/memoir/craft/memoir-structure-types.md`.*\n"
+        )
+
+    structure_path.write_text(new_text, encoding="utf-8")
+    _cache.invalidate()
+
+    return json.dumps({
+        "success": True,
+        "book_slug": book_slug,
+        "structure_type": structure_type,
+        "path": str(structure_path),
     })
 
 

--- a/skills/plot-architect/SKILL.md
+++ b/skills/plot-architect/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: plot-architect
 description: |
-  Structure the plot with acts, beats, turning points, and character arcs.
-  Use when: (1) User says "Plot", "Handlung", "Struktur", "outline",
-  (2) After concept is developed, before character creation.
+  Fiction: structure the plot with acts, beats, turning points, character arcs.
+  Memoir: shape narrative arc by structure type (chronological / thematic / braided / vignette).
+  Use when: (1) User says "Plot", "Handlung", "Struktur", "outline", "narrative arc",
+  (2) After concept is developed, before character / people creation.
 model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<book-slug>"
@@ -11,8 +12,22 @@ argument-hint: "<book-slug>"
 
 # Plot Architect
 
+This skill branches on `book_category` (Path E #97 Phase 2 #58). Fiction runs the historical Step-0..9 workflow with the standard structure catalog (3-Act, Hero's Journey, Save the Cat, etc.). Memoir runs a memoir-aware narrative-arc workflow that picks one of four structure types and shapes the chapter spine per that type.
+
+## Step 0a — Resolve book category
+
+Before any other prerequisite load:
+
+1. **Load book data** via MCP `get_book_full(slug)`.
+2. Read `book_category`. Treat missing as `fiction`.
+3. Branch the workflow on `book_category`. The fiction and memoir flows are non-overlapping — no acts/beats for memoir, no structure-type for fiction.
+
+If `book_category == "memoir"`, surface a one-line note: *"Working in memoir mode — picking a structure type (chronological / thematic / braided / vignette), no antagonist phase, the chapter spine is shaped by the chosen structure."*
+
 ## Prerequisites — MANDATORY LOADS
-- **Book data** via MCP `get_book_full()`. **Why:** Existing premise, theme, characters, writing-mode — Step 0 branches on `effective_author_writing_mode` and Step 1 builds on existing concept output.
+
+### Fiction mode (`book_category == "fiction"`)
+- **Book data** via MCP `get_book_full()`. **Why:** Existing premise, theme, characters, writing-mode — Step 0b branches on `effective_author_writing_mode` and Step 1 builds on existing concept output.
 - **Author profile** via MCP `get_author()` if assigned. **Why:** The author profile may carry structural preferences (e.g. "always uses 5-act tragic arcs") that bias the recommendation in Step 2.
 - **Genre README(s)** via MCP `get_genre()`. **Why:** Genre dictates expected structures (romance = 3-Act + HEA, thriller = Fichtean) and beat conventions.
 - **Craft references** via MCP `get_craft_reference()`:
@@ -21,9 +36,20 @@ argument-hint: "<book-slug>"
   - `tension-and-suspense` — **Why:** Stakes, cliffhangers, pacing — what makes the chapter-by-chapter plan in Step 7 actually keep readers turning pages.
   - `conflict-types` — **Why:** Escalation patterns and moral dilemma structures — Step 4 subplot architecture depends on knowing how conflicts compound.
 
-## Workflow
+### Memoir mode (`book_category == "memoir"`)
+- **Book data** via MCP `get_book_full()`. **Why:** premise, theme, scope (Phase 3 of `book-conceptualizer` #60), people roster — the structure type must serve what the conceptualizer already locked in.
+- **Author profile** via MCP `get_author()` if assigned. **Why:** Memoirist's voice and tonal preferences inform structure-type fit.
+- **Memoir craft** from `book_categories/memoir/craft/` (resolve via MCP `get_book_category_dir("memoir")`):
+  - `memoir-structure-types.md` — **Why:** the four-type catalog with when-it-works / when-it-fails / discipline-required notes; this is the single source of truth for Step M2.
+  - `scene-vs-summary.md` — **Why:** the structure type drives scene/summary ratio decisions in the chapter spine (Step M5).
+  - `emotional-truth.md` — **Why:** the structure type must serve the felt sense of the lived material, not impose a fictional plot shape on it.
+  - `memoir-anti-ai-patterns.md` — **Why:** prevents drift toward "looking back I realize" framing in the through-line statement.
+- Read `{project}/README.md` `## Scope` (Phase 3 of `book-conceptualizer` #60) — the time window, structural cast, and exclusions are inputs to structure-type choice.
+- Read `{project}/people/INDEX.md` if real-people profiles already exist (`character-creator` memoir mode #59) — structure-type cadence in Step M3 may vary by who carries which thread.
 
-### Step 0: Check Writing Mode
+## Workflow — Fiction
+
+### Step 0b: Check Writing Mode
 Load the book via MCP `get_book_full(slug)` and read `effective_author_writing_mode`.
 
 - **`discovery`** — Stop here. Discovery writers skip `plot-architect` entirely.
@@ -149,9 +175,152 @@ This document guards against tonal drift during long-form writing. Without it, b
 
 ---
 
+## Workflow — Memoir
+
+The fiction structure catalog (3-Act, Hero's Journey, etc.) does not apply. Memoir picks one of four structure types and shapes the chapter spine per that type. There is no antagonist phase, no foreshadowing map (memoir does not "plant payoffs" — lived events do not work that way), no subplot architecture.
+
+The memoir flow has 6 steps. Step M5 preserves the chapter-spine concept; Step M6 keeps the timeline anchor (memoir uses real chronology, but the timeline file still anchors story-time for `chapter-writer`).
+
+### Step M0: Read existing concept
+
+- Read `{project}/README.md` for premise, theme, **and the `## Scope` section** that `book-conceptualizer` (#60) wrote in Phase 3 (time window, structural cast, deliberate exclusions). The scope decisions gate Step M2 — a memoir whose scope is "thematic exclusions across decades" cannot honestly choose chronological.
+- If `## Scope` is missing, stop and route to `/storyforge:book-conceptualizer` first. Memoir plot-architect builds on scope; building it without scope produces structure-shopping, not structure-choosing.
+- Read `{project}/plot/outline.md` for any existing through-line draft (the `book-conceptualizer` Phase 4 sketch — Step M3 below refines it).
+- Read `{project}/people/INDEX.md` if it exists (post-`character-creator` memoir mode #59).
+
+### Step M1: Confirm or refine the through-line
+
+The through-line is the **single sentence** that says what the memoir is *about* — not the events, but the question or claim. The conceptualizer's Phase 1 premise is the raw material; the through-line is the operational form that drives structure choice.
+
+Ask the user:
+
+- *"Read your premise back to yourself. What is the one sentence that, if a stranger asked what your memoir is about, you would say?"*
+- *"Does that sentence point at a time-window question (chronological-friendly), a conceptual question (thematic-friendly), a then-vs-now question (braided-friendly), or a mosaic-of-fragments question (vignette-friendly)?"*
+
+Write the through-line to `{project}/plot/outline.md` under "## Through-line". This is what the chapter spine in Step M5 will serve.
+
+**Wait for user confirmation of the through-line before Step M2. Structure choice cascades from this sentence.**
+
+### Step M2: Choose structure type
+
+Reference `memoir-structure-types.md` (loaded as prerequisite). Use AskUserQuestion with the four options. Show concrete pros/cons rooted in *this user's* scope and through-line — generic descriptions are not enough.
+
+| Type | Picks itself when… |
+|------|--------------------|
+| `chronological` | Period is bounded and short, causality is tight, suspense of not-yet-knowing is part of the experience |
+| `thematic` | Central question is conceptual not temporal, multiple decades inform it, memory clusters by topic |
+| `braided` | Past + present-day vantage comment on each other, dramatic irony is structural |
+| `vignette` | Lived material is fragmented in memory, mosaic accumulation is the meaning, each scene bears weight alone |
+
+Reference the **decision tree** at the bottom of `memoir-structure-types.md` if the user is torn between two types — pick the one whose **failure modes you can avoid**, not the one with the prettier examples.
+
+After the user picks, persist the choice via MCP `set_memoir_structure_type(book_slug, structure_type)`. The tool validates against the four allowed values and writes to `plot/structure.md` frontmatter so downstream skills (`chapter-writer` memoir mode #57, `rolling-planner`) can read it.
+
+**Wait for the user's structure-type selection before Step M3.** Every downstream step branches on this choice.
+
+### Step M3: Map the narrative arc per structure type
+
+The arc-mapping shape depends on the structure type. Pick the matching sub-step:
+
+#### M3-chronological — Time-bounded arc
+
+- **Begin point** — *not* the chronological start, the **narrative** start. *In medias res* is the default. Where does the reader enter?
+- **Hinge moments** — name 3–6 events that turned the period. Compress aggressively between them.
+- **End point** — where does the narrative close? Has the question the through-line raises been *answered*, *re-framed*, or deliberately *left open*?
+- **Compression strategy** — for each gap between hinges, decide: paragraph / scene cluster / single image / cut.
+
+Write to `{project}/plot/outline.md` under "## Narrative arc — chronological".
+
+#### M3-thematic — Conceptual chapters with a through-line
+
+- **Theme list** — typically 5–9 concrete themes. *Money / Faith / Bodies / Hunger / Silence* — concrete, not abstract. Kill *Truth / Beauty / Love* and pick substitutes.
+- **Through-line thread** — what runs across the themes? A relationship, a place, a recurring question. Visible by Chapter 3 or the reader bails.
+- **Argumentative order** — chapter sequence is an argument, not a list. Why does Chapter 5 need to come *after* Chapter 4?
+- **Scene-spine per theme** — each thematic chapter still needs scene work; theme alone is essay-shaped.
+
+Write to `{project}/plot/outline.md` under "## Narrative arc — thematic" (theme list + through-line) and "## Argument order" (chapter sequence rationale).
+
+#### M3-braided — Two threads in conversation
+
+- **Thread A** — name it (e.g. "the year of the diagnosis"). Specify timeframe and POV.
+- **Thread B** — name it (e.g. "present-day reckoning"). Specify timeframe and what vantage point it carries.
+- **Cadence** — strict alternation? weighted (e.g. 2:1 toward Thread A)? variable per chapter cluster? Pick a pattern and commit.
+- **Transition principle** — image / theme / echo / question. Never "meanwhile, decades later". Define the working principle and apply it consistently.
+- **Earn-test** — for each thread, write one sentence saying what would be lost if it were cut. Vague answers mean the braid is decorative; one thread should probably go.
+
+Write to `{project}/plot/outline.md` under "## Narrative arc — braided".
+
+#### M3-vignette — Mosaic with a through-line
+
+- **Through-line** — recurring image, place, relationship, unanswered question. Visible by Chapter 3.
+- **Vignette inventory** — list 12–25 candidate vignettes (more than you'll use). For each: one-line summary + emotional weight + which through-line element it touches.
+- **Selection** — cut to 8–18 strong vignettes. Weak vignettes stop the read; vignette memoirs cannot carry filler.
+- **Order as argument** — vignettes are arranged, not collected. The order is craft. Group by theme, contrast, or cumulative weight — the pattern is itself a craft choice.
+
+Write to `{project}/plot/outline.md` under "## Narrative arc — vignette" (through-line + ordered vignette list).
+
+### Step M4: Identify the structure-specific failure modes
+
+Re-read the **failure modes** section of the chosen structure in `memoir-structure-types.md`. For each failure mode, write one sentence to `{project}/plot/outline.md` under "## Structure failure-mode watch" stating how *this specific memoir* will avoid it. This is the prose equivalent of Phase 4 from `book-conceptualizer` — committing to discipline, in writing, before drafting.
+
+Examples:
+
+- Chronological → *"Decades-long span: I will compress 2003-2010 to two paragraphs in Chapter 4. The story is the diagnosis year, not my whole adulthood."*
+- Thematic → *"Module risk: Chapter 5 (Money) and Chapter 7 (Bodies) both touch the same hospital scene. I will plant the recurring image in Chapter 5 and pay it off in Chapter 7 to thread them."*
+- Braided → *"Lazy transition risk: I will not use date-stamps as crutches. Every cut carries an image bridge."*
+- Vignette → *"Anecdote-collection risk: by Vignette 4, the reader will know the through-line question. If they don't, the order is wrong."*
+
+### Step M5: Chapter spine
+
+The fiction concept of a chapter spine — the running list of chapters with title, focus, and rough word target — is preserved for memoir. The shape varies per structure type:
+
+| Type | Chapter spine shape |
+|------|---------------------|
+| `chronological` | Linear chapter list with date or season anchors per chapter, hinge events flagged |
+| `thematic` | Chapter list = theme list (one theme per chapter, or a theme cluster spanning 2–3 chapters) |
+| `braided` | Chapter list with thread tags (A / B / both) and cadence pattern noted |
+| `vignette` | Vignette list with grouping/clustering noted; "chapters" may bundle 2–4 short vignettes |
+
+For each chapter:
+
+- Number + working title
+- Focus (event / theme / vignette / braid pair)
+- Through-line touchpoint — how this chapter advances the through-line
+- POV vantage — past-self, present-self, or both (relevant for chronological + braided especially)
+- Rough word target
+
+Offer to create chapter directories via MCP `create_chapter()` once the spine is locked.
+
+Write the chapter spine to `{project}/plot/outline.md` under "## Chapter spine".
+
+### Step M6: Initialize timeline + tonal document
+
+These two universal steps still apply to memoir.
+
+#### M6a: Timeline anchor
+
+Memoir uses **real chronology** for `plot/timeline.md`, not invented story-days. But the file still serves the same purpose: anchoring story-time for `chapter-writer` so cross-chapter temporal references stay consistent.
+
+1. Ask the user: *"What is the real start date (or month/year) of the period your memoir covers?"*
+2. Establish the **Anchor Point** as that real date. Story Day 1 = first scene's date.
+3. Pre-fill the Event Calendar with the hinge moments / themed-chapter clusters / vignette dates from Step M3. Mark all entries `[PLANNED]`.
+4. For braided memoir, the timeline tracks **both** threads — note Thread A and Thread B dates separately.
+
+This step is MANDATORY. A memoir without a timeline anchor produces cross-chapter time drift the same way fiction does.
+
+#### M6b: Tonal document
+
+Same as fiction Step 9 — interview the user, populate the Tonal Arc per structure type (a chronological arc tone-shifts across the period; a thematic arc may keep tone steady within chapters and shift between them; braided demands two distinct tonal palettes; vignette tone may shift per vignette).
+
+Write to `{project}/plot/tone.md`.
+
+Update book status to "Plot Outlined" via MCP `update_field()`.
+
+---
+
 ## Snowflake Workflow
 
-*Use this section instead of Steps 3–8 when the user selects the Snowflake Method.*
+*Use this section instead of Steps 3–8 when the user selects the Snowflake Method (fiction only).*
 
 *Theory and step descriptions in `reference/craft/story-structure.md` (loaded as prerequisite). This section covers StoryForge-specific execution: file paths, MCP tools, and skill integrations.*
 
@@ -265,8 +434,20 @@ Also create the tonal document (original Step 9 of the standard workflow) at thi
 ---
 
 ## Rules
+
+### Universal
+- Resolve `book_category` in Step 0a before any prerequisite load.
 - Structure serves story — pick the structure that fits, not the structure on the bestseller list.
+
+### Fiction
 - Every beat must have emotional PURPOSE, not just plot function.
 - The "Therefore/But" test: every event must cause the next. "And then" sequencing means the plot is just a list.
 - Midpoint is NOT halfway through the events — it's the REVERSAL that changes everything.
 - Foreshadowing map is mandatory — every climax payoff needs a prior plant. Deus ex machina is a craft failure.
+
+### Memoir
+- The structure type is one of `chronological`, `thematic`, `braided`, `vignette`. Persist the choice via MCP `set_memoir_structure_type` — never improvise a fifth type. Hybrids belong in the prose, not the metadata.
+- The `## Scope` section from `book-conceptualizer` (#60) gates structure choice. Without it, route the user back to the conceptualizer; do not invent a scope here.
+- Every memoir chapter spine entry must touch the through-line — chapters that drift away from the through-line are scope-failure dressed as "more material".
+- Re-read the failure-mode notes for the chosen structure (in `memoir-structure-types.md`) before drafting Step M5. Structure choice without failure-mode awareness is structure-shopping.
+- No foreshadowing map. Memoir does not plant payoffs — lived events do not arrange themselves around climaxes. Use thematic recurrence and image-rhyme instead, captured in the through-line and Step M3 mapping.

--- a/tests/test_memoir_structure_type.py
+++ b/tests/test_memoir_structure_type.py
@@ -1,0 +1,257 @@
+"""Tests for the memoir structure type selector (Issue #58, Path E Phase 2).
+
+`plot-architect` (memoir mode) lets the user pick one of four narrative
+structures from `book_categories/memoir/craft/memoir-structure-types.md`:
+chronological / thematic / braided / vignette. The choice persists to
+`plot/structure.md` frontmatter via the `set_memoir_structure_type` MCP
+tool so downstream skills (`chapter-writer` memoir mode #57,
+`rolling-planner`) can read it without re-asking the user.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools.state.parsers import (
+    is_valid_memoir_structure_type,
+    parse_frontmatter,
+)
+
+
+# ---------------------------------------------------------------------------
+# Validator
+# ---------------------------------------------------------------------------
+
+
+class TestValidateMemoirStructureType:
+    """Only the four documented structure types are accepted."""
+
+    @pytest.mark.parametrize(
+        "value", ["chronological", "thematic", "braided", "vignette"]
+    )
+    def test_valid_types_accepted(self, value: str):
+        assert is_valid_memoir_structure_type(value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "linear",  # adjacent term that is not the canonical one
+            "three-act",  # fiction structure, wrong category
+            "snowflake",  # fiction method, wrong category
+            "CHRONOLOGICAL",  # case-sensitive
+            "",
+            "hybrid",  # explicitly not allowed — earn hybrids in prose, not metadata
+        ],
+    )
+    def test_invalid_types_rejected(self, value: str):
+        assert not is_valid_memoir_structure_type(value)
+
+
+# ---------------------------------------------------------------------------
+# set_memoir_structure_type MCP tool
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def content_root(tmp_path: Path) -> Path:
+    root = tmp_path / "content"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def mock_config(content_root: Path):
+    fake_config = {
+        "paths": {
+            "content_root": str(content_root),
+            "authors_root": str(content_root / "authors"),
+        },
+        "defaults": {
+            "language": "en",
+            "book_type": "novel",
+            "book_category": "fiction",
+        },
+    }
+
+    import server as server_mod  # noqa: WPS433
+    from tools.state import indexer as indexer_mod  # noqa: WPS433
+
+    with patch.object(server_mod, "load_config", return_value=fake_config), \
+         patch.object(server_mod, "get_content_root", return_value=content_root), \
+         patch.object(indexer_mod, "load_config", return_value=fake_config):
+        server_mod._cache.invalidate()
+        yield fake_config
+
+
+@pytest.fixture
+def server_module(mock_config):
+    import server as server_mod  # noqa: WPS433
+    return server_mod
+
+
+class TestSetMemoirStructureTypeValidation:
+    """Enum validation + memoir-only gate."""
+
+    def test_invalid_structure_type_rejected(
+        self, server_module, content_root: Path
+    ):
+        json.loads(
+            server_module.create_book_structure(
+                title="Memoir A", book_category="memoir"
+            )
+        )
+
+        result = json.loads(
+            server_module.set_memoir_structure_type(
+                book_slug="memoir-a", structure_type="five-act"
+            )
+        )
+        assert "error" in result
+        assert "structure_type" in result["error"]
+        # Valid options surfaced for the user.
+        for valid in ["chronological", "thematic", "braided", "vignette"]:
+            assert valid in result["error"]
+
+    def test_rejects_fiction_book(self, server_module, content_root: Path):
+        json.loads(
+            server_module.create_book_structure(
+                title="Fiction Plot", book_category="fiction"
+            )
+        )
+        server_module._cache.invalidate()
+
+        result = json.loads(
+            server_module.set_memoir_structure_type(
+                book_slug="fiction-plot", structure_type="chronological"
+            )
+        )
+        assert "error" in result
+        assert "memoir" in result["error"].lower()
+
+    def test_rejects_unknown_book(self, server_module):
+        result = json.loads(
+            server_module.set_memoir_structure_type(
+                book_slug="does-not-exist", structure_type="chronological"
+            )
+        )
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+
+class TestSetMemoirStructureTypePersistence:
+    """Successful calls write the choice to plot/structure.md frontmatter."""
+
+    def test_writes_structure_type_to_existing_scaffold(
+        self, server_module, content_root: Path
+    ):
+        # The #63 scaffold creates plot/structure.md without frontmatter.
+        # set_memoir_structure_type must add frontmatter while preserving
+        # the scaffold body.
+        json.loads(
+            server_module.create_book_structure(
+                title="Year of Glass", book_category="memoir"
+            )
+        )
+
+        structure_path = (
+            content_root / "projects" / "year-of-glass" / "plot" / "structure.md"
+        )
+        scaffold_text = structure_path.read_text(encoding="utf-8")
+        assert "Memoir Structure" in scaffold_text  # #63 scaffold marker
+
+        result = json.loads(
+            server_module.set_memoir_structure_type(
+                book_slug="year-of-glass", structure_type="chronological"
+            )
+        )
+        assert result.get("success") is True
+        assert result["structure_type"] == "chronological"
+
+        new_text = structure_path.read_text(encoding="utf-8")
+        meta, body = parse_frontmatter(new_text)
+        assert meta["structure_type"] == "chronological"
+        # Original body content is preserved.
+        assert "Memoir Structure" in body
+
+    def test_overwrites_previous_choice(
+        self, server_module, content_root: Path
+    ):
+        # A user may revise the choice mid-conceptualization.
+        json.loads(
+            server_module.create_book_structure(
+                title="Revision Memoir", book_category="memoir"
+            )
+        )
+
+        json.loads(
+            server_module.set_memoir_structure_type(
+                book_slug="revision-memoir", structure_type="chronological"
+            )
+        )
+        json.loads(
+            server_module.set_memoir_structure_type(
+                book_slug="revision-memoir", structure_type="braided"
+            )
+        )
+
+        structure_path = (
+            content_root / "projects" / "revision-memoir" / "plot" / "structure.md"
+        )
+        meta, _ = parse_frontmatter(structure_path.read_text(encoding="utf-8"))
+        assert meta["structure_type"] == "braided"
+
+    def test_creates_file_when_legacy_memoir_lacks_structure_md(
+        self, server_module, content_root: Path
+    ):
+        # Memoir books scaffolded before #63 do not have plot/structure.md.
+        # The tool must create it rather than failing.
+        json.loads(
+            server_module.create_book_structure(
+                title="Legacy Memoir", book_category="memoir"
+            )
+        )
+
+        # Simulate a legacy memoir by deleting the scaffolded structure.md.
+        structure_path = (
+            content_root / "projects" / "legacy-memoir" / "plot" / "structure.md"
+        )
+        structure_path.unlink()
+        assert not structure_path.exists()
+
+        result = json.loads(
+            server_module.set_memoir_structure_type(
+                book_slug="legacy-memoir", structure_type="thematic"
+            )
+        )
+        assert result.get("success") is True
+        assert structure_path.exists()
+        meta, _ = parse_frontmatter(structure_path.read_text(encoding="utf-8"))
+        assert meta["structure_type"] == "thematic"
+
+    @pytest.mark.parametrize(
+        "structure_type",
+        ["chronological", "thematic", "braided", "vignette"],
+    )
+    def test_all_four_types_persist(
+        self, server_module, content_root: Path, structure_type: str
+    ):
+        # Each of the four valid types persists identically.
+        title = f"Memoir {structure_type}"
+        json.loads(
+            server_module.create_book_structure(
+                title=title, book_category="memoir"
+            )
+        )
+
+        slug = title.lower().replace(" ", "-")
+        result = json.loads(
+            server_module.set_memoir_structure_type(
+                book_slug=slug, structure_type=structure_type
+            )
+        )
+        assert result.get("success") is True
+        assert result["structure_type"] == structure_type

--- a/tools/state/parsers.py
+++ b/tools/state/parsers.py
@@ -138,6 +138,18 @@ _ALLOWED_ANONYMIZATION_LEVELS: tuple[str, ...] = (
     "composite",
 )
 
+# Path E #58: memoir books use one of four structure types instead of
+# fiction's three-act / hero's-journey / etc. catalog. plot-architect
+# (memoir mode) lets the user pick; downstream skills (chapter-writer #57,
+# rolling-planner) consume the choice from plot/structure.md frontmatter.
+# Reference: book_categories/memoir/craft/memoir-structure-types.md.
+_ALLOWED_MEMOIR_STRUCTURE_TYPES: tuple[str, ...] = (
+    "chronological",
+    "thematic",
+    "braided",
+    "vignette",
+)
+
 
 def is_valid_person_category(value: str) -> bool:
     return value in _ALLOWED_PERSON_CATEGORIES
@@ -149,6 +161,10 @@ def is_valid_consent_status(value: str) -> bool:
 
 def is_valid_anonymization(value: str) -> bool:
     return value in _ALLOWED_ANONYMIZATION_LEVELS
+
+
+def is_valid_memoir_structure_type(value: str) -> bool:
+    return value in _ALLOWED_MEMOIR_STRUCTURE_TYPES
 
 
 def parse_person_file(path: Path) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Phase 2 of the Memoir support epic (#97). Branches `plot-architect` on `book_category` so memoir books pick one of four narrative structures from `book_categories/memoir/craft/memoir-structure-types.md` instead of running the fiction structure catalog.

**The four memoir structure types:**

| Type | Picks itself when… |
|------|--------------------|
| `chronological` | Period is bounded and short, causality is tight |
| `thematic` | Central question is conceptual not temporal |
| `braided` | Past + present-day vantage comment on each other |
| `vignette` | Lived material is fragmented in memory, mosaic accumulation is the meaning |

**New MCP tool:** `set_memoir_structure_type(book_slug, structure_type)` — validates the enum, refuses fiction books, persists to `plot/structure.md` frontmatter so downstream skills (`chapter-writer` memoir mode #57, `rolling-planner`) can read the choice without re-asking.

**The memoir 6-step flow:**

- **M0** Read scope from `book-conceptualizer` (#60); refuse if missing
- **M1** Confirm/refine the through-line
- **M2** Choose structure type → persist via `set_memoir_structure_type`
- **M3** Map narrative arc per structure type (four sub-flavors)
- **M4** Commit to structure-specific failure-mode discipline in writing
- **M5** Chapter spine (preserved from fiction, shaped by structure type)
- **M6** Timeline anchor (real chronology) + tonal document

No antagonist phase. No foreshadowing map (memoir doesn't plant payoffs — lived events don't arrange around climaxes). Fiction workflow is verbatim unchanged.

Closes #58. Unblocks #57 (`chapter-writer` memoir mode).

## Acceptance from #58

- [x] `plot-architect` detects `book_category` and switches mode
- [x] Memoir output produces structure-appropriate outline (Step M3 is structure-type-specific; chapter spine in M5 varies per type)
- [x] Fiction-mode unchanged (Step 0a-0b-1..9 + Snowflake workflow preserved verbatim)
- [x] Tests cover both modes (validator + memoir-only gate + persistence + legacy memoir fallback + all four types parametrized)

## Test plan

- [ ] `/storyforge:plot-architect` on a fiction book — expect Step 0b writing-mode branch, structure catalog with 3-Act/Hero/etc.
- [ ] `/storyforge:plot-architect` on a memoir book without `## Scope` — expect routing back to `/storyforge:book-conceptualizer`
- [ ] `/storyforge:plot-architect` on a memoir book with scope — expect 6-step memoir flow, structure-type AskUserQuestion with four options
- [ ] After picking a type, verify `plot/structure.md` carries `structure_type:` in frontmatter
- [ ] Existing fiction project (Blood & Binary) — re-running plot-architect does not introduce a `structure_type` field

## Notes

- Hybrid structures are explicitly **not** allowed in metadata. The validator rejects "hybrid" — earn hybrids in prose, not in the persisted enum.
- Legacy memoir books scaffolded before #63 (no `plot/structure.md`) are handled — the tool creates the file rather than failing.
- The four structure types are now a Single Source of Truth: the enum lives in `tools/state/parsers.py` and is imported by both the validator and the MCP tool's error message.

## Quality gates

- pytest: 720 passed (20 new in `test_memoir_structure_type.py`)
- ruff: clean

## Related

- Schema-aligned with `book_categories/memoir/craft/memoir-structure-types.md`
- Builds on #60 (book-conceptualizer Phase 4) which already pre-stages structure-type selection
- Unblocks #57 (chapter-writer memoir mode reads `structure_type` to load the right craft prompts)