### PR TITLE
feat: memoir-ethics-checker skill (Phase 3 #65)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Phase 1 (#54–#56, #67) adds the field plus knowledge scaffold. Skill branching
 | "promote rule" / "rule global machen" / "Regel hochstufen" / "promote to author" / "promote to global" | `/storyforge:promote-rule` |
 | "Recherche" / "Research" | `/storyforge:researcher` |
 | "Sensitivity" / "Problematisch?" | `/storyforge:sensitivity-reader` |
+| "Ethics check" / "Consent check" / "Einwilligungen prüfen" / "Personen prüfen" | `/storyforge:memoir-ethics-checker` (memoir only) |
 | "Export" / "EPUB" / "PDF" / "MOBI" | `/storyforge:export-engineer` |
 | "Übersetzen" / "Translate" | `/storyforge:translator` |
 | "Cover" / "Buchcover" | `/storyforge:cover-artist` |
@@ -141,9 +142,12 @@ Memoir-aware skills already wired:
 - `/storyforge:plot-architect` (memoir mode) — narrative-arc shaping; user picks one of four structure types (chronological / thematic / braided / vignette), persisted via `set_memoir_structure_type`; chapter spine, timeline anchor, and tonal document still apply (Issue #58)
 - `/storyforge:chapter-writer` (memoir mode) — loads memoir craft (scene-vs-summary, emotional-truth, real-people-ethics, memoir-anti-ai-patterns); reads `book_category` + `consent_status_warnings` from the brief; surfaces consent gates for refused/pending/missing status before drafting; closes chapters into `plot/people-log.md` instead of `plot/canon-log.md`; skips `world/setting.md` (no Travel Matrix) and genre-as-plot-contract loads (Issue #57)
 
+Memoir-specific skills now wired (Phase 3):
+
+- `/storyforge:memoir-ethics-checker` — consent/defamation/anonymization scan; calls `check_memoir_consent` MCP tool; export-engineer runs this as Step 0 for memoir books; hard-fails when any person has `consent_status: refused` (Issue #65)
+
 The forthcoming memoir-specific routing (not yet wired):
 
-- `/storyforge:memoir-ethics-checker` — consent/defamation/anonymization scan (Issue #65)
 - `/storyforge:emotional-truth-prompt` — render-the-felt-sense pass (Issue #66)
 
 Until those land, when working on a memoir book, manually load `book_categories/memoir/README.md` and the relevant `craft/` files at the start of any creative skill.
@@ -217,7 +221,7 @@ Concept → Profile → Backstory → Arc Defined → Final
 
 ### Memoir status interpretation
 
-The book status sequence is **identical** for `book_category: memoir`. Several stages carry shifted intent (e.g., `Plot Outlined` = narrative arc identified; `Characters Created` = people profiles drafted with consent decisions). Phase 3 quality gates (consent verification, emotional-truth pass) are documented in `book_categories/memoir/status-model.md` and will be enforced by `memoir-ethics-checker` (#65) once Phase 3 lands.
+The book status sequence is **identical** for `book_category: memoir`. Several stages carry shifted intent (e.g., `Plot Outlined` = narrative arc identified; `Characters Created` = people profiles drafted with consent decisions). Phase 3 quality gates (consent verification, emotional-truth pass) are documented in `book_categories/memoir/status-model.md`. `memoir-ethics-checker` (#65) enforces the consent gate; `emotional-truth-prompt` (#66) enforces the felt-sense pass (forthcoming).
 
 ## Author Profiles
 
@@ -277,7 +281,7 @@ Skills MUST load relevant craft references before generating creative content. U
 17. ALWAYS load the book's `CLAUDE.md` via MCP `get_book_claudemd()` before writing or reviewing a chapter — it contains persisted workflow rules and callbacks that survive session compaction
 18. Prefix grammar for persistence: messages starting with `Regel:`, `Workflow:`, or `Callback:` are extracted by the PreCompact hook and written to the book's CLAUDE.md. Unprefixed messages are never persisted automatically.
 19. **ALWAYS `Read` the full file when processing review comments** (GH#27). When the user signals that review comments (`{review_handle}:` blocks) are ready, call the `Read` tool on the full file first. The file-change `system-reminder` diff is truncated for long files — end-of-file comments get silently dropped. After reading, count the comments you see and report the count; re-read if the count mismatches expectation.
-20. **ALWAYS check `book_category` before creative work on a book** (Path E #54/#67). Read it from `get_book_full(slug).book_category`. For `memoir`, additionally load `book_categories/memoir/README.md` and the relevant `book_categories/memoir/craft/*.md` docs at the start of any creative skill. Phase 1 wires the field but does not yet auto-branch skills — the manual load is the bridge until Phase 2+ ships the automatic routing. For named living people in memoir scenes, surface `consent_status` decisions explicitly (Phase 3 #65 will enforce this automatically).
+20. **ALWAYS check `book_category` before creative work on a book** (Path E #54/#67). Read it from `get_book_full(slug).book_category`. For `memoir`, additionally load `book_categories/memoir/README.md` and the relevant `book_categories/memoir/craft/*.md` docs at the start of any creative skill. Phase 1 wires the field but does not yet auto-branch skills — the manual load is the bridge until Phase 2+ ships the automatic routing. For named living people in memoir scenes, surface `consent_status` decisions explicitly — use `/storyforge:memoir-ethics-checker` to run the full consent scan (Phase 3 #65, now wired).
 
 ## Code Style
 

--- a/servers/storyforge-server/server.py
+++ b/servers/storyforge-server/server.py
@@ -39,6 +39,7 @@ from tools.state.parsers import (
 )
 from tools.analysis.callback_validator import verify_callbacks as _verify_callbacks_impl
 from tools.analysis.manuscript_checker import scan_repetitions, render_report
+from tools.analysis.memoir_ethics import check_consent as _check_consent_impl
 from tools.analysis.timeline_validator import validate_timeline
 from tools.analysis.tactical_checker import (
     verify_tactical_setup as _verify_tactical_setup_impl,
@@ -668,6 +669,45 @@ def verify_callbacks(book_slug: str) -> str:
 
     claudemd_text = claudemd_path.read_text(encoding="utf-8")
     result = _verify_callbacks_impl(book_path, claudemd_text)
+    return json.dumps(result)
+
+
+@mcp.tool()
+def check_memoir_consent(book_slug: str) -> str:
+    """Check consent status and ethics risk for all people in a memoir book.
+
+    Reads every profile in ``people/`` and classifies each person as:
+    - PASS  — confirmed-consent or not-required
+    - WARN  — pending, not-asking, missing or unknown consent_status or
+              person_category (incomplete profile)
+    - FAIL  — refused (person explicitly declined — publication blocked)
+
+    Overall verdict: FAIL beats WARN beats PASS.
+
+    Returns a JSON object with:
+        book_slug    — slug string
+        overall      — "PASS" | "WARN" | "FAIL"
+        people       — per-person list with verdict + reason
+        pass_count   — int
+        warn_count   — int
+        fail_count   — int
+
+    Only runs on memoir books (book_category: memoir). Returns an error
+    for fiction books.
+
+    Args:
+        book_slug: The book project slug.
+    """
+    config = load_config()
+    book_path = resolve_project_path(config, book_slug)
+    if not book_path.exists():
+        return json.dumps({"error": f"Book '{book_slug}' not found at {book_path}"})
+    try:
+        result = _check_consent_impl(book_path)
+    except ValueError as exc:
+        return json.dumps({"error": str(exc), "book_slug": book_slug})
+    except FileNotFoundError as exc:
+        return json.dumps({"error": str(exc), "book_slug": book_slug})
     return json.dumps(result)
 
 

--- a/skills/export-engineer/SKILL.md
+++ b/skills/export-engineer/SKILL.md
@@ -19,6 +19,20 @@ argument-hint: "<book-slug> [format]"
 
 ## Workflow
 
+### Step 0: Memoir consent gate _(memoir books only)_
+
+Call MCP `get_book_full(book_slug)` and read `book_category`.
+
+If `book_category == "memoir"`: call MCP `check_memoir_consent(book_slug)`
+**before** running pre-export gates.
+
+- Overall `FAIL` → **hard stop**. Do not proceed. Tell the user:
+  > Export blocked — at least one person has `consent_status: refused`.
+  > Resolve via `/storyforge:memoir-ethics-checker` before exporting.
+- Overall `WARN` → surface the warnings, ask the user to confirm they want
+  to export anyway. Proceed only on explicit confirmation.
+- Overall `PASS` → continue to Step 1.
+
 ### Step 1: Pre-Flight Check
 Run MCP `run_pre_export_gates()`. If BLOCKED, show the issues and stop.
 If WARN-only, show warnings and ask if user wants to proceed anyway.

--- a/skills/memoir-ethics-checker/SKILL.md
+++ b/skills/memoir-ethics-checker/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: memoir-ethics-checker
+description: |
+  Consent and defamation risk scan for memoir books. Checks every person in
+  people/ against their consent_status and person_category, produces a
+  PASS / WARN / FAIL verdict, and flags anonymization gaps and defamation-risk
+  language patterns in chapter drafts.
+  Use when: (1) User says "ethics check", "consent check", "Einwilligungen prüfen",
+  "Personen prüfen", (2) Before export of a memoir book, (3) After adding new
+  people profiles, (4) During the revision phase of a memoir.
+  Only runs on memoir books (book_category: memoir).
+model: claude-opus-4-7
+user-invocable: true
+argument-hint: "<book-slug>"
+---
+
+# Memoir Ethics Checker
+
+Consent gate and defamation-risk scanner for memoir books. Catches the class
+of issues that can make a memoir legally or ethically unpublishable: people
+who refused consent, profiles with missing/incomplete consent decisions, and
+language patterns in the prose that map to defamation-risk territory.
+
+## When to run
+
+- After all people profiles in `people/` have been created or updated.
+- Before the export gate — the export skill calls this as a pre-flight check
+  when `book_category: memoir`.
+- Whenever the user adds a new person or changes a consent decision.
+- During the revision phase, as a safety check before sharing ARCs.
+
+Does not replace `manuscript-checker` (prose quality) or `voice-checker`
+(AI-tells). This one catches ethical and legal risk — a different class of
+problem.
+
+## Prerequisites — MANDATORY LOADS
+
+- **`real-people-ethics.md`** via MCP `get_book_category_dir("memoir")` +
+  `/craft/real-people-ethics.md`. **Why:** Defines the four-category model
+  (public figure, private living person, deceased, anonymized/composite), the
+  consent-status taxonomy, and defamation risk patterns the scan grades against.
+
+## Workflow
+
+### 1. Resolve target book
+
+Use the user-supplied slug if provided. Otherwise call MCP `get_session()` and
+use the active book. If still ambiguous, call `list_books()` and ask.
+
+### 2. Verify memoir mode
+
+Call MCP `get_book_full(book_slug)` and read `book_category`.
+
+If `book_category` is not `memoir`: stop, explain that this skill only applies
+to memoir books, and offer `/storyforge:sensitivity-reader` as the fiction
+analogue.
+
+### 3. Run the consent scan
+
+Call MCP `check_memoir_consent(book_slug)`.
+
+The tool returns:
+```json
+{
+  "book_slug": "...",
+  "overall": "PASS" | "WARN" | "FAIL",
+  "people": [
+    {
+      "slug": "...",
+      "name": "...",
+      "person_category": "...",
+      "consent_status": "...",
+      "verdict": "PASS" | "WARN" | "FAIL",
+      "reason": "..."
+    }
+  ],
+  "pass_count": 3,
+  "warn_count": 1,
+  "fail_count": 0
+}
+```
+
+### 4. Defamation-risk prose scan
+
+After reading the consent report, read each chapter draft that mentions a
+WARN or FAIL person by name (or by their `real_name` if anonymized). Scan for
+the four defamation-risk patterns from `real-people-ethics.md`:
+
+**D1. Compressed-time assertion** — a characterization that would be defensible
+with precise scope but reads as a blanket fact without it.
+Signal: claim about a person's habitual behaviour, character, or condition
+without a scoped time phrase ("that year", "during those months", "at the time").
+Example: `"He drank too much."` → needs scope.
+
+**D2. Reconstructed defamatory dialogue** — dialogue the person did not say,
+attributed in a way that reads as fact rather than perception.
+Signal: quoted speech attributed to a real, named person making a damaging
+claim or confession they have not publicly made.
+
+**D3. Unframed mind-reading** — internal state stated as fact rather than
+perception.
+Signal: `"She hated me"`, `"He despised the family"` without perception framing
+(`"I felt that"`, `"It seemed to me"`, `"my impression was"`).
+
+**D4. Per-se-defamatory imputation** — imputing crime, professional incompetence,
+or sexual misconduct without verification or protective framing.
+Signal: direct or near-direct assertions of these categories about identifiable
+real people.
+
+For each hit: quote the passage, name the pattern (D1–D4), give a one-sentence
+fix direction.
+
+### 5. Present the report
+
+**Chat summary target: max ~250 words.** Full detail in the sections below
+if needed.
+
+```
+Ethics check: "{book_slug}" — {N} people profiled.
+Overall: PASS | WARN | FAIL
+
+Consent status:
+  PASS ({n}): [names]
+  WARN ({n}): [names + one-line reason each]
+  FAIL ({n}): [names — EXPORT BLOCKED]
+
+Defamation-risk findings: {n}
+  [one line per hit: chapter, person, pattern code, fix direction]
+```
+
+### 6. Verdict and next step
+
+**PASS (no FAILs, no WARNs, no defamation hits):**
+Tell the user the ethics check is clean. They may proceed to export.
+
+**WARN only (no FAILs, no defamation hits):**
+Tell the user: these are resolvable before publication. For each WARN person,
+propose the smallest concrete fix:
+- `pending` → ask the person; if refused, re-profile.
+- `not-asking` → confirm the decision is deliberate and documented.
+- Missing `person_category` → fill in the four-category field.
+- Missing/unknown `consent_status` → fill in a valid value.
+
+**FAIL (any refused consent):**
+Hard stop. Export is blocked. Tell the user:
+
+> **Export blocked** — {name} has refused consent. Options:
+> 1. Anonymize fully (must pass the "identifiable by close acquaintance" test —
+>    see `real-people-ethics.md`). Re-profile as `anonymized-or-composite`,
+>    consent_status `not-required`.
+> 2. Remove the person from the narrative.
+> 3. Obtain consent (unlikely if already refused — but if the situation has
+>    changed, update the profile and re-run).
+
+**Defamation-risk hits:**
+Offer rewrites. Prioritize D4 (per-se-defamatory) > D2 (reconstructed
+dialogue) > D3 (unframed mind-reading) > D1 (compressed-time).
+
+## Output Format
+
+```markdown
+## Ethics Check Report — {book_slug}
+
+### Overall Verdict: PASS | WARN | FAIL
+
+### Consent Status by Person
+| Person | Category | Consent Status | Verdict | Action |
+|--------|----------|---------------|---------|--------|
+| Name | person_category | consent_status | PASS/WARN/FAIL | — or action needed |
+
+### Defamation-Risk Findings _(if any)_
+
+**[Chapter slug, person name]** — Pattern D{n}: {pattern name}
+> "{quoted passage}"
+Fix: {one-sentence fix direction}
+
+### Verdict
+[EXPORT CLEAR / RESOLVE BEFORE EXPORT / EXPORT BLOCKED]
+
+### Next Steps
+[Specific, ordered action items]
+```
+
+## Rules
+
+- This skill is **memoir-only**. Do not run it on fiction books.
+- A `refused` consent status is a **hard export block** — not a suggestion.
+  The book cannot go to readers (even beta readers) in a form that identifies
+  the refusing person. Anonymization is the only path forward short of removal.
+- `not-asking` is a deliberate posture, not a bug. Present it as WARN so the
+  author consciously confirms the decision before publication, but do not
+  pressure them to ask. The `real-people-ethics.md` doc covers why someone
+  might not ask (estranged relationship, abuser, deceased-but-survivors-hostile).
+- Missing `person_category` always produces WARN even when consent is clean —
+  an unclassified person is an unreviewed risk.
+- Defamation patterns D1–D4 are risk flags, not verdicts. Most instances are
+  fixable with a single-sentence reframe. Only D4 (per-se-defamatory imputation)
+  warrants treating the passage as blocked prose.
+- Do not re-run the consent check automatically after a profile update — tell
+  the user to run `/storyforge:memoir-ethics-checker` again once they have
+  made the change.
+- Load `real-people-ethics.md` before presenting any finding. The nuance in
+  that document (public figure vs. private, "per se" defamation categories,
+  anonymization patterns that work vs. don't) is what separates a useful risk
+  flag from a false alarm.

--- a/tests/test_memoir_ethics.py
+++ b/tests/test_memoir_ethics.py
@@ -1,0 +1,278 @@
+"""Tests for memoir ethics checker (Phase 3, Issue #65).
+
+Covers:
+- read_people_for_ethics: reads person profiles from people/ dir
+- check_consent: classifies each person as PASS / WARN / FAIL
+- Overall verdict: FAIL beats WARN beats PASS
+- Fiction books: raises ValueError (ethics checker is memoir-only)
+- Edge cases: empty people/, missing person_category, missing consent_status
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.analysis.memoir_ethics import check_consent, read_people_for_ethics
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_book(tmp_path: Path, book_category: str = "memoir") -> Path:
+    book = tmp_path / "my-memoir"
+    book.mkdir()
+    readme = f"""---
+title: "My Memoir"
+slug: "my-memoir"
+book_category: {book_category}
+status: Drafting
+---
+
+# My Memoir
+"""
+    (book / "README.md").write_text(readme, encoding="utf-8")
+    (book / "people").mkdir()
+    return book
+
+
+def _add_person(
+    book: Path,
+    slug: str,
+    name: str,
+    person_category: str = "private-living-person",
+    consent_status: str = "confirmed-consent",
+    anonymization: str = "none",
+    real_name: str = "",
+) -> None:
+    real_name_line = f"real_name: {real_name}" if real_name else ""
+    content = f"""---
+name: {name}
+person_category: {person_category}
+consent_status: {consent_status}
+anonymization: {anonymization}
+{real_name_line}
+---
+
+Notes about {name}.
+"""
+    (book / "people" / f"{slug}.md").write_text(content, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# read_people_for_ethics
+# ---------------------------------------------------------------------------
+
+
+class TestReadPeopleForEthics:
+    def test_returns_empty_list_when_no_people_dir(self, tmp_path):
+        book = tmp_path / "bare-book"
+        book.mkdir()
+        (book / "README.md").write_text("---\nbook_category: memoir\n---\n", encoding="utf-8")
+        result = read_people_for_ethics(book)
+        assert result == []
+
+    def test_returns_empty_list_when_people_dir_empty(self, tmp_path):
+        book = _make_book(tmp_path)
+        result = read_people_for_ethics(book)
+        assert result == []
+
+    def test_skips_index_md(self, tmp_path):
+        book = _make_book(tmp_path)
+        (book / "people" / "INDEX.md").write_text("# People Index\n", encoding="utf-8")
+        result = read_people_for_ethics(book)
+        assert result == []
+
+    def test_returns_person_with_all_fields(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "alice", "Alice Smith", consent_status="confirmed-consent")
+        result = read_people_for_ethics(book)
+        assert len(result) == 1
+        p = result[0]
+        assert p["slug"] == "alice"
+        assert p["name"] == "Alice Smith"
+        assert p["consent_status"] == "confirmed-consent"
+        assert p["person_category"] == "private-living-person"
+        assert p["anonymization"] == "none"
+
+    def test_returns_multiple_people(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "alice", "Alice", consent_status="confirmed-consent")
+        _add_person(book, "bob", "Bob", consent_status="refused")
+        result = read_people_for_ethics(book)
+        slugs = {p["slug"] for p in result}
+        assert slugs == {"alice", "bob"}
+
+    def test_handles_missing_frontmatter_fields(self, tmp_path):
+        book = _make_book(tmp_path)
+        (book / "people" / "unknown.md").write_text(
+            "---\nname: Unknown\n---\nNo category here.\n", encoding="utf-8"
+        )
+        result = read_people_for_ethics(book)
+        assert len(result) == 1
+        p = result[0]
+        assert p["consent_status"] == ""
+        assert p["person_category"] == ""
+
+
+# ---------------------------------------------------------------------------
+# check_consent — individual verdicts
+# ---------------------------------------------------------------------------
+
+
+class TestCheckConsentIndividualVerdicts:
+    def test_confirmed_consent_is_pass(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "alice", "Alice", consent_status="confirmed-consent")
+        result = check_consent(book)
+        alice = next(p for p in result["people"] if p["slug"] == "alice")
+        assert alice["verdict"] == "PASS"
+
+    def test_not_required_is_pass(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(
+            book,
+            "pub-fig",
+            "Famous Politician",
+            person_category="public-figure",
+            consent_status="not-required",
+        )
+        result = check_consent(book)
+        person = result["people"][0]
+        assert person["verdict"] == "PASS"
+
+    def test_refused_is_fail(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "ex", "Ex Partner", consent_status="refused")
+        result = check_consent(book)
+        person = result["people"][0]
+        assert person["verdict"] == "FAIL"
+
+    def test_pending_is_warn(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "friend", "Old Friend", consent_status="pending")
+        result = check_consent(book)
+        person = result["people"][0]
+        assert person["verdict"] == "WARN"
+
+    def test_not_asking_is_warn(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "abuser", "The Abuser", consent_status="not-asking")
+        result = check_consent(book)
+        person = result["people"][0]
+        assert person["verdict"] == "WARN"
+
+    def test_missing_consent_status_is_warn(self, tmp_path):
+        book = _make_book(tmp_path)
+        (book / "people" / "mystery.md").write_text(
+            "---\nname: Mystery Person\nperson_category: private-living-person\n---\n",
+            encoding="utf-8",
+        )
+        result = check_consent(book)
+        person = result["people"][0]
+        assert person["verdict"] == "WARN"
+
+    def test_unknown_consent_status_is_warn(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "weird", "Weird Person", consent_status="some-unknown-value")
+        result = check_consent(book)
+        person = result["people"][0]
+        assert person["verdict"] == "WARN"
+
+    def test_missing_person_category_is_warn(self, tmp_path):
+        book = _make_book(tmp_path)
+        (book / "people" / "nocat.md").write_text(
+            "---\nname: No Category\nconsent_status: confirmed-consent\n---\n",
+            encoding="utf-8",
+        )
+        result = check_consent(book)
+        person = result["people"][0]
+        assert person["verdict"] == "WARN"
+
+    def test_verdict_includes_reason_string(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "bob", "Bob", consent_status="refused")
+        result = check_consent(book)
+        person = result["people"][0]
+        assert isinstance(person["reason"], str)
+        assert len(person["reason"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# check_consent — overall verdicts
+# ---------------------------------------------------------------------------
+
+
+class TestCheckConsentOverallVerdict:
+    def test_all_pass_gives_overall_pass(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "alice", "Alice", consent_status="confirmed-consent")
+        _add_person(
+            book, "bob", "Bob", person_category="deceased", consent_status="not-required"
+        )
+        result = check_consent(book)
+        assert result["overall"] == "PASS"
+
+    def test_one_warn_gives_overall_warn(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "alice", "Alice", consent_status="confirmed-consent")
+        _add_person(book, "bob", "Bob", consent_status="pending")
+        result = check_consent(book)
+        assert result["overall"] == "WARN"
+
+    def test_one_fail_gives_overall_fail(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "alice", "Alice", consent_status="confirmed-consent")
+        _add_person(book, "bob", "Bob", consent_status="refused")
+        result = check_consent(book)
+        assert result["overall"] == "FAIL"
+
+    def test_fail_beats_warn(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "warned", "Warned", consent_status="pending")
+        _add_person(book, "failed", "Failed", consent_status="refused")
+        result = check_consent(book)
+        assert result["overall"] == "FAIL"
+
+    def test_empty_people_gives_overall_pass(self, tmp_path):
+        book = _make_book(tmp_path)
+        result = check_consent(book)
+        assert result["overall"] == "PASS"
+        assert result["people"] == []
+
+    def test_result_includes_counts(self, tmp_path):
+        book = _make_book(tmp_path)
+        _add_person(book, "alice", "Alice", consent_status="confirmed-consent")
+        _add_person(book, "bob", "Bob", consent_status="pending")
+        _add_person(book, "carol", "Carol", consent_status="refused")
+        result = check_consent(book)
+        assert result["pass_count"] == 1
+        assert result["warn_count"] == 1
+        assert result["fail_count"] == 1
+
+    def test_result_includes_book_slug(self, tmp_path):
+        book = _make_book(tmp_path)
+        result = check_consent(book)
+        assert result["book_slug"] == "my-memoir"
+
+
+# ---------------------------------------------------------------------------
+# check_consent — memoir-only gate
+# ---------------------------------------------------------------------------
+
+
+class TestCheckConsentMemoirOnly:
+    def test_raises_for_fiction_book(self, tmp_path):
+        book = _make_book(tmp_path, book_category="fiction")
+        with pytest.raises(ValueError, match="memoir"):
+            check_consent(book)
+
+    def test_raises_when_no_readme(self, tmp_path):
+        book = tmp_path / "orphan"
+        book.mkdir()
+        (book / "people").mkdir()
+        with pytest.raises((ValueError, FileNotFoundError)):
+            check_consent(book)

--- a/tools/analysis/memoir_ethics.py
+++ b/tools/analysis/memoir_ethics.py
@@ -1,0 +1,192 @@
+"""Memoir ethics checker — consent and real-people risk scanner (Issue #65).
+
+Reads person profiles from a memoir book's ``people/`` directory and
+classifies each person as PASS / WARN / FAIL based on their
+``consent_status`` and ``person_category`` fields.
+
+Verdict logic
+-------------
+FAIL  — ``refused``: person explicitly declined consent.
+WARN  — ``pending``: consent not yet sought.
+       ``not-asking``: deliberate choice not to ask.
+       Missing, empty, or unrecognised ``consent_status``.
+       Missing or unrecognised ``person_category`` (incomplete profile).
+PASS  — ``confirmed-consent``: person has agreed.
+       ``not-required``: public figure on public matters, deceased, or
+       fully anonymised composite.
+
+Overall verdict: FAIL beats WARN beats PASS.
+
+The checker is memoir-only.  Calling it on a fiction book raises
+``ValueError``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from tools.state.parsers import parse_person_file
+
+# ---------------------------------------------------------------------------
+# Constants (mirrored from parsers.py to avoid importing private names)
+# ---------------------------------------------------------------------------
+
+_PASS_STATUSES = frozenset({"confirmed-consent", "not-required"})
+_FAIL_STATUSES = frozenset({"refused"})
+_WARN_STATUSES = frozenset({"pending", "not-asking"})
+
+_VALID_PERSON_CATEGORIES = frozenset(
+    {"public-figure", "private-living-person", "deceased", "anonymized-or-composite"}
+)
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+_BOOK_CATEGORY_RE = re.compile(r"^\s*book_category:\s*['\"]?(\w[\w-]*)['\"]?\s*$", re.MULTILINE)
+_BOOK_SLUG_RE = re.compile(r"^\s*slug:\s*['\"]?([^'\"\n]+?)['\"]?\s*$", re.MULTILINE)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_book_meta(book_path: Path) -> tuple[str, str]:
+    """Return (book_category, book_slug) from book README frontmatter."""
+    readme = book_path / "README.md"
+    if not readme.is_file():
+        raise FileNotFoundError(f"No README.md found at {book_path}")
+    text = readme.read_text(encoding="utf-8")
+    fm = _FRONTMATTER_RE.match(text)
+    if not fm:
+        return "fiction", book_path.name
+    body = fm.group(1)
+    cat_m = _BOOK_CATEGORY_RE.search(body)
+    category = cat_m.group(1).strip() if cat_m else "fiction"
+    slug_m = _BOOK_SLUG_RE.search(body)
+    slug = slug_m.group(1).strip() if slug_m else book_path.name
+    return category, slug
+
+
+def _classify_person(person: dict[str, Any]) -> tuple[str, str]:
+    """Return (verdict, reason) for a single person dict."""
+    consent = (person.get("consent_status") or "").strip()
+    category = (person.get("person_category") or "").strip()
+
+    # FAIL gate — hard stop
+    if consent in _FAIL_STATUSES:
+        return "FAIL", (
+            f"consent_status is '{consent}' — this person has explicitly refused. "
+            "Do not publish their portrayal without legal review."
+        )
+
+    # Incomplete profile — always at least WARN
+    missing_category = category not in _VALID_PERSON_CATEGORIES
+
+    if consent in _PASS_STATUSES:
+        if missing_category:
+            return "WARN", (
+                f"consent_status is '{consent}' but person_category is "
+                f"'{category or '(empty)'}' — fill in the four-category field "
+                "before export."
+            )
+        return "PASS", f"consent_status '{consent}' with category '{category}'."
+
+    if consent in _WARN_STATUSES:
+        if missing_category:
+            return "WARN", (
+                f"consent_status is '{consent}' and person_category is "
+                f"'{category or '(empty)'}' — both need attention before publication."
+            )
+        return "WARN", (
+            f"consent_status is '{consent}' — resolve before publication."
+        )
+
+    # Unknown / empty consent_status
+    reason_parts = [
+        f"consent_status is '{consent or '(empty)'}' — unrecognised value."
+    ]
+    if missing_category:
+        reason_parts.append(
+            f"person_category is '{category or '(empty)'}' — unrecognised value."
+        )
+    return "WARN", " ".join(reason_parts)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def read_people_for_ethics(book_path: Path) -> list[dict[str, Any]]:
+    """Read all person profiles from ``people/`` and return structured list.
+
+    Returns an empty list when the directory is absent.  INDEX.md is skipped.
+    """
+    people_dir = book_path / "people"
+    if not people_dir.is_dir():
+        return []
+    result = []
+    for md in sorted(people_dir.glob("*.md")):
+        if md.name.upper() == "INDEX.MD":
+            continue
+        result.append(parse_person_file(md))
+    return result
+
+
+def check_consent(book_path: Path) -> dict[str, Any]:
+    """Run the ethics check for a memoir book.
+
+    Returns a dict with keys:
+        book_slug    — slug string from README
+        overall      — "PASS" | "WARN" | "FAIL"
+        people       — list of per-person result dicts
+        pass_count   — int
+        warn_count   — int
+        fail_count   — int
+
+    Each person dict adds ``verdict`` and ``reason`` to the parsed fields.
+
+    Raises
+    ------
+    ValueError
+        When the book is not a memoir (``book_category != "memoir"``).
+    FileNotFoundError
+        When no README.md is found.
+    """
+    category, slug = _read_book_meta(book_path)
+    if category != "memoir":
+        raise ValueError(
+            f"memoir-ethics-checker only runs on memoir books; "
+            f"this book has book_category='{category}'."
+        )
+
+    people_raw = read_people_for_ethics(book_path)
+    people_out: list[dict[str, Any]] = []
+    pass_count = warn_count = fail_count = 0
+
+    for person in people_raw:
+        verdict, reason = _classify_person(person)
+        people_out.append({**person, "verdict": verdict, "reason": reason})
+        if verdict == "PASS":
+            pass_count += 1
+        elif verdict == "WARN":
+            warn_count += 1
+        else:
+            fail_count += 1
+
+    if fail_count:
+        overall = "FAIL"
+    elif warn_count:
+        overall = "WARN"
+    else:
+        overall = "PASS"
+
+    return {
+        "book_slug": slug,
+        "overall": overall,
+        "people": people_out,
+        "pass_count": pass_count,
+        "warn_count": warn_count,
+        "fail_count": fail_count,
+    }


### PR DESCRIPTION
## Summary

- New `tools/analysis/memoir_ethics.py` — consent scanner with `read_people_for_ethics()` and `check_consent()`: classifies each person PASS / WARN / FAIL by `consent_status` and `person_category`
- New `check_memoir_consent` MCP tool in `server.py` — memoir-only gate; returns per-person verdicts + overall verdict + counts
- New `skills/memoir-ethics-checker/SKILL.md` — full skill with consent-scan workflow, defamation-risk patterns D1–D4, per-verdict action paths (hard stop on FAIL, resolve list on WARN)
- `skills/export-engineer/SKILL.md` — Step 0 memoir consent gate added; hard-stops on FAIL, asks confirmation on WARN
- `CLAUDE.md` — routing row added, memoir-aware skills section updated, Rule 20 updated

Closes #65

## Verdict logic

| consent_status | verdict |
|---|---|
| `confirmed-consent` | PASS |
| `not-required` | PASS |
| `pending` | WARN |
| `not-asking` | WARN |
| missing / unknown | WARN |
| `refused` | FAIL |

Missing `person_category` always degrades to WARN (even if consent is clean).

Overall: FAIL beats WARN beats PASS.

## Test plan

- [x] 24 unit tests in `tests/test_memoir_ethics.py` — all green
- [x] Full suite 790/790 passes
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)