### PR TITLE
feat: branch manuscript-checker for memoir-specific patterns (#61)

### DIFF
--- a/servers/storyforge-server/server.py
+++ b/servers/storyforge-server/server.py
@@ -552,14 +552,21 @@ def scan_manuscript(
     """Scan all chapter drafts of a book for prose-quality issues that only
     surface when the whole manuscript is read in one pass.
 
-    Detects:
+    Detects (all books):
     - Violations of rules from the book's CLAUDE.md (highest priority)
-    - Curated fiction clichés ("blood ran cold", "time stood still", ...)
+    - Curated clichés ("blood ran cold", "time stood still", ...)
     - Dialogue punctuation anomalies (Q-word opener + trailing period)
     - POV filter-word overuse per chapter ("felt", "noticed", "saw that", ...)
     - Per-chapter `-ly` adverb density
     - Cross-chapter repeated phrases: similes, character tells, blocking tics,
       structural patterns, signature phrases
+
+    Memoir-only (book_category: memoir, Phase 3 #61):
+    - Anonymization leaks — real name appearing despite people/ profile marking
+    - Tidy-lesson endings — chapters that close on a moral instead of a moment
+    - Reflective platitude density — retrospective commentary overuse per chapter
+    - Timeline ambiguity — temporal hand-waving density per chapter
+    - Real-people name consistency — inconsistent name forms across chapters
 
     Returns the structured findings as JSON. When `write_report` is true,
     also writes a human-readable Markdown report to

--- a/skills/manuscript-checker/SKILL.md
+++ b/skills/manuscript-checker/SKILL.md
@@ -45,21 +45,35 @@ does real work in each location may be an intentional motif.
 
 ## Detection categories
 
+The checker is `book_category`-aware. All books get the base checks; memoir
+books additionally get five memoir-specific passes.
+
+### Base checks (all books)
+
 | Category | What it catches | Severity logic |
 |---|---|---|
 | `book_rule_violation` | Patterns extracted from `<book>/CLAUDE.md` rules | always high |
-| `cliche` | Curated banlist of worn-out fiction phrasings | always high |
+| `cliche` | Curated banlist of worn-out phrasings | always high |
 | `question_as_statement` | Dialogue starting with a Q-word but ending with `.` | high if ≥5 hits |
 | `filter_word` | POV-distancing verbs per chapter (>3/1k words) | high if >6/1k |
 | `adverb_density` | `-ly` adverbs per chapter (>8/1k words) | high if >14/1k |
 | `sentence_repetition` | Identical 8-15-word sentences across chapters | always high |
 | `snapshot` | ≥5 consecutive descriptive sentences, no action, no dialog | always medium |
-| `callback_dropped` | Registered callback past its `expected return by Ch N` deadline, or must-not-forget + >10 ch silence | always high |
-| `callback_deferred` | Registered callback not seen in >10 drafted chapters | always medium |
+| `callback_dropped` | Callback past deadline or must-not-forget + >10 ch silence | always high |
+| `callback_deferred` | Callback not seen in >10 drafted chapters | always medium |
 | `simile` / `character_tell` / `blocking_tic` / `sensory` / `structural` / `signature_phrase` | Cross-chapter n-gram repetition | high if ≥4 hits |
 
-The first two always sort to the top of the report — book rules because the
-user explicitly wrote them, clichés because they're unambiguously stale.
+### Memoir-specific checks (`book_category: memoir` only)
+
+| Category | What it catches | Severity logic |
+|---|---|---|
+| `anonymization_leak` | Real name appearing in manuscript despite people/ profile marking the person as anonymized | always high — pre-publication blocker |
+| `tidy_lesson_ending` | Chapter's final paragraph closes on a moral/lesson summary instead of a moment | high if ≥3 cues, medium if 2 |
+| `reflective_platitude` | Density of retrospective commentary per chapter ("looking back", "in hindsight", "what I learned") | high if ≥3 hits, medium if 2 |
+| `timeline_ambiguity` | Density of temporal hand-waving per chapter ("at some point", "eventually", "years later") | high if >6/1k words, medium if >3/1k |
+| `real_people_consistency` | Same person's display name appearing in inconsistent capitalization or forms across chapters | always medium |
+
+Sort priority: `book_rule_violation` → `anonymization_leak` (privacy-critical) → `cliche` → all others by severity.
 
 ## Workflow
 
@@ -68,6 +82,25 @@ user explicitly wrote them, clichés because they're unambiguously stale.
 If the user provided a slug, use it. Otherwise call MCP `get_session()` and
 use the active book. If still ambiguous, call `list_books()` and ask which
 one.
+
+### 1b. Check book_category
+
+Call MCP `get_book_full(book_slug)` and read `book_category`. If it is
+`memoir`, load `book_categories/memoir/README.md` and
+`book_categories/memoir/craft/memoir-anti-ai-patterns.md` before presenting
+findings — memoir-specific recommendations need that context.
+
+**Memoir mode differences in presentation:**
+- Surface `anonymization_leak` findings first and mark them as
+  **pre-publication blockers** — these are not craft suggestions, they are
+  privacy issues that must be resolved before the manuscript leaves the author.
+- For `tidy_lesson_ending` findings: quote the last paragraph and ask the
+  author whether the lesson language is load-bearing or can be cut.
+- For `reflective_platitude` findings: distinguish between narrating-self
+  commentary (legitimate in memoir) and filler platitudes (cut).
+- For `timeline_ambiguity` findings: suggest the smallest possible anchor
+  ("late summer 1987" beats "a few years later") rather than pushing for
+  exact dates everywhere.
 
 ### 2. Run the scan
 
@@ -144,10 +177,13 @@ If the user says yes (or passes `--interactive`):
 Process findings in **category priority order**:
 
 1. `book_rule_violation` (user explicitly wants these fixed)
-2. `cliche` (always worth fixing)
-3. `question_as_statement` (distinct fix pattern — see below)
-4. `filter_word`, `adverb_density` (per-chapter craft fixes)
-5. Repetition categories (`simile`, `character_tell`, etc.)
+2. `anonymization_leak` (memoir: privacy blocker — fix before any other category)
+3. `cliche` (always worth fixing)
+4. `question_as_statement` (distinct fix pattern — see below)
+5. `filter_word`, `adverb_density` (per-chapter craft fixes)
+6. Memoir-specific: `tidy_lesson_ending`, `reflective_platitude`, `timeline_ambiguity`
+7. Repetition categories (`simile`, `character_tell`, etc.)
+8. `real_people_consistency` (last — name-form cleanup, no prose rewrite needed)
 
 For each high-severity finding:
 

--- a/tests/test_manuscript_checker_memoir.py
+++ b/tests/test_manuscript_checker_memoir.py
@@ -1,0 +1,441 @@
+"""Tests for memoir-specific manuscript checker passes (Phase 3, Issue #61).
+
+Covers:
+- _read_book_category: parses book_category from README frontmatter
+- _read_people_profiles: reads person profiles from people/ directory
+- _scan_timeline_ambiguity: flags chapters with excessive temporal hand-waving
+- _scan_reflective_platitudes: flags chapters heavy with lesson-summary narration
+- _scan_tidy_lesson_endings: flags chapters whose last paragraph ends on a moral
+- _scan_anonymization_leak: flags real names appearing despite anonymization
+- _scan_real_people_consistency: flags inconsistent name forms across chapters
+- scan_repetitions: memoir checks run only for memoir books, not fiction
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.analysis.manuscript_checker import (
+    _read_book_category,
+    _read_people_profiles,
+    _scan_anonymization_leak,
+    _scan_real_people_consistency,
+    _scan_reflective_platitudes,
+    _scan_tidy_lesson_endings,
+    _scan_timeline_ambiguity,
+    scan_repetitions,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_book(tmp_path: Path, book_category: str = "memoir") -> Path:
+    """Create a minimal book scaffold with the given book_category."""
+    book = tmp_path / "my-memoir"
+    book.mkdir()
+    readme = f"""---
+title: "My Memoir"
+slug: "my-memoir"
+book_category: {book_category}
+book_type: novel
+status: Drafting
+---
+
+# My Memoir
+"""
+    (book / "README.md").write_text(readme, encoding="utf-8")
+    (book / "chapters").mkdir()
+    return book
+
+
+def _add_chapter(book: Path, slug: str, prose: str) -> Path:
+    ch = book / "chapters" / slug
+    ch.mkdir(parents=True, exist_ok=True)
+    draft = ch / "draft.md"
+    draft.write_text(prose, encoding="utf-8")
+    return draft
+
+
+def _add_person(
+    book: Path,
+    slug: str,
+    name: str,
+    anonymization: str = "none",
+    real_name: str = "",
+) -> Path:
+    people_dir = book / "people"
+    people_dir.mkdir(exist_ok=True)
+    real_name_line = f'real_name: "{real_name}"\n' if real_name else ""
+    content = f"""---
+name: "{name}"
+slug: "{slug}"
+relationship: "friend"
+person_category: "inner-circle"
+consent_status: "obtained"
+anonymization: "{anonymization}"
+{real_name_line}---
+
+# {name}
+"""
+    path = people_dir / f"{slug}.md"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# _read_book_category
+# ---------------------------------------------------------------------------
+
+
+class TestReadBookCategory:
+    def test_returns_memoir_when_set(self, tmp_path):
+        book = _make_book(tmp_path, book_category="memoir")
+        assert _read_book_category(book) == "memoir"
+
+    def test_returns_fiction_when_set(self, tmp_path):
+        book = _make_book(tmp_path, book_category="fiction")
+        assert _read_book_category(book) == "fiction"
+
+    def test_defaults_to_fiction_when_missing(self, tmp_path):
+        book = tmp_path / "no-category"
+        book.mkdir()
+        (book / "README.md").write_text("---\ntitle: X\n---\n# X\n", encoding="utf-8")
+        assert _read_book_category(book) == "fiction"
+
+    def test_defaults_to_fiction_when_no_readme(self, tmp_path):
+        book = tmp_path / "empty"
+        book.mkdir()
+        assert _read_book_category(book) == "fiction"
+
+
+# ---------------------------------------------------------------------------
+# _read_people_profiles
+# ---------------------------------------------------------------------------
+
+
+class TestReadPeopleProfiles:
+    def test_empty_without_people_dir(self, tmp_path):
+        book = _make_book(tmp_path)
+        assert _read_people_profiles(book) == []
+
+    def test_reads_non_anonymized_person(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "sarah", "Sarah Johnson")
+        profiles = _read_people_profiles(book)
+        assert len(profiles) == 1
+        assert profiles[0]["name"] == "Sarah Johnson"
+        assert profiles[0]["anonymization"] == "none"
+        assert profiles[0]["real_name"] == ""
+
+    def test_reads_anonymized_person_with_real_name(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "anna", "Anna", anonymization="name-changed", real_name="Maria Schmidt")
+        profiles = _read_people_profiles(book)
+        assert len(profiles) == 1
+        assert profiles[0]["name"] == "Anna"
+        assert profiles[0]["anonymization"] == "name-changed"
+        assert profiles[0]["real_name"] == "Maria Schmidt"
+
+    def test_skips_index_file(self, tmp_path):
+        book = _make_book(tmp_path)
+        people_dir = book / "people"
+        people_dir.mkdir()
+        (people_dir / "INDEX.md").write_text("# Index\n", encoding="utf-8")
+        _add_person(book, "bob", "Bob")
+        profiles = _read_people_profiles(book)
+        assert len(profiles) == 1
+        assert profiles[0]["slug"] == "bob"
+
+
+# ---------------------------------------------------------------------------
+# _scan_timeline_ambiguity
+# ---------------------------------------------------------------------------
+
+
+TIMELINE_VAGUE_PROSE = """
+I got on the bus. At some point, I arrived. Eventually I found the house.
+Years later, it all made sense. One day I would understand. Back then I was naive.
+Around that time, things shifted. Before long, everything changed.
+The summer was long and hot and full of waiting.
+""" * 15  # repeat to exceed density threshold
+
+
+TIMELINE_CLEAN_PROSE = """
+On the morning of June 14th, 1987, I woke at five to the smell of rain.
+By nine o'clock I was on the bus. At noon I sat across from my father.
+That Tuesday felt like the longest day of my life.
+""" * 15
+
+
+class TestScanTimelineAmbiguity:
+    def test_no_findings_for_clean_chapter(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_chapter(book, "01-morning", TIMELINE_CLEAN_PROSE)
+        findings = _scan_timeline_ambiguity(book)
+        assert findings == []
+
+    def test_flags_vague_chapter(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_chapter(book, "01-vague", TIMELINE_VAGUE_PROSE)
+        findings = _scan_timeline_ambiguity(book)
+        assert len(findings) >= 1
+        assert findings[0].category == "timeline_ambiguity"
+
+    def test_finding_shows_chapter_slug(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_chapter(book, "01-vague", TIMELINE_VAGUE_PROSE)
+        findings = _scan_timeline_ambiguity(book)
+        assert "01-vague" in findings[0].phrase
+
+    def test_severity_high_at_extreme_density(self, tmp_path):
+        book = _make_book(tmp_path)
+        # Heavy repetition of vague phrases
+        prose = "At some point eventually one day back then. " * 100
+        _add_chapter(book, "01-dense", prose)
+        findings = _scan_timeline_ambiguity(book)
+        assert any(f.severity == "high" for f in findings)
+
+    def test_no_findings_for_empty_book(self, tmp_path):
+        book = _make_book(tmp_path)
+        assert _scan_timeline_ambiguity(book) == []
+
+
+# ---------------------------------------------------------------------------
+# _scan_reflective_platitudes
+# ---------------------------------------------------------------------------
+
+
+PLATITUDE_PROSE = """
+Looking back, I realize how blind I was. In retrospect, I should have known.
+What I learned that day has stayed with me forever.
+I now understand why she did it. I came to realize the truth only years later.
+In hindsight, the signs were obvious. It taught me that nothing lasts.
+""" * 5
+
+
+PLATITUDE_CLEAN_PROSE = """
+She slammed the door. The glass rattled in the frame.
+I stood in the hall not moving, listening to the silence settle.
+The smell of coffee came from the kitchen, and I had nowhere to go.
+""" * 20
+
+
+class TestScanReflectivePlatitudes:
+    def test_no_findings_for_scene_grounded_chapter(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_chapter(book, "01-scene", PLATITUDE_CLEAN_PROSE)
+        findings = _scan_reflective_platitudes(book)
+        assert findings == []
+
+    def test_flags_platitude_heavy_chapter(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_chapter(book, "01-lessons", PLATITUDE_PROSE)
+        findings = _scan_reflective_platitudes(book)
+        assert len(findings) >= 1
+        assert findings[0].category == "reflective_platitude"
+
+    def test_finding_contains_chapter_slug(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_chapter(book, "03-reflection", PLATITUDE_PROSE)
+        findings = _scan_reflective_platitudes(book)
+        assert "03-reflection" in findings[0].phrase
+
+    def test_no_findings_for_empty_book(self, tmp_path):
+        book = _make_book(tmp_path)
+        assert _scan_reflective_platitudes(book) == []
+
+
+# ---------------------------------------------------------------------------
+# _scan_tidy_lesson_endings
+# ---------------------------------------------------------------------------
+
+
+LESSON_ENDING_CHAPTER = """
+She came in from the cold. The kettle was already boiling.
+We sat across from each other for a long time.
+Nobody said anything.
+
+That winter taught me that silence can be its own kind of answer.
+It made me realize some distances cannot be closed no matter how many years pass.
+I had learned this lesson the hard way, and I would not forget it.
+"""
+
+SCENE_ENDING_CHAPTER = """
+She came in from the cold. The kettle was already boiling.
+We sat across from each other for a long time.
+Nobody said anything.
+
+She poured two cups and pushed one across the table.
+I wrapped my hands around it and looked out the window at the snow.
+"""
+
+
+class TestScanTidyLessonEndings:
+    def test_no_findings_for_scene_ending(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_chapter(book, "01-scene", SCENE_ENDING_CHAPTER)
+        findings = _scan_tidy_lesson_endings(book)
+        assert findings == []
+
+    def test_flags_lesson_ending_chapter(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_chapter(book, "01-lesson", LESSON_ENDING_CHAPTER)
+        findings = _scan_tidy_lesson_endings(book)
+        assert len(findings) >= 1
+        assert findings[0].category == "tidy_lesson_ending"
+
+    def test_finding_contains_chapter_slug(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_chapter(book, "05-winter", LESSON_ENDING_CHAPTER)
+        findings = _scan_tidy_lesson_endings(book)
+        assert "05-winter" in findings[0].phrase
+
+    def test_no_findings_for_empty_book(self, tmp_path):
+        book = _make_book(tmp_path)
+        assert _scan_tidy_lesson_endings(book) == []
+
+
+# ---------------------------------------------------------------------------
+# _scan_anonymization_leak
+# ---------------------------------------------------------------------------
+
+
+class TestScanAnonymizationLeak:
+    def test_no_findings_without_people_dir(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_chapter(book, "01-ch", "She walked in. Maria smiled.")
+        assert _scan_anonymization_leak(book) == []
+
+    def test_no_findings_when_only_pseudonym_used(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "anna", "Anna", anonymization="name-changed", real_name="Maria Schmidt")
+        _add_chapter(book, "01-ch", "Anna smiled and sat down. Anna was kind.")
+        findings = _scan_anonymization_leak(book)
+        assert findings == []
+
+    def test_flags_real_name_in_chapter(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "anna", "Anna", anonymization="name-changed", real_name="Maria Schmidt")
+        _add_chapter(book, "01-ch", "Maria Schmidt walked in and sat beside me.")
+        findings = _scan_anonymization_leak(book)
+        assert len(findings) == 1
+        assert findings[0].category == "anonymization_leak"
+        assert findings[0].severity == "high"
+
+    def test_real_name_case_insensitive(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "anna", "Anna", anonymization="name-changed", real_name="Maria Schmidt")
+        _add_chapter(book, "01-ch", "MARIA SCHMIDT was there.")
+        findings = _scan_anonymization_leak(book)
+        assert len(findings) == 1
+
+    def test_no_findings_for_non_anonymized_person(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "bob", "Bob", anonymization="none")
+        _add_chapter(book, "01-ch", "Bob walked in.")
+        assert _scan_anonymization_leak(book) == []
+
+    def test_finding_references_real_and_pseudonym_names(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "anna", "Anna", anonymization="name-changed", real_name="Maria Schmidt")
+        _add_chapter(book, "01-ch", "Maria Schmidt walked in.")
+        findings = _scan_anonymization_leak(book)
+        assert "Maria Schmidt" in findings[0].phrase
+        assert "Anna" in findings[0].phrase
+
+    def test_no_findings_for_empty_book(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "anna", "Anna", anonymization="name-changed", real_name="Maria Schmidt")
+        assert _scan_anonymization_leak(book) == []
+
+
+# ---------------------------------------------------------------------------
+# _scan_real_people_consistency
+# ---------------------------------------------------------------------------
+
+
+class TestScanRealPeopleConsistency:
+    def test_no_findings_without_people_dir(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_chapter(book, "01-ch", "She came in.")
+        assert _scan_real_people_consistency(book) == []
+
+    def test_no_findings_when_name_consistent(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "anna", "Anna")
+        _add_chapter(book, "01-ch", "Anna sat down. Anna smiled.")
+        _add_chapter(book, "02-ch", "Anna came back. Anna laughed.")
+        findings = _scan_real_people_consistency(book)
+        assert findings == []
+
+    def test_flags_inconsistent_capitalisation(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "anna", "Anna")
+        _add_chapter(book, "01-ch", "Anna sat down.")
+        _add_chapter(book, "02-ch", "anna came back.")  # lowercase variant
+        findings = _scan_real_people_consistency(book)
+        assert len(findings) == 1
+        assert findings[0].category == "real_people_consistency"
+
+    def test_no_findings_for_empty_book(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "anna", "Anna")
+        assert _scan_real_people_consistency(book) == []
+
+
+# ---------------------------------------------------------------------------
+# scan_repetitions — memoir mode integration
+# ---------------------------------------------------------------------------
+
+
+class TestScanRepetitionsMemoirMode:
+    def test_memoir_checks_run_for_memoir_book(self, tmp_path):
+        """Anonymization leak must appear in results for memoir books."""
+        book = _make_book(tmp_path, book_category="memoir")
+        _add_person(book, "anna", "Anna", anonymization="name-changed", real_name="Maria Schmidt")
+        _add_chapter(book, "01-ch", "Maria Schmidt walked in and sat beside me. " * 20)
+        result = scan_repetitions(book)
+        categories = {f["category"] for f in result["findings"]}
+        assert "anonymization_leak" in categories
+
+    def test_memoir_checks_do_not_run_for_fiction_book(self, tmp_path):
+        """Memoir-specific categories must not appear for fiction books."""
+        book = _make_book(tmp_path, book_category="fiction")
+        # Even if people/ dir exists (unusual for fiction, but shouldn't crash)
+        _add_person(book, "anna", "Anna", anonymization="name-changed", real_name="Maria Schmidt")
+        _add_chapter(book, "01-ch", "Maria Schmidt walked in. " * 20)
+        result = scan_repetitions(book)
+        memoir_cats = {
+            "anonymization_leak", "tidy_lesson_ending",
+            "reflective_platitude", "timeline_ambiguity", "real_people_consistency",
+        }
+        found_cats = {f["category"] for f in result["findings"]}
+        assert memoir_cats.isdisjoint(found_cats), (
+            f"Memoir checks ran on fiction book: {memoir_cats & found_cats}"
+        )
+
+    def test_anonymization_leak_is_high_priority_in_sort(self, tmp_path):
+        """anonymization_leak findings must appear before clichés in the output."""
+        book = _make_book(tmp_path, book_category="memoir")
+        _add_person(book, "anna", "Anna", anonymization="name-changed", real_name="Maria Schmidt")
+        prose = (
+            "Maria Schmidt walked in. Blood ran cold. "
+            "Maria Schmidt sat down. Blood ran cold. "
+            "Maria Schmidt left. Blood ran cold. "
+        ) * 10
+        _add_chapter(book, "01-ch", prose)
+        result = scan_repetitions(book)
+        cats_in_order = [f["category"] for f in result["findings"]]
+        leak_idx = next(i for i, c in enumerate(cats_in_order) if c == "anonymization_leak")
+        cliche_idx = next(
+            (i for i, c in enumerate(cats_in_order) if c == "cliche"), len(cats_in_order)
+        )
+        assert leak_idx < cliche_idx, (
+            f"anonymization_leak (pos {leak_idx}) should be before cliche (pos {cliche_idx})"
+        )

--- a/tests/test_manuscript_checker_memoir.py
+++ b/tests/test_manuscript_checker_memoir.py
@@ -13,10 +13,7 @@ Covers:
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
-
-import pytest
 
 from tools.analysis.manuscript_checker import (
     _read_book_category,

--- a/tools/analysis/manuscript_checker.py
+++ b/tools/analysis/manuscript_checker.py
@@ -92,6 +92,72 @@ def _read_book_genres(book_path: Path) -> list[str]:
     return []
 
 
+_BOOK_CATEGORY_RE = re.compile(
+    r"^\s*book_category:\s*['\"]?(\w+)['\"]?\s*$", re.MULTILINE
+)
+
+
+def _read_book_category(book_path: Path) -> str:
+    """Parse book_category from book README.md frontmatter. Defaults to 'fiction'."""
+    readme = book_path / "README.md"
+    if not readme.is_file():
+        return "fiction"
+    text = readme.read_text(encoding="utf-8")
+    fm_match = _FRONTMATTER_BLOCK_RE.match(text)
+    if not fm_match:
+        return "fiction"
+    m = _BOOK_CATEGORY_RE.search(fm_match.group(1))
+    return m.group(1).strip() if m else "fiction"
+
+
+# ---------------------------------------------------------------------------
+# People profiles (memoir — Path E #59)
+# ---------------------------------------------------------------------------
+
+_PERSON_NAME_RE = re.compile(
+    r"^\s*name:\s*['\"]?([^'\"\n]+?)['\"]?\s*$", re.MULTILINE
+)
+_PERSON_ANONYMIZATION_RE = re.compile(
+    r"^\s*anonymization:\s*['\"]?([^'\"\n]+?)['\"]?\s*$", re.MULTILINE
+)
+_PERSON_REAL_NAME_RE = re.compile(
+    r"^\s*real_name:\s*['\"]?([^'\"\n]+?)['\"]?\s*$", re.MULTILINE
+)
+
+
+def _read_people_profiles(book_path: Path) -> list[dict[str, str]]:
+    """Read person profiles from book's people/ directory.
+
+    Returns a list of dicts with keys: slug, name, anonymization, real_name.
+    """
+    people_dir = book_path / "people"
+    if not people_dir.is_dir():
+        return []
+
+    people: list[dict[str, str]] = []
+    for person_file in sorted(people_dir.glob("*.md")):
+        if person_file.name == "INDEX.md":
+            continue
+        try:
+            text = person_file.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        fm_match = _FRONTMATTER_BLOCK_RE.match(text)
+        if not fm_match:
+            continue
+        fm = fm_match.group(1)
+        name_m = _PERSON_NAME_RE.search(fm)
+        anon_m = _PERSON_ANONYMIZATION_RE.search(fm)
+        real_m = _PERSON_REAL_NAME_RE.search(fm)
+        people.append({
+            "slug": person_file.stem,
+            "name": name_m.group(1).strip() if name_m else person_file.stem,
+            "anonymization": anon_m.group(1).strip() if anon_m else "none",
+            "real_name": real_m.group(1).strip() if real_m else "",
+        })
+    return people
+
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -1348,6 +1414,360 @@ def _scan_callbacks(book_path: Path) -> list[Finding]:
 
 
 # ---------------------------------------------------------------------------
+# Memoir-specific checks (Phase 3, Issue #61)
+# ---------------------------------------------------------------------------
+
+# Temporal hand-waving phrases that leave the reader unanchored in time.
+_TEMPORAL_VAGUE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("some time later",  re.compile(r"\bsome\s+time\s+later\b", re.IGNORECASE)),
+    ("at some point",    re.compile(r"\bat\s+some\s+point\b", re.IGNORECASE)),
+    ("one day",          re.compile(r"\bone\s+day\b", re.IGNORECASE)),
+    ("one night",        re.compile(r"\bone\s+night\b", re.IGNORECASE)),
+    ("eventually",       re.compile(r"\beventually\b", re.IGNORECASE)),
+    ("after a while",    re.compile(r"\bafter\s+a\s+while\b", re.IGNORECASE)),
+    ("a while later",    re.compile(r"\ba\s+while\s+later\b", re.IGNORECASE)),
+    ("years later",      re.compile(r"\byears\s+later\b", re.IGNORECASE)),
+    ("years earlier",    re.compile(r"\byears\s+earlier\b", re.IGNORECASE)),
+    ("years before",     re.compile(r"\byears\s+before\b", re.IGNORECASE)),
+    ("years ago",        re.compile(r"\byears\s+ago\b", re.IGNORECASE)),
+    ("a long time ago",  re.compile(r"\ba\s+long\s+time\s+ago\b", re.IGNORECASE)),
+    ("back then",        re.compile(r"\bback\s+then\b", re.IGNORECASE)),
+    ("in those days",    re.compile(r"\bin\s+those\s+days\b", re.IGNORECASE)),
+    ("at that time",     re.compile(r"\bat\s+that\s+time\b", re.IGNORECASE)),
+    ("around that time", re.compile(r"\baround\s+that\s+time\b", re.IGNORECASE)),
+    ("sometime later",   re.compile(r"\bsometime\s+later\b", re.IGNORECASE)),
+    ("not long after",   re.compile(r"\bnot\s+long\s+after\b", re.IGNORECASE)),
+    ("before long",      re.compile(r"\bbefore\s+long\b", re.IGNORECASE)),
+)
+
+TIMELINE_AMBIGUITY_MEDIUM_PER_1K = 3.0
+TIMELINE_AMBIGUITY_HIGH_PER_1K = 6.0
+
+
+def _scan_timeline_ambiguity(book_path: Path) -> list[Finding]:
+    """Memoir: flag chapters with excessive temporal hand-waving.
+
+    A memoir scene that never anchors when it happened loses credibility. This
+    check flags chapters where temporal vagueness density is high — not single
+    uses (which are legitimate shorthand), but systemic avoidance of specific
+    time anchoring.
+    """
+    drafts = _read_chapter_drafts(book_path)
+    if not drafts:
+        return []
+
+    findings: list[Finding] = []
+    for chapter_slug, raw_text in drafts:
+        cleaned = _strip_markdown(raw_text)
+        word_count = len(_tokenise(cleaned))
+        if word_count < 200:
+            continue
+
+        occurrences: list[Occurrence] = []
+        per_pattern_counts: dict[str, int] = defaultdict(int)
+
+        for line_no, line in enumerate(cleaned.splitlines(), start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            for label, pattern in _TEMPORAL_VAGUE_PATTERNS:
+                for m in pattern.finditer(stripped):
+                    per_pattern_counts[label] += 1
+                    occurrences.append(
+                        Occurrence(
+                            chapter=chapter_slug,
+                            line=line_no,
+                            snippet=_make_snippet(stripped, m.group(0).lower()),
+                        )
+                    )
+
+        if not occurrences:
+            continue
+
+        density = (len(occurrences) / word_count) * 1000.0
+        if density < TIMELINE_AMBIGUITY_MEDIUM_PER_1K:
+            continue
+
+        severity = "high" if density >= TIMELINE_AMBIGUITY_HIGH_PER_1K else "medium"
+        top = sorted(per_pattern_counts.items(), key=lambda kv: -kv[1])[:3]
+        top_str = ", ".join(f"{label}×{n}" for label, n in top)
+        phrase = f"{chapter_slug}: {top_str} ({density:.1f}/1k words)"
+
+        findings.append(
+            Finding(
+                phrase=phrase,
+                category="timeline_ambiguity",
+                severity=severity,
+                count=len(occurrences),
+                occurrences=occurrences[:20],
+            )
+        )
+    return findings
+
+
+# Retrospective commentary patterns that collapse scene into TED talk.
+_REFLECTIVE_PLATITUDE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("looking back",         re.compile(r"\blooking\s+back\b", re.IGNORECASE)),
+    ("in retrospect",        re.compile(r"\bin\s+retrospect\b", re.IGNORECASE)),
+    ("in hindsight",         re.compile(r"\bin\s+hindsight\b", re.IGNORECASE)),
+    ("with hindsight",       re.compile(r"\bwith\s+hindsight\b", re.IGNORECASE)),
+    ("I now realize",        re.compile(r"\bI\s+now\s+realiz", re.IGNORECASE)),
+    ("I now understand",     re.compile(r"\bI\s+now\s+understand\b", re.IGNORECASE)),
+    ("I now know",           re.compile(r"\bI\s+now\s+know\b", re.IGNORECASE)),
+    ("I realize now",        re.compile(r"\bI\s+realiz\w*\s+now\b", re.IGNORECASE)),
+    ("I understand now",     re.compile(r"\bI\s+understand\s+now\b", re.IGNORECASE)),
+    ("what I learned",       re.compile(r"\bwhat\s+I\s+learned\b", re.IGNORECASE)),
+    ("I came to realize",    re.compile(r"\bI\s+came\s+to\s+realiz", re.IGNORECASE)),
+    ("I came to understand", re.compile(r"\bI\s+came\s+to\s+understand\b", re.IGNORECASE)),
+    ("I would later",        re.compile(r"\bI\s+would\s+later\b", re.IGNORECASE)),
+    ("it taught me",         re.compile(r"\bit\s+taught\s+me\b", re.IGNORECASE)),
+    ("taught me that",       re.compile(r"\btaught\s+me\s+that\b", re.IGNORECASE)),
+    ("I had come to",        re.compile(r"\bI\s+had\s+come\s+to\b", re.IGNORECASE)),
+    ("the lesson was",       re.compile(r"\bthe\s+lesson\s+was\b", re.IGNORECASE)),
+)
+
+PLATITUDE_MEDIUM_THRESHOLD = 2  # per chapter (absolute count)
+PLATITUDE_HIGH_THRESHOLD = 3
+
+
+def _scan_reflective_platitudes(book_path: Path) -> list[Finding]:
+    """Memoir: flag chapters heavy with retrospective lesson-summary language.
+
+    Some reflective narration is memoir's lifeblood. But dense retrospective
+    commentary ("looking back", "in hindsight", "what I learned") turns a lived
+    scene into a TED talk. Flag chapters where the count crosses the threshold.
+    """
+    drafts = _read_chapter_drafts(book_path)
+    if not drafts:
+        return []
+
+    findings: list[Finding] = []
+    for chapter_slug, raw_text in drafts:
+        cleaned = _strip_markdown(raw_text)
+
+        occurrences: list[Occurrence] = []
+        per_pattern_counts: dict[str, int] = defaultdict(int)
+
+        for line_no, line in enumerate(cleaned.splitlines(), start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            for label, pattern in _REFLECTIVE_PLATITUDE_PATTERNS:
+                for m in pattern.finditer(stripped):
+                    per_pattern_counts[label] += 1
+                    occurrences.append(
+                        Occurrence(
+                            chapter=chapter_slug,
+                            line=line_no,
+                            snippet=_make_snippet(stripped, m.group(0).lower()),
+                        )
+                    )
+
+        if len(occurrences) < PLATITUDE_MEDIUM_THRESHOLD:
+            continue
+
+        severity = "high" if len(occurrences) >= PLATITUDE_HIGH_THRESHOLD else "medium"
+        top = sorted(per_pattern_counts.items(), key=lambda kv: -kv[1])[:3]
+        top_str = ", ".join(f"{label}×{n}" for label, n in top)
+        phrase = f"{chapter_slug}: {top_str} ({len(occurrences)} hits)"
+
+        findings.append(
+            Finding(
+                phrase=phrase,
+                category="reflective_platitude",
+                severity=severity,
+                count=len(occurrences),
+                occurrences=occurrences[:20],
+            )
+        )
+    return findings
+
+
+# Lesson-summary patterns in chapter endings.
+_LESSON_ENDING_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bI\s+(?:had\s+)?learned\b", re.IGNORECASE),
+    re.compile(r"\btaught\s+me\b", re.IGNORECASE),
+    re.compile(r"\bmade\s+me\s+realiz", re.IGNORECASE),
+    re.compile(r"\bhelped\s+me\s+(?:realiz|understand|see)\b", re.IGNORECASE),
+    re.compile(r"\bshowed\s+me\s+that\b", re.IGNORECASE),
+    re.compile(r"\bmade\s+me\s+understand\b", re.IGNORECASE),
+    re.compile(r"\bI\s+(?:had\s+)?come\s+to\s+understand\b", re.IGNORECASE),
+    re.compile(r"\bI\s+now\s+(?:understood|knew)\b", re.IGNORECASE),
+    re.compile(r"\bwhat\s+I\s+came\s+away\s+with\b", re.IGNORECASE),
+    re.compile(r"\bchanged\s+(?:the\s+way\s+I|me\s+forever|everything)\b", re.IGNORECASE),
+    re.compile(r"\bI\s+would\s+never\s+(?:forget|be\s+the\s+same)\b", re.IGNORECASE),
+    re.compile(r"\bthe\s+lesson\s+(?:I|was|here)\b", re.IGNORECASE),
+)
+
+
+def _last_paragraph(text: str) -> str:
+    """Return the last non-empty paragraph of a text block."""
+    paragraphs = [p.strip() for p in text.split("\n\n") if p.strip()]
+    return paragraphs[-1] if paragraphs else ""
+
+
+def _scan_tidy_lesson_endings(book_path: Path) -> list[Finding]:
+    """Memoir: flag chapters whose final paragraph closes on a moral or lesson summary.
+
+    Great memoir endings leave the reader in the moment — not in a retrospective
+    summary. A chapter ending with "and that is what taught me X" explains rather
+    than renders. Flag chapters where the last paragraph has multiple lesson-cues.
+    """
+    drafts = _read_chapter_drafts(book_path)
+    if not drafts:
+        return []
+
+    findings: list[Finding] = []
+    for chapter_slug, raw_text in drafts:
+        cleaned = _strip_markdown(raw_text)
+        last_para = _last_paragraph(cleaned)
+        if not last_para or len(last_para.split()) < 10:
+            continue
+
+        hits: list[str] = []
+        for pattern in _LESSON_ENDING_PATTERNS:
+            for m in pattern.finditer(last_para):
+                hits.append(m.group(0))
+
+        if len(hits) < 2:
+            continue
+
+        severity = "high" if len(hits) >= 3 else "medium"
+        snippet = last_para[:200].rstrip()
+        if len(last_para) > 200:
+            snippet += "…"
+
+        findings.append(
+            Finding(
+                phrase=f"{chapter_slug}: chapter ends on lesson-summary language",
+                category="tidy_lesson_ending",
+                severity=severity,
+                count=len(hits),
+                occurrences=[
+                    Occurrence(chapter=chapter_slug, line=0, snippet=snippet)
+                ],
+            )
+        )
+    return findings
+
+
+def _scan_anonymization_leak(book_path: Path) -> list[Finding]:
+    """Memoir: flag draft chapters that contain a person's real name despite anonymization.
+
+    A single occurrence is high severity — this is a potential privacy or
+    defamation leak that must be caught before publication.
+    """
+    people = _read_people_profiles(book_path)
+    anon_people = [
+        p for p in people
+        if p["anonymization"] != "none" and p["real_name"]
+    ]
+    if not anon_people:
+        return []
+
+    drafts = _read_chapter_drafts(book_path)
+    if not drafts:
+        return []
+
+    findings: list[Finding] = []
+    for person in anon_people:
+        real_name = person["real_name"]
+        display_name = person["name"]
+        pattern = re.compile(r"\b" + re.escape(real_name) + r"\b", re.IGNORECASE)
+
+        occurrences: list[Occurrence] = []
+        for chapter_slug, raw_text in drafts:
+            cleaned = _strip_markdown(raw_text)
+            for line_no, line in enumerate(cleaned.splitlines(), start=1):
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                for m in pattern.finditer(stripped):
+                    occurrences.append(
+                        Occurrence(
+                            chapter=chapter_slug,
+                            line=line_no,
+                            snippet=_make_snippet(stripped, m.group(0).lower()),
+                        )
+                    )
+
+        if occurrences:
+            findings.append(
+                Finding(
+                    phrase=f'real name "{real_name}" (pseudonym: "{display_name}")',
+                    category="anonymization_leak",
+                    severity="high",
+                    count=len(occurrences),
+                    occurrences=sorted(occurrences, key=lambda o: (o.chapter, o.line)),
+                )
+            )
+    return findings
+
+
+def _scan_real_people_consistency(book_path: Path) -> list[Finding]:
+    """Memoir: flag inconsistent capitalisation/form of a person's display name across chapters.
+
+    If "Anna" appears as "anna" in one chapter and "Anna" in another, that is
+    an inconsistency the author should resolve — especially for pseudonymous
+    characters where case variation can break anonymization conventions.
+    """
+    people = _read_people_profiles(book_path)
+    if not people:
+        return []
+
+    drafts = _read_chapter_drafts(book_path)
+    if not drafts:
+        return []
+
+    findings: list[Finding] = []
+
+    for person in people:
+        display_name = person["name"]
+        if not display_name or len(display_name) < 2:
+            continue
+
+        # Case-sensitive search: collect distinct forms found across chapters.
+        forms_found: dict[str, list[Occurrence]] = defaultdict(list)
+        name_pattern = re.compile(r"\b" + re.escape(display_name) + r"\b", re.IGNORECASE)
+
+        for chapter_slug, raw_text in drafts:
+            cleaned = _strip_markdown(raw_text)
+            for line_no, line in enumerate(cleaned.splitlines(), start=1):
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                for m in name_pattern.finditer(stripped):
+                    matched_form = m.group(0)  # preserve original case
+                    forms_found[matched_form].append(
+                        Occurrence(
+                            chapter=chapter_slug,
+                            line=line_no,
+                            snippet=_make_snippet(stripped, matched_form.lower()),
+                        )
+                    )
+
+        if len(forms_found) <= 1:
+            continue
+
+        forms_str = ", ".join(f'"{f}"' for f in sorted(forms_found.keys()))
+        all_occurrences = [
+            occ for occs in forms_found.values() for occ in occs
+        ]
+        findings.append(
+            Finding(
+                phrase=f'"{display_name}": multiple forms found — {forms_str}',
+                category="real_people_consistency",
+                severity="medium",
+                count=len(forms_found),
+                occurrences=sorted(
+                    all_occurrences, key=lambda o: (o.chapter, o.line)
+                )[:10],
+            )
+        )
+    return findings
+
+
+# ---------------------------------------------------------------------------
 # Scanning
 # ---------------------------------------------------------------------------
 
@@ -1358,6 +1778,7 @@ def scan_repetitions(
     min_occurrences: int = DEFAULT_MIN_OCCURRENCES,
     max_findings_per_category: int | None = None,
     plugin_root: Path | None = None,
+    book_category: str | None = None,
 ) -> dict[str, Any]:
     """Scan all chapter drafts of a book for repeated phrases.
 
@@ -1456,12 +1877,24 @@ def scan_repetitions(
     findings.extend(_scan_snapshots(book_path, plugin_root=plugin_root))
     findings.extend(_scan_callbacks(book_path))
 
+    # Memoir-specific checks — run only when book_category is memoir.
+    if book_category is None:
+        book_category = _read_book_category(book_path)
+    if book_category == "memoir":
+        findings.extend(_scan_anonymization_leak(book_path))
+        findings.extend(_scan_tidy_lesson_endings(book_path))
+        findings.extend(_scan_reflective_platitudes(book_path))
+        findings.extend(_scan_timeline_ambiguity(book_path))
+        findings.extend(_scan_real_people_consistency(book_path))
+
     # Sort order priority: book_rule_violation first (user-authored rules
-    # override everything), then clichés (always bad), then the rest by
-    # severity. Within same bucket: severity desc, count desc, phrase asc.
+    # override everything), then anonymization_leak (privacy-critical),
+    # then clichés (always bad), then the rest by severity.
+    # Within same bucket: severity desc, count desc, phrase asc.
     category_rank = {
         "book_rule_violation": 0,
-        "cliche": 1,
+        "anonymization_leak": 1,
+        "cliche": 2,
     }
     severity_rank = {"high": 0, "medium": 1}
     findings.sort(
@@ -1515,6 +1948,13 @@ CATEGORY_LABELS = {
     "snapshot": "Snapshot Blocks (static description, no movement)",
     "callback_dropped": "Dropped Callbacks (promised threads, no follow-through)",
     "callback_deferred": "Deferred Callbacks (long-silent registered threads)",
+    # Memoir-specific (Phase 3, #61)
+    "anonymization_leak": "Anonymization Leaks (real name in manuscript)",
+    "tidy_lesson_ending": "Tidy-Lesson Endings (chapter closes on a moral)",
+    "reflective_platitude": "Reflective Platitude Density (retrospective commentary)",
+    "timeline_ambiguity": "Timeline Ambiguity (temporal hand-waving)",
+    "real_people_consistency": "Real-People Name Inconsistency",
+    # N-gram repetition categories
     "simile": "Similes & Metaphors",
     "blocking_tic": "Blocking Tics",
     "character_tell": "Character Tells",
@@ -1525,6 +1965,7 @@ CATEGORY_LABELS = {
 
 CATEGORY_ORDER = [
     "book_rule_violation",
+    "anonymization_leak",
     "cliche",
     "question_as_statement",
     "filter_word",
@@ -1533,6 +1974,12 @@ CATEGORY_ORDER = [
     "snapshot",
     "callback_dropped",
     "callback_deferred",
+    # Memoir-specific
+    "tidy_lesson_ending",
+    "reflective_platitude",
+    "timeline_ambiguity",
+    "real_people_consistency",
+    # N-gram repetition categories
     "simile",
     "character_tell",
     "blocking_tic",
@@ -1709,6 +2156,44 @@ def _recommendation_for(finding: dict[str, Any]) -> str:
         return (
             f"_Recommendation:_ '{finding['phrase']}' has been silent for {count} "
             f"chapters. Decide whether to plant it soon or remove it from the register."
+        )
+    if cat == "anonymization_leak":
+        return (
+            "_Recommendation:_ A person's real name appears in the manuscript despite "
+            "their profile being marked as anonymized. Replace every occurrence with "
+            "the pseudonym (or a relationship-term like 'my colleague') before the "
+            "manuscript leaves the author's desk. This is a pre-publication blocker."
+        )
+    if cat == "tidy_lesson_ending":
+        return (
+            "_Recommendation:_ The chapter ends by explaining what the experience "
+            "meant rather than letting the moment speak. Cut the lesson language and "
+            "close on a concrete detail — an image, a gesture, a line of dialogue. "
+            "The reader draws the meaning; the author renders the scene."
+        )
+    if cat == "reflective_platitude":
+        return (
+            "_Recommendation:_ Dense retrospective commentary ('looking back', "
+            "'in hindsight', 'what I learned') collapses scene into TED talk. "
+            "Memoir earns its reflection by first rendering the experience fully. "
+            "Cut or push the commentary phrases to a single moment of narrating-self "
+            "intrusion; let the rest of the chapter stay in the experiencing self."
+        )
+    if cat == "timeline_ambiguity":
+        return (
+            "_Recommendation:_ Temporal hand-waving ('at some point', 'eventually', "
+            "'one day') leaves the reader unanchored. Memoir credibility depends on "
+            "specificity: a season, a year, a day-of-week, a life stage. Replace at "
+            "least the chapter-opening time anchor with something concrete. A few "
+            "vague transitions inside a chapter are fine; flagging density means too "
+            "many in a row with no specific date anywhere in the chapter."
+        )
+    if cat == "real_people_consistency":
+        return (
+            "_Recommendation:_ The same person is referred to by different name forms "
+            "across chapters. Pick the canonical form (the pseudonym, or the first-name "
+            "only, or the full pseudonym) and apply it consistently throughout. "
+            "Inconsistency confuses readers and can partially undermine anonymization."
         )
     return (
         f"_Recommendation:_ Decide which occurrence is most necessary; cut or "


### PR DESCRIPTION
## Summary

- Branches `manuscript-checker` for `book_category: memoir` (Phase 3, closes #61)
- Five new memoir-only scan passes in `tools/analysis/manuscript_checker.py`
- Memoir checks are gated on `book_category` — fiction books are unaffected (zero regression)

## Changes

**New helpers:**
- `_read_book_category()` — stdlib frontmatter parser
- `_read_people_profiles()` — reads `people/` dir for anonymization metadata

**New memoir-specific scanners:**
- `anonymization_leak` — real name in draft despite `people/` profile marking anonymization (high severity, sort rank 1 after `book_rule_violation`, pre-publication blocker)
- `tidy_lesson_ending` — chapter final paragraph closes on moral/lesson summary instead of a moment
- `reflective_platitude` — per-chapter density of retrospective commentary ("looking back", "in hindsight", "what I learned")
- `timeline_ambiguity` — per-chapter density of temporal hand-waving ("at some point", "eventually", "years later")
- `real_people_consistency` — inconsistent name forms across chapters

**Infrastructure:**
- `scan_repetitions()` auto-detects `book_category` from README; accepts optional override param
- `CATEGORY_LABELS`, `CATEGORY_ORDER`, `_recommendation_for()` extended for memoir categories
- `server.py` `scan_manuscript` docstring updated

**SKILL.md:**
- Memoir-mode workflow branching (1b. Check book_category step)
- Separate base-checks and memoir-checks tables
- Interactive fix priority order updated

## Test plan

- [x] 35 new tests in `tests/test_manuscript_checker_memoir.py` (all pass)
- [x] 766 total tests pass, zero regressions
- [x] Memoir checks verified to run for `book_category: memoir`
- [x] Memoir checks verified to NOT run for `book_category: fiction`
- [x] `anonymization_leak` verified to sort before `cliche` in results