### PR TITLE
feat: chapter-writer for memoir mode (#57)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,12 +139,12 @@ Memoir-aware skills already wired:
 - `/storyforge:book-conceptualizer` (memoir mode) — runs the 5-phase concept with Phase 3 *Scope* (time window / cast / deliberate exclusions) instead of Phase 3 *Conflict*, memoir-blurb conventions in Phase 5 (Issue #60)
 - `/storyforge:character-creator` (memoir mode) — real-people handler that captures relationship, person_category (4-category model), consent_status, and anonymization decisions; writes to `people/{slug}.md` via `create_person` MCP tool (Issue #59)
 - `/storyforge:plot-architect` (memoir mode) — narrative-arc shaping; user picks one of four structure types (chronological / thematic / braided / vignette), persisted via `set_memoir_structure_type`; chapter spine, timeline anchor, and tonal document still apply (Issue #58)
+- `/storyforge:chapter-writer` (memoir mode) — loads memoir craft (scene-vs-summary, emotional-truth, real-people-ethics, memoir-anti-ai-patterns); reads `book_category` + `consent_status_warnings` from the brief; surfaces consent gates for refused/pending/missing status before drafting; closes chapters into `plot/people-log.md` instead of `plot/canon-log.md`; skips `world/setting.md` (no Travel Matrix) and genre-as-plot-contract loads (Issue #57)
 
 The forthcoming memoir-specific routing (not yet wired):
 
 - `/storyforge:memoir-ethics-checker` — consent/defamation/anonymization scan (Issue #65)
 - `/storyforge:emotional-truth-prompt` — render-the-felt-sense pass (Issue #66)
-- `/storyforge:chapter-writer` (memoir mode) — loads memoir craft, scene-vs-summary discipline (Issue #57)
 
 Until those land, when working on a memoir book, manually load `book_categories/memoir/README.md` and the relevant `craft/` files at the start of any creative skill.
 
@@ -247,7 +247,7 @@ Each doc in `reference/craft/` carries a `book_categories: [...]` frontmatter (I
 Skills MUST load relevant craft references before generating creative content. Until Phase 2+ wires automatic filtering by `book_category`, skills should also manually skip docs whose frontmatter excludes the current category.
 
 - `book-conceptualizer` → loads: theme-development for both modes; fiction adds story-structure + plot-craft; memoir adds (via `book_categories/memoir/craft/`) memoir-structure-types, emotional-truth, scene-vs-summary, real-people-ethics, memoir-anti-ai-patterns. Memoir replaces Phase 3 (Conflict) with Phase 3 (Scope).
-- `chapter-writer` → loads: chapter-construction, dialog-craft, show-dont-tell, pacing-guide, anti-ai-patterns, prose-style, simile-discipline + genre craft (memoir mode adds: `book_categories/memoir/craft/scene-vs-summary.md`, `emotional-truth.md`, `memoir-anti-ai-patterns.md`)
+- `chapter-writer` → both modes load: chapter-construction, dialog-craft, show-dont-tell, pacing-guide, anti-ai-patterns, prose-style, simile-discipline. Fiction adds: genre craft, `world/setting.md` (Travel Matrix), `plot/canon-log.md`. Memoir replaces those with: `book_categories/memoir/craft/scene-vs-summary.md`, `emotional-truth.md`, `memoir-anti-ai-patterns.md`, `real-people-ethics.md`, `plot/structure.md` (structure_type), `plot/people-log.md`. Memoir mode also enforces a consent gate via the brief's `consent_status_warnings` field — refused-tier warnings halt drafting (#57).
 - `chapter-reviewer` → loads: dos-and-donts, anti-ai-patterns, chapter-construction, dialog-craft, show-dont-tell, simile-discipline (memoir mode adds: `book_categories/memoir/craft/memoir-anti-ai-patterns.md`)
 - `plot-architect` → fiction loads: story-structure, plot-craft, tension-and-suspense, conflict-types. Memoir branches to a 6-step narrative-arc workflow (#58) that loads `book_categories/memoir/craft/memoir-structure-types.md`, `scene-vs-summary.md`, `emotional-truth.md`, `memoir-anti-ai-patterns.md`; the user picks one of four structure types (chronological / thematic / braided / vignette), persisted via `set_memoir_structure_type` MCP tool to `plot/structure.md` frontmatter.
 - `character-creator` → fiction loads: character-creation, character-arcs, dialog-craft + genre. Memoir branches to a 6-step real-people handler (#59) that loads `book_categories/memoir/craft/real-people-ethics.md`, `emotional-truth.md`, `memoir-anti-ai-patterns.md`; writes to `people/{slug}.md` via `create_person` MCP tool with the four-category ethics schema.

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -11,13 +11,24 @@ argument-hint: "<book-slug> <chapter-number>"
 
 # Chapter Writer
 
+## Step 0 — Resolve book category
+
+Read `book_category` from the chapter writing brief (Step 1). The brief carries it explicitly so the skill never has to re-fetch the book just to check. Treat missing as `fiction` (legacy default).
+
+If `book_category == "memoir"`, surface a one-line note: *"Working in memoir mode — loading memoir craft (scene-vs-summary, emotional-truth, anti-AI patterns), checking consent_status before drafting any scene with named living people."*
+
+The fiction and memoir prerequisite sets are non-overlapping. Branch every load below on `book_category`.
+
 ## Prerequisites — MANDATORY LOADS
 
 Before writing a single word:
 
-1. **Chapter writing brief** — MCP `get_chapter_writing_brief(book_slug, chapter_slug)`. **Why:** One structured payload that bundles 12 separate context sources — story_anchor, recent_chapter_timelines, recent_chapter_endings, characters_present (with knowledge + tactical profiles), rules_to_honor (book CLAUDE.md ## Rules with severity), callbacks_in_register, banned_phrases (book + author + global), recent_simile_count_per_chapter, tone_litmus_questions, tactical_constraints, review_handle, plus the chapter metadata. Honor every populated field while writing. Empty fields and entries in `errors` mean "not available for this chapter" — degrade gracefully, do not invent. Store the returned `review_handle` as `{review_handle}`.
-2. **Author profile** — MCP `get_author()`. **Why:** Drives tone, vocabulary, rhythm, voice. Without it prose defaults to generic AI register. Not in the brief because it lives outside the book scope.
-3. **Book data** — MCP `get_book_full()`. **Why:** Genres, plot context, the frame the chapter must fit.
+1. **Chapter writing brief** — MCP `get_chapter_writing_brief(book_slug, chapter_slug)`. **Why:** One structured payload that bundles 13 separate context sources — `book_category`, story_anchor, recent_chapter_timelines, recent_chapter_endings, characters_present (fiction: role + knowledge + tactical profiles; memoir: relationship + person_category + consent_status + anonymization), `consent_status_warnings` (memoir only), rules_to_honor (book CLAUDE.md ## Rules with severity), callbacks_in_register, banned_phrases (book + author + global), recent_simile_count_per_chapter, tone_litmus_questions, tactical_constraints, review_handle, plus the chapter metadata. Honor every populated field while writing. Empty fields and entries in `errors` mean "not available for this chapter" — degrade gracefully, do not invent. Store the returned `review_handle` as `{review_handle}`.
+2. **Author profile** — MCP `get_author()`. **Why:** Drives tone, vocabulary, rhythm, voice. Memoirist's voice is the same load. Without it prose defaults to generic AI register.
+3. **Book data** — MCP `get_book_full()`. **Why:** Genres / category context, plot or scope, the frame the chapter must fit.
+
+### Fiction mode (`book_category == "fiction"`)
+
 4. **Genre README(s)** — MCP `get_genre()` for each genre. **Why:** Reader-expected conventions; violations need to be deliberate.
 5. **Craft references** — MCP `get_craft_reference()`:
    - `chapter-construction` — **Why:** Hooks, scene-sequel, endings — the structural skeleton of every chapter.
@@ -31,6 +42,29 @@ Before writing a single word:
 7. **Story timeline** — Read `{project}/plot/timeline.md`. **Why:** Canonical day/date calendar — the brief's `recent_chapter_timelines` covers intra-day grids; `timeline.md` covers the macro arc.
 8. **Canon log** — Read `{project}/plot/canon-log.md`. **Why:** Established facts, including `CHANGED` revisions. Contradicting canon breaks reader trust.
 9. **Series canon** — If part of a series, read `{series}/world/canon.md`. **Why:** Series-level facts and constraints carry across books.
+
+### Memoir mode (`book_category == "memoir"`)
+
+4. **Genre README(s)** — MCP `get_genre()` for each genre, framed as **thematic tags** (memoir-of-illness, memoir-of-place). **Why:** Memoir uses genre as theme, not as plot-convention contract. Skip the plot-genre conventions (HEA, ticking-clock, etc.) — they do not apply.
+5. **Craft references — universal** — MCP `get_craft_reference()`:
+   - `chapter-construction` — **Why:** Hooks and chapter endings still apply; memoir scenes still need shape.
+   - `dialog-craft` — **Why:** Reconstructed dialogue in memoir is still dialogue and must not all sound the same. Subtext + beats apply identically.
+   - `show-dont-tell` — **Why:** Memoir's failure mode is reflective summary; show-don't-tell is the antidote.
+   - `pacing-guide` — **Why:** The scene/summary ratio is the central memoir-craft decision per page.
+   - `anti-ai-patterns` — **Why:** The fiction anti-AI catalog still applies for prose-level tells (delve, tapestry, smooth-but-flat rhythm).
+   - `prose-style` — **Why:** Sentence-level craft is identical across categories.
+   - `simile-discipline` — **Why:** The two-question test still gates Step 6c pre-save scan.
+6. **Memoir craft** from `book_categories/memoir/craft/` (resolve via MCP `get_book_category_dir("memoir")`):
+   - `scene-vs-summary.md` — **Why:** The first decision per page — dramatize or reflect — drives every memoir scene's shape. The fiction craft's "scene = goal/conflict/disaster" still applies; this layer adds *when not to render a scene at all*.
+   - `emotional-truth.md` — **Why:** The standard memoir is held to. Factual / emotional / narrative truth, in that order of priority. Failure mode: facts without felt sense.
+   - `memoir-anti-ai-patterns.md` — **Why:** Memoir-specific tells the universal anti-AI doc misses — "looking back I realize", reflective platitudes, tidy lessons learned, hedged intimacy.
+   - `real-people-ethics.md` — **Why:** Consent gate enforcement before any scene with a named living person; framing for anonymized portrayals; defamation-trigger awareness.
+7. **Memoir structure type** — Read `plot/structure.md` frontmatter (`structure_type:` — set by `plot-architect` memoir mode #58). **Why:** The chapter's scene/summary ratio and POV vantage vary by structure type (chronological / thematic / braided / vignette). For braided memoir, the chapter spine in `plot/outline.md` flags which thread (A or B) this chapter belongs to.
+8. **Story timeline** — Read `{project}/plot/timeline.md`. **Why:** Memoir uses real chronology, but the timeline file still anchors story-time so cross-chapter references stay consistent.
+9. **People log** — Read `{project}/plot/people-log.md` if it exists (analogue to fiction's `canon-log.md`). **Why:** Real-person consistency — what each person *did*, *said*, *believed* in earlier chapters. Memoir's truth standard requires consistency across chapters; canon-log contradictions in memoir are not just craft failures, they are factual errors. If the file does not exist yet, create it on first chapter close (Step 7).
+10. **Consent status check** — Read `consent_status_warnings` from the brief. **MANDATORY GATE.** If any warning has tier `refused`, halt drafting and route the user back to `/storyforge:character-creator` (memoir mode) to decide cut / anonymize / re-frame. For tier `missing` or `pending`, surface the warning to the user and confirm before drafting.
+
+Note: memoir does **not** read `world/setting.md` (no Travel Matrix — real settings live in `research/sources.md` and the chapter's own setting prose) and does **not** read `plot/canon-log.md` (memoir uses `people-log.md` for real-person consistency tracking instead).
 
 ## Writing Process
 
@@ -119,10 +153,21 @@ For clean scenes, silence is fine. When cuts happen, optionally note "Simile-Sca
 ### Step 7: Save and Update (both modes)
 1. Draft is at `{project}/chapters/{chapter}/draft.md`. Count words — report to user.
 2. Chapter status: MCP `update_field()` on `chapter.yaml` → `Review` / `Final` (per user) or leave `Draft`. Book-level status auto-derives via the #21 indexer.
-3. **Update `plot/timeline.md`** — one row per story-day. MANDATORY.
+3. **Update `plot/timeline.md`** — one row per story-day (memoir: real-date row). MANDATORY.
+
+**Fiction (`book_category: fiction`):**
+
 4. **Update Travel Matrix** in `world/setting.md` if new routes appeared.
 5. **Update `plot/canon-log.md`** — new facts. If revising, mark changed facts `CHANGED` with old version in Notes, and add downstream chapters to the Revision Impact Tracker.
-6. **Update Chapter Timeline** in this chapter's `README.md` — every time-anchored event with `~HH:MM`. MANDATORY (future chapters depend on it).
+
+**Memoir (`book_category: memoir`):**
+
+4. **Update `plot/people-log.md`** — what each named person did, said, believed, or revealed in this chapter. The memoir analogue of canon-log; consistency across chapters is a truth standard, not just a craft standard. Create the file on first chapter close if it does not exist. Mark changed/corrected facts `CHANGED` with old version in Notes.
+5. **No Travel Matrix update** — memoir documents real settings via research, not a structured matrix. Note any new place names worth tracking in `research/sources.md` instead.
+
+**Both modes — universal step:**
+
+6. **Update Chapter Timeline** in this chapter's `README.md` — every time-anchored event with `~HH:MM`. MANDATORY (future chapters depend on it). Memoir uses real clock times.
 
 ### Step 8: Self-Review (both modes)
 Before presenting to user (in full-chapter mode) or after all scenes assembled (in scene-by-scene mode), quick-check:
@@ -149,9 +194,10 @@ If the user is blocked or struggling: redirect to `/storyforge:unblock` instead 
 
 ## Rules
 
-- Author profile is LAW. SHOW don't tell. Every scene needs conflict. Dialog has subtext. Banned words trigger sentence rewrite.
+### Universal (both modes)
+- Resolve `book_category` in Step 0 before any prerequisite load. The fiction and memoir prerequisite sets are non-overlapping.
+- Author profile is LAW. SHOW don't tell. Every scene needs conflict (memoir: every scene needs *stakes* — the lived equivalent). Dialog has subtext. Banned words trigger sentence rewrite.
 - **Simile Discipline (Step 6c) is non-negotiable.** Every scene survives the two-question test before it enters `draft.md`. Author-voice bias = quality not quantity. See `simile-discipline.md`.
-- Continuity is global: check `plot/timeline.md`, `plot/canon-log.md`, and `world/setting.md` Travel Matrix in addition to the brief's recent chapter timelines. Never invent travel times. Never contradict canon. Use NEW versions of `CHANGED` facts.
 - Honor every entry in the brief's `rules_to_honor` (book CLAUDE.md ## Rules) — `severity: block` rules will be hard-blocked by the PostToolUse hook. Honor `tone_litmus_questions` (from `plot/tone.md`) when present.
 - Never write a relative time reference without checking against the brief's `story_anchor` and `recent_chapter_timelines`. If the math doesn't work, adjust the prose — not the timeline.
 - The Chapter Timeline section in `README.md` is MANDATORY at review status. Future chapters depend on it.
@@ -160,7 +206,22 @@ If the user is blocked or struggling: redirect to `/storyforge:unblock` instead 
 - **Read the full `draft.md` for review (GH#27).** When the user signals `{review_handle}:` blocks are ready (keywords: "kommentiert", "gelesen", "Feedback", "lies mal", "schau dir an"), ALWAYS call `Read` on the whole file first. The file-change system-reminder diff truncates for long files; trailing comments get silently dropped. Count the blocks you see and report the count.
 - **One Claude Code session per chapter.** Cold-start brief is designed for a fresh session; scene-by-scene cycles burn context fast. If auto-compaction fires mid-chapter, earlier review decisions can be silently dropped. Finish the chapter, close, open a new session.
 - **Stop if context pressure mounts.** A scene written after partial context loss degrades silently. End the session and resume fresh rather than shipping a degraded scene.
-- Target word count from the chapter README. Respect genre conventions.
+- Target word count from the chapter README.
+
+### Fiction
+- Continuity is global: check `plot/timeline.md`, `plot/canon-log.md`, and `world/setting.md` Travel Matrix in addition to the brief's recent chapter timelines. Never invent travel times. Never contradict canon. Use NEW versions of `CHANGED` facts.
+- Respect genre conventions — they're the contract with the reader.
+
+### Memoir
+- **Consent gate is non-negotiable.** Before drafting any scene, read the brief's `consent_status_warnings`. Tier `refused` halts drafting — route to `/storyforge:character-creator` (memoir mode) for the cut/anonymize/re-frame decision. Tier `missing` requires the user's explicit decision before drafting. Tier `pending` requires user confirmation that drafting is okay (the consent request still needs to happen pre-publication).
+- **Real names are sacred.** Frontmatter `real_name` stays in the people file; never render it into prose. Use the `name` field (which may be a pseudonym).
+- **Scene-vs-summary discipline.** The first decision per page is dramatize or reflect. Default to mix; never default to one alone. See `book_categories/memoir/craft/scene-vs-summary.md`.
+- **Emotional truth, not just factual truth.** Reconstructed dialogue carries the substance of remembered conversation, not a fabricated transcript. Memoir's truth standard is felt-sense first; rendered events second; verifiable facts third — but never violate any of the three.
+- **No invented details.** If you don't know what someone wore, said, smelled like — leave it out, don't invent. The instinct to "fill in" with plausible detail is the fiction reflex; in memoir it produces fabrication.
+- **No tidy lessons.** "Looking back I realize…", "what I learned was…", reflective platitudes — these are the memoir AI-tells. See `memoir-anti-ai-patterns.md`.
+- **People-log over canon-log.** Memoir's continuity log is `plot/people-log.md` — what each named person did, said, believed, revealed across chapters. Inconsistency across chapters is not just craft failure, it is factual error.
+- **No Travel Matrix.** Memoir does not pre-tabulate travel times — real life provides them. Specific real places get noted in `research/sources.md`, not in `world/setting.md`.
+- **Genres are themes, not contracts.** A "horror memoir" is a memoir of horrifying experience, not a haunted-house plot. Don't impose plot-genre conventions on lived material.
 
 ## User Feedback Handling — CRITICAL
 

--- a/tests/test_chapter_writing_brief_memoir.py
+++ b/tests/test_chapter_writing_brief_memoir.py
@@ -1,0 +1,428 @@
+"""Tests for the memoir-mode chapter writing brief (Issue #57, Path E Phase 2).
+
+`chapter-writer` branches on `book_category`. Memoir books load real-people
+profiles from `people/` (with the four-category ethics schema), surface
+`consent_status_warnings` before drafting, and skip the world/setting.md +
+canon-log fiction-only loads. This module covers:
+
+- `book_category` exposure on the brief
+- `characters_present` payload differs per category (memoir surfaces
+  relationship + person_category + consent_status + anonymization,
+  not role + knowledge + tactical)
+- `consent_status_warnings` populated for memoir scenes
+- Fiction brief unchanged — regression guard for the historical shape
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.state.chapter_writing_brief import build_chapter_writing_brief
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_memoir_book(tmp_path: Path, *, category: str = "memoir") -> tuple[Path, Path]:
+    """Create a minimal memoir scaffold and return (book_root, plugin_root)."""
+    book = tmp_path / "test-memoir"
+    (book / "chapters").mkdir(parents=True)
+    (book / "people").mkdir()
+    (book / "plot").mkdir()
+    (book / "README.md").write_text(
+        f'---\ntitle: "Test Memoir"\nbook_category: "{category}"\n---\n\n# Test Memoir\n',
+        encoding="utf-8",
+    )
+    return book, Path(__file__).resolve().parent.parent
+
+
+def _make_fiction_book(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a minimal fiction scaffold."""
+    book = tmp_path / "test-fiction"
+    (book / "chapters").mkdir(parents=True)
+    (book / "characters").mkdir()
+    (book / "plot").mkdir()
+    (book / "world").mkdir()
+    (book / "README.md").write_text(
+        '---\ntitle: "Test Fiction"\nbook_category: "fiction"\n---\n\n# Test Fiction\n',
+        encoding="utf-8",
+    )
+    return book, Path(__file__).resolve().parent.parent
+
+
+def _make_chapter(
+    book: Path,
+    slug: str,
+    *,
+    number: int,
+    title: str,
+    pov: str = "",
+    body: str = "",
+) -> None:
+    chapter = book / "chapters" / slug
+    chapter.mkdir(parents=True)
+    pov_line = f'pov_character: "{pov}"\n' if pov else ""
+    (chapter / "README.md").write_text(
+        "---\n"
+        f'title: "{title}"\n'
+        f"number: {number}\n"
+        f'status: "Draft"\n'
+        f"{pov_line}"
+        "---\n\n"
+        f"# {title}\n\n"
+        f"{body}\n",
+        encoding="utf-8",
+    )
+
+
+def _make_person(
+    book: Path,
+    slug: str,
+    *,
+    name: str,
+    relationship: str = "",
+    person_category: str = "private-living-person",
+    consent_status: str = "pending",
+    anonymization: str = "none",
+) -> None:
+    text = (
+        "---\n"
+        f'name: "{name}"\n'
+        f'relationship: "{relationship}"\n'
+        f'person_category: "{person_category}"\n'
+        f'consent_status: "{consent_status}"\n'
+        f'anonymization: "{anonymization}"\n'
+        "---\n\n"
+        f"# {name}\n"
+    )
+    (book / "people" / f"{slug}.md").write_text(text, encoding="utf-8")
+
+
+def _make_character(
+    book: Path,
+    slug: str,
+    *,
+    name: str,
+    role: str = "supporting",
+) -> None:
+    text = (
+        "---\n"
+        f'name: "{name}"\n'
+        f'role: "{role}"\n'
+        "---\n\n"
+        f"# {name}\n"
+    )
+    (book / "characters" / f"{slug}.md").write_text(text, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# book_category exposure
+# ---------------------------------------------------------------------------
+
+
+class TestBookCategoryExposure:
+    """The brief surfaces book_category so the skill can branch."""
+
+    def test_memoir_book_category_exposed(self, tmp_path: Path):
+        book, plugin_root = _make_memoir_book(tmp_path)
+        _make_chapter(book, "01-opening", number=1, title="Opening")
+
+        brief = build_chapter_writing_brief(
+            book_root=book,
+            book_slug="test-memoir",
+            chapter_slug="01-opening",
+            plugin_root=plugin_root,
+        )
+        assert brief["book_category"] == "memoir"
+
+    def test_fiction_book_category_exposed(self, tmp_path: Path):
+        book, plugin_root = _make_fiction_book(tmp_path)
+        _make_chapter(book, "01-opening", number=1, title="Opening")
+
+        brief = build_chapter_writing_brief(
+            book_root=book,
+            book_slug="test-fiction",
+            chapter_slug="01-opening",
+            plugin_root=plugin_root,
+        )
+        assert brief["book_category"] == "fiction"
+
+    def test_legacy_book_without_category_defaults_to_fiction(self, tmp_path: Path):
+        # Books written before #54 have no book_category. The brief must
+        # default to fiction so the historical writing flow stays intact.
+        book = tmp_path / "legacy"
+        (book / "chapters").mkdir(parents=True)
+        (book / "characters").mkdir()
+        (book / "plot").mkdir()
+        (book / "world").mkdir()
+        (book / "README.md").write_text(
+            '---\ntitle: "Legacy"\n---\n\n# Legacy\n', encoding="utf-8"
+        )
+        _make_chapter(book, "01-opening", number=1, title="Opening")
+
+        brief = build_chapter_writing_brief(
+            book_root=book,
+            book_slug="legacy",
+            chapter_slug="01-opening",
+            plugin_root=Path(__file__).resolve().parent.parent,
+        )
+        assert brief["book_category"] == "fiction"
+
+
+# ---------------------------------------------------------------------------
+# characters_present payload differs per category
+# ---------------------------------------------------------------------------
+
+
+class TestCharactersPresentBranching:
+    """Memoir loads people/ with the ethics schema; fiction loads characters/."""
+
+    def test_memoir_loads_people_not_characters(self, tmp_path: Path):
+        book, plugin_root = _make_memoir_book(tmp_path)
+        _make_person(
+            book,
+            "maria",
+            name="Maria",
+            relationship="sister",
+            person_category="private-living-person",
+            consent_status="confirmed-consent",
+        )
+        # Even if a stray characters/ directory exists, people/ wins for memoir.
+        (book / "characters").mkdir(exist_ok=True)
+        _make_chapter(
+            book,
+            "01-opening",
+            number=1,
+            title="Opening",
+            pov="Maria",
+            body="Maria walked through the kitchen.",
+        )
+
+        brief = build_chapter_writing_brief(
+            book_root=book,
+            book_slug="test-memoir",
+            chapter_slug="01-opening",
+            plugin_root=plugin_root,
+        )
+        people = brief["characters_present"]
+        assert len(people) == 1
+        person = people[0]
+        # Memoir schema fields surface
+        assert person["name"] == "Maria"
+        assert person["relationship"] == "sister"
+        assert person["person_category"] == "private-living-person"
+        assert person["consent_status"] == "confirmed-consent"
+        assert person["anonymization"] == "none"
+        # Fiction-only fields absent
+        assert "role" not in person
+
+    def test_fiction_loads_characters_with_role(self, tmp_path: Path):
+        book, plugin_root = _make_fiction_book(tmp_path)
+        _make_character(book, "alex", name="Alex", role="protagonist")
+        _make_chapter(
+            book,
+            "01-opening",
+            number=1,
+            title="Opening",
+            pov="Alex",
+            body="Alex stepped into the alley.",
+        )
+
+        brief = build_chapter_writing_brief(
+            book_root=book,
+            book_slug="test-fiction",
+            chapter_slug="01-opening",
+            plugin_root=plugin_root,
+        )
+        chars = brief["characters_present"]
+        assert len(chars) == 1
+        char = chars[0]
+        # Fiction schema fields surface
+        assert char["name"] == "Alex"
+        assert char["role"] == "protagonist"
+        # Memoir-only fields absent
+        assert "consent_status" not in char
+        assert "person_category" not in char
+
+    def test_memoir_real_name_excluded_from_brief(self, tmp_path: Path):
+        # real_name is private — it stays in the people file, never on the
+        # brief that chapter-writer reads. Pseudonymized portrayals must
+        # not leak the real name into the writing context.
+        book, plugin_root = _make_memoir_book(tmp_path)
+        person_path = book / "people" / "the-doctor.md"
+        person_path.write_text(
+            "---\n"
+            'name: "The doctor"\n'
+            'relationship: "diagnosing physician"\n'
+            'person_category: "anonymized-or-composite"\n'
+            'consent_status: "not-asking"\n'
+            'anonymization: "pseudonym"\n'
+            'real_name: "Dr. Henrik Lassen"\n'
+            "---\n# The doctor\n",
+            encoding="utf-8",
+        )
+        _make_chapter(
+            book,
+            "01-diagnosis",
+            number=1,
+            title="Diagnosis",
+            pov="The doctor",
+            body="The doctor sat across from her.",
+        )
+
+        brief = build_chapter_writing_brief(
+            book_root=book,
+            book_slug="test-memoir",
+            chapter_slug="01-diagnosis",
+            plugin_root=plugin_root,
+        )
+        person = brief["characters_present"][0]
+        assert "real_name" not in person
+
+
+# ---------------------------------------------------------------------------
+# consent_status_warnings for memoir
+# ---------------------------------------------------------------------------
+
+
+class TestConsentStatusWarnings:
+    """The brief surfaces consent issues before drafting any memoir scene."""
+
+    def test_pending_consent_produces_warning(self, tmp_path: Path):
+        book, plugin_root = _make_memoir_book(tmp_path)
+        _make_person(
+            book,
+            "maria",
+            name="Maria",
+            relationship="sister",
+            consent_status="pending",
+        )
+        _make_chapter(
+            book,
+            "01-opening",
+            number=1,
+            title="Opening",
+            pov="Maria",
+            body="Maria sits across the table.",
+        )
+
+        brief = build_chapter_writing_brief(
+            book_root=book,
+            book_slug="test-memoir",
+            chapter_slug="01-opening",
+            plugin_root=plugin_root,
+        )
+        warnings = brief["consent_status_warnings"]
+        assert len(warnings) == 1
+        assert warnings[0]["tier"] == "pending"
+        assert warnings[0]["person"] == "Maria"
+
+    def test_refused_consent_produces_warning(self, tmp_path: Path):
+        book, plugin_root = _make_memoir_book(tmp_path)
+        _make_person(
+            book,
+            "the-ex",
+            name="Daniel",
+            relationship="ex-partner",
+            consent_status="refused",
+        )
+        _make_chapter(
+            book,
+            "02-disclosure",
+            number=2,
+            title="Disclosure",
+            pov="Daniel",
+            body="Daniel comes to the door.",
+        )
+
+        brief = build_chapter_writing_brief(
+            book_root=book,
+            book_slug="test-memoir",
+            chapter_slug="02-disclosure",
+            plugin_root=plugin_root,
+        )
+        warnings = brief["consent_status_warnings"]
+        assert any(w["tier"] == "refused" for w in warnings)
+
+    def test_missing_consent_produces_warning(self, tmp_path: Path):
+        # Person file with no consent_status — the user has not yet decided.
+        book, plugin_root = _make_memoir_book(tmp_path)
+        person_path = book / "people" / "anonymous.md"
+        person_path.write_text(
+            "---\n"
+            'name: "Anonymous"\n'
+            'relationship: "neighbor"\n'
+            'person_category: "private-living-person"\n'
+            "---\n# Anonymous\n",
+            encoding="utf-8",
+        )
+        _make_chapter(
+            book,
+            "03-encounter",
+            number=3,
+            title="Encounter",
+            pov="Anonymous",
+            body="Anonymous waved from the porch.",
+        )
+
+        brief = build_chapter_writing_brief(
+            book_root=book,
+            book_slug="test-memoir",
+            chapter_slug="03-encounter",
+            plugin_root=plugin_root,
+        )
+        warnings = brief["consent_status_warnings"]
+        assert any(w["tier"] == "missing" for w in warnings)
+
+    def test_confirmed_consent_produces_no_warning(self, tmp_path: Path):
+        book, plugin_root = _make_memoir_book(tmp_path)
+        _make_person(
+            book,
+            "father",
+            name="Father",
+            relationship="father",
+            consent_status="confirmed-consent",
+        )
+        _make_person(
+            book,
+            "uncle",
+            name="Uncle",
+            relationship="uncle",
+            person_category="deceased",
+            consent_status="not-required",
+        )
+        _make_chapter(
+            book,
+            "04-family",
+            number=4,
+            title="Family",
+            pov="Father",
+            body="Father and Uncle were close once.",
+        )
+
+        brief = build_chapter_writing_brief(
+            book_root=book,
+            book_slug="test-memoir",
+            chapter_slug="04-family",
+            plugin_root=plugin_root,
+        )
+        assert brief["consent_status_warnings"] == []
+
+    def test_fiction_brief_has_no_consent_warnings(self, tmp_path: Path):
+        # Regression guard — fiction never populates consent_status_warnings.
+        book, plugin_root = _make_fiction_book(tmp_path)
+        _make_character(book, "alex", name="Alex", role="protagonist")
+        _make_chapter(
+            book, "01-opening", number=1, title="Opening", pov="Alex",
+            body="Alex stood at the door.",
+        )
+
+        brief = build_chapter_writing_brief(
+            book_root=book,
+            book_slug="test-fiction",
+            chapter_slug="01-opening",
+            plugin_root=plugin_root,
+        )
+        assert brief["consent_status_warnings"] == []

--- a/tools/state/chapter_writing_brief.py
+++ b/tools/state/chapter_writing_brief.py
@@ -31,7 +31,7 @@ from tools.analysis.tactical_checker import (
     load_tactical_profiles,
     analyze_tactical_setup,
 )
-from tools.shared.paths import slugify
+from tools.shared.paths import resolve_people_dir, slugify
 from tools.state.chapter_timeline_parser import get_recent_chapter_timelines
 from tools.state.parsers import parse_chapter_readme, parse_frontmatter
 from tools.timeline_anchor import get_story_anchor
@@ -249,6 +249,81 @@ def _character_payload(path: Path) -> dict[str, Any]:
     return payload
 
 
+# Path E #57: memoir mode pulls real-people profiles (not character profiles)
+# from `people/`. The schema is different — no role/knowledge/tactical;
+# instead relationship + person_category + consent_status + anonymization.
+# Surfaced separately so chapter-writer can apply ethics-aware drafting.
+
+def _person_payload(path: Path) -> dict[str, Any]:
+    """Full real-person payload for memoir mode.
+
+    Shape mirrors what `parse_person_file` returns. The brief consumer
+    (chapter-writer in memoir mode) reads `consent_status` and surfaces
+    a warning before drafting any scene with a `pending` or `refused`
+    person. `real_name` is intentionally excluded — it stays private to
+    the people file and never enters the writing brief.
+    """
+    text = path.read_text(encoding="utf-8")
+    meta, _body = parse_frontmatter(text)
+    return {
+        "slug": path.stem,
+        "name": str(meta.get("name", path.stem)),
+        "relationship": str(meta.get("relationship", "")),
+        "person_category": str(meta.get("person_category", "")),
+        "consent_status": str(meta.get("consent_status", "")),
+        "anonymization": str(meta.get("anonymization", "none")),
+        "description": str(meta.get("description", "")),
+    }
+
+
+def _consent_status_warnings(people: list[dict[str, Any]]) -> list[dict[str, str]]:
+    """Surface consent issues for memoir scenes (Path E #57).
+
+    Three warning tiers:
+      - missing  — no consent_status set; user must decide before drafting
+      - pending  — consent intended but not yet asked; flag if scene is
+                   sensitive
+      - refused  — consent was refused; the person should be cut,
+                   anonymized, or re-framed before this scene drafts
+
+    Confirmed-consent / not-required / not-asking statuses produce no
+    warning. The skill consumes the full list; an empty list means the
+    chapter passes the consent gate.
+    """
+    warnings: list[dict[str, str]] = []
+    for person in people:
+        status = str(person.get("consent_status", "")).strip()
+        if not status:
+            warnings.append({
+                "person": person.get("name", person.get("slug", "")),
+                "tier": "missing",
+                "message": (
+                    "consent_status is unset — decide before drafting any "
+                    "scene with this person on the page."
+                ),
+            })
+        elif status == "pending":
+            warnings.append({
+                "person": person.get("name", person.get("slug", "")),
+                "tier": "pending",
+                "message": (
+                    "consent_status is pending — drafting is allowed, "
+                    "but the request must happen before publication."
+                ),
+            })
+        elif status == "refused":
+            warnings.append({
+                "person": person.get("name", person.get("slug", "")),
+                "tier": "refused",
+                "message": (
+                    "consent_status is refused — cut the scene, "
+                    "anonymize the portrayal, or re-frame from a different "
+                    "angle before drafting."
+                ),
+            })
+    return warnings
+
+
 # ---------------------------------------------------------------------------
 # Public assembler
 # ---------------------------------------------------------------------------
@@ -310,10 +385,38 @@ def build_chapter_writing_brief(
             except ValueError:
                 pass
 
-    # ----- characters present ---------------------------------------------
+    # ----- book category --------------------------------------------------
+    # Path E #57: chapter-writer behavior branches on book_category. The
+    # field lives in the book's README frontmatter; missing defaults to
+    # fiction (legacy books pre-#54).
+    book_category = "fiction"
+    book_readme = book_root / "README.md"
+    if book_readme.is_file():
+        book_text = recorder.run(
+            "book.read",
+            lambda: book_readme.read_text(encoding="utf-8"),
+            "",
+        )
+        if book_text:
+            book_meta, _ = parse_frontmatter(book_text)
+            book_category = str(book_meta.get("book_category", "fiction"))
+
+    is_memoir = book_category == "memoir"
+
+    # ----- characters / people present -------------------------------------
+    # Memoir books look in `people/` (with `characters/` fallback for
+    # legacy memoir books written before #59). Fiction stays at
+    # `characters/`. The same `characters_present` key carries both —
+    # consumers branch on `book_category` from the brief.
     characters: list[dict[str, Any]] = []
-    chars_dir = book_root / "characters"
+    consent_warnings: list[dict[str, str]] = []
+    chars_dir = (
+        resolve_people_dir(book_root, book_category) if is_memoir
+        else book_root / "characters"
+    )
     pov_added = False
+
+    payload_loader = _person_payload if is_memoir else _character_payload
 
     if pov_character:
         pov_slug = slugify(pov_character)
@@ -321,7 +424,7 @@ def build_chapter_writing_brief(
         if pov_path.is_file():
             payload = recorder.run(
                 "characters.pov",
-                lambda: _character_payload(pov_path),
+                lambda: payload_loader(pov_path),
                 None,
             )
             if payload:
@@ -350,11 +453,21 @@ def build_chapter_writing_brief(
             continue
         payload = recorder.run(
             f"characters.{slug}",
-            lambda p=path: _character_payload(p),
+            lambda p=path: payload_loader(p),
             None,
         )
         if payload:
             characters.append(payload)
+
+    # Memoir consent gate: surface any present-in-scene people whose
+    # consent_status is missing, pending, or refused. The skill must
+    # show these warnings to the user before drafting.
+    if is_memoir:
+        consent_warnings = recorder.run(
+            "consent_status_warnings",
+            lambda: _consent_status_warnings(characters),
+            [],
+        )
 
     # ----- story anchor ---------------------------------------------------
     story_anchor = recorder.run(
@@ -473,6 +586,7 @@ def build_chapter_writing_brief(
 
     return {
         "book_slug": book_slug,
+        "book_category": book_category,
         "chapter_slug": chapter_slug,
         "chapter": _serialize_chapter_meta(chapter_meta),
         "pov_character": pov_character,
@@ -480,6 +594,7 @@ def build_chapter_writing_brief(
         "recent_chapter_timelines": recent_timelines,
         "recent_chapter_endings": recent_endings,
         "characters_present": characters,
+        "consent_status_warnings": consent_warnings,
         "rules_to_honor": rules_to_honor,
         "callbacks_in_register": callbacks_in_register,
         "banned_phrases": banned_phrases,


### PR DESCRIPTION
## Summary

**Closes Phase 2 of the Memoir epic (#97).** Branches `chapter-writer` on `book_category` so memoir books run a distinct flow with the four-category ethics schema, structure-type-aware prerequisites, and the felt-sense / emotional-truth craft.

**Brief layer** (`tools/state/chapter_writing_brief.py`):

- Reads `book_category` from the book README and surfaces it on the brief — chapter-writer branches without a second tool call.
- Memoir books load `people/` instead of `characters/` (with a `characters/` fallback for legacy memoir books written before #59), using a new `_person_payload` that exposes relationship, person_category, consent_status, anonymization. **`real_name` is intentionally excluded** from the brief — it stays private to the people file, never enters the writing context.
- New **`consent_status_warnings`** field enumerates any person in the chapter whose consent_status is `missing` / `pending` / `refused`. Confirmed-consent / not-required / not-asking produce no warning. Fiction books always get an empty list.

**Skill layer** (`skills/chapter-writer/SKILL.md`):

- Step 0 resolves `book_category` from the brief.
- Prerequisites split per category. Fiction: genre craft + `world/setting.md` (Travel Matrix) + `plot/canon-log.md`. Memoir: `book_categories/memoir/craft/{scene-vs-summary, emotional-truth, real-people-ethics, memoir-anti-ai-patterns}.md` + `plot/structure.md` (structure_type from #58) + `plot/people-log.md`.
- Step 7 (Save and Update) branches: fiction updates Travel Matrix + canon-log; memoir updates people-log and routes new place names to `research/sources.md`.
- New memoir rules: consent gate (refused halts drafting), real-name discipline, scene-vs-summary, emotional-truth standard, no invented details, no tidy lessons, genre-as-theme reframe.

Closes #57. **Phase 2 (#57, #58, #59, #60, #63) of #97 complete.**

## Acceptance from #57

- [x] chapter-writer respects `book_category` (Step 0 resolves it; prerequisites + Save step branch on it)
- [x] Memoir-mode loads correct craft and people-log (memoir craft files + `plot/people-log.md` instead of canon-log)
- [x] Fiction-mode unchanged (regression-guarded by full pytest suite + new memoir tests confirming fiction brief shape preserved)
- [x] Tests for both modes (11 new in `test_chapter_writing_brief_memoir.py`)
- [x] No regression in fiction chapter writing (700+ existing tests still pass; `book_category` defaults to fiction for legacy books without the field)

## Test plan

- [ ] `/storyforge:chapter-writer` on a fiction chapter — expect Step 0 confirms fiction, full prerequisites including `world/setting.md` + `canon-log.md`, no consent gate
- [ ] `/storyforge:chapter-writer` on a memoir chapter where all people have `confirmed-consent` — expect memoir mode note, no consent warnings, drafting proceeds
- [ ] `/storyforge:chapter-writer` on a memoir chapter with one person at `pending` — expect warning surfaced, user confirmation required before drafting
- [ ] `/storyforge:chapter-writer` on a memoir chapter with one person at `refused` — expect drafting halted, route back to character-creator
- [ ] On a memoir chapter, verify the brief's `characters_present` payload carries `relationship` / `person_category` / `consent_status` / `anonymization` fields, NOT `role` / `knowledge` / `tactical`
- [ ] On a memoir chapter, verify `real_name` from a pseudonymized person file is **not** in the brief (test asserts this)
- [ ] Existing fiction project (Blood & Binary) — chapter-writer behavior unchanged

## Notes

- The skill explicitly tells the user when memoir mode kicks in, so the category branch is visible — no silent behavior change.
- Memoir's `plot/people-log.md` follows the same lazy-creation pattern as fiction's `plot/canon-log.md` — it's not pre-scaffolded; chapter-writer creates it on first close.
- The consent gate is the central memoir-specific safety check. `refused` is hard — drafting halts. `pending` is soft — user confirms. `missing` is medium — user must decide.
- This PR completes Phase 2 of the memoir epic (#97). Phase 3 (memoir-ethics-checker #65, emotional-truth-prompt #66, manuscript-checker memoir-aware #61, voice-checker memoir-aware #62) is the next implementation layer.

## Quality gates

- pytest: 731 passed (11 new in `test_chapter_writing_brief_memoir.py`)
- ruff: clean