### PR TITLE
feat: memoir support for 10 supporting skills (Phase 4, #64)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,26 +130,38 @@ Phase 1 (#54–#56, #67) adds the field plus knowledge scaffold. Skill branching
 13. `/storyforge:promo-writer` — Social media campaign (FB, Instagram, TikTok, X, Bluesky, Newsletter)
 14. `/storyforge:translator` — Translate to other languages
 
-### Memoir Workflows (Phase 2+ — forthcoming)
+### Memoir Workflows
 
-Phase 1 ships memoir knowledge under `book_categories/memoir/` but does **not** yet branch the skills above. Memoir books currently flow through the same fiction workflows; skills will branch on `book_category` once Phase 2 (#57–#60, #63), Phase 3 (#61, #62, #65, #66) and Phase 4 (#64) land.
+All memoir skill phases are now wired (Phases 1–4). Memoir books flow through memoir-specific paths automatically via `book_category` branching.
 
-Memoir-aware skills already wired:
+**Phase 1–2 skills (foundation + core branching):**
 
 - `/storyforge:new-book` — scaffolds memoir-shaped tree (`people/` instead of `characters/`, no `world/`, structure-types outline) when `book_category: memoir` is selected (Issue #63)
 - `/storyforge:book-dashboard` — surfaces `Category` and `Length` separately, re-labels people table for memoir (Issue #63)
-- `/storyforge:book-conceptualizer` (memoir mode) — runs the 5-phase concept with Phase 3 *Scope* (time window / cast / deliberate exclusions) instead of Phase 3 *Conflict*, memoir-blurb conventions in Phase 5 (Issue #60)
-- `/storyforge:character-creator` (memoir mode) — real-people handler that captures relationship, person_category (4-category model), consent_status, and anonymization decisions; writes to `people/{slug}.md` via `create_person` MCP tool (Issue #59)
-- `/storyforge:plot-architect` (memoir mode) — narrative-arc shaping; user picks one of four structure types (chronological / thematic / braided / vignette), persisted via `set_memoir_structure_type`; chapter spine, timeline anchor, and tonal document still apply (Issue #58)
-- `/storyforge:chapter-writer` (memoir mode) — loads memoir craft (scene-vs-summary, emotional-truth, real-people-ethics, memoir-anti-ai-patterns); reads `book_category` + `consent_status_warnings` from the brief; surfaces consent gates for refused/pending/missing status before drafting; closes chapters into `plot/people-log.md` instead of `plot/canon-log.md`; skips `world/setting.md` (no Travel Matrix) and genre-as-plot-contract loads (Issue #57)
+- `/storyforge:book-conceptualizer` (memoir mode) — 5-phase concept with Phase 3 *Scope*; memoir-blurb conventions in Phase 5 (Issue #60)
+- `/storyforge:character-creator` (memoir mode) — real-people handler; consent_status, anonymization, people-log (Issue #59)
+- `/storyforge:plot-architect` (memoir mode) — narrative-arc shaping; four structure types (Issue #58)
+- `/storyforge:chapter-writer` (memoir mode) — memoir craft loads; consent gates; people-log closes (Issue #57)
 
-Memoir-specific skills now wired (Phase 3):
+**Phase 3 skills (memoir-specific):**
 
-- `/storyforge:memoir-ethics-checker` — consent/defamation/anonymization scan; calls `check_memoir_consent` MCP tool; export-engineer runs this as Step 0 for memoir books; hard-fails when any person has `consent_status: refused` (Issue #65)
+- `/storyforge:manuscript-checker` (memoir mode) — memoir-specific pattern passes (Issue #61)
+- `/storyforge:voice-checker` (memoir mode) — Dimension 8 memoir AI-tells (Issue #62)
+- `/storyforge:memoir-ethics-checker` — consent/defamation/anonymization scan; export-engineer Step 0 (Issue #65)
+- `/storyforge:emotional-truth-prompt` — 7-dimension felt-sense analysis; memoir-only (Issue #66)
 
-- `/storyforge:emotional-truth-prompt` — interactive felt-sense interrogation of a chapter draft; 7-dimension analysis (implicit feeling, retrospective vantage drift, memory contradiction, avoidance hedges, thoroughness trap, scene/summary mode errors, "I was wrong" rendering); outputs targeted questions + revision directions, not rewrites; runs before `chapter-reviewer`; memoir-only (Issue #66)
+**Phase 4 supporting skills — now wired (Issue #64):**
 
-All Phase 3 memoir-specific skills are now wired (#61, #62, #65, #66). When working on a memoir book, still manually load `book_categories/memoir/README.md` and the relevant `craft/` files at the start of any creative skill — Phase 4 (#64) will add the automatic routing.
+- `/storyforge:brainstorm` (memoir mode) — excavation mode: three-question framework (why this story / why you / why now); refuses to invent memoir material
+- `/storyforge:create-author` (memoir mode) — subject_position field (writing-self / writing-other / shared), relationship-to-material, off_limits; memoir-specific influence list; memoir AI-tell banlist pre-populated
+- `/storyforge:researcher` (memoir mode) — self-research categories (memory verification, period detail, place recovery, timeline anchoring); verifies and reports gaps honestly
+- `/storyforge:world-builder` (memoir mode) — Setting Notes mode: four-question sensory anchoring per location; memory vs. researched tagging; no Travel Matrix
+- `/storyforge:rolling-planner` (memoir mode) — life-stakes questions instead of plot-stakes; skip tactical sanity check for memoir
+- `/storyforge:continuity-checker` (memoir mode) — people-log instead of canon-log; real-world plausibility check instead of Travel Matrix; no matrix reconstruction
+- `/storyforge:chapter-reviewer` (memoir mode) — memoir anti-AI patterns (6-point dimension); consent gate flags; people-log continuity; dialog reconstruction honesty check
+- `/storyforge:cover-artist` (memoir mode) — photographic/typographic/portrait brief; period color palette; no AI-generated real-person likenesses
+- `/storyforge:promo-writer` (memoir mode) — 4-element memoir blurb (hook / personal stake / universal theme / tone signal); memoir quote card guidance
+- `/storyforge:study-author` (memoir mode) — voice excavation from personal writing (journals, letters, diaries); privacy-safe analysis; no Phase 2.5 gate for memoir
 
 ## Project Structure
 
@@ -280,7 +292,7 @@ Skills MUST load relevant craft references before generating creative content. U
 17. ALWAYS load the book's `CLAUDE.md` via MCP `get_book_claudemd()` before writing or reviewing a chapter — it contains persisted workflow rules and callbacks that survive session compaction
 18. Prefix grammar for persistence: messages starting with `Regel:`, `Workflow:`, or `Callback:` are extracted by the PreCompact hook and written to the book's CLAUDE.md. Unprefixed messages are never persisted automatically.
 19. **ALWAYS `Read` the full file when processing review comments** (GH#27). When the user signals that review comments (`{review_handle}:` blocks) are ready, call the `Read` tool on the full file first. The file-change `system-reminder` diff is truncated for long files — end-of-file comments get silently dropped. After reading, count the comments you see and report the count; re-read if the count mismatches expectation.
-20. **ALWAYS check `book_category` before creative work on a book** (Path E #54/#67). Read it from `get_book_full(slug).book_category`. For `memoir`, additionally load `book_categories/memoir/README.md` and the relevant `book_categories/memoir/craft/*.md` docs at the start of any creative skill. The manual load remains the bridge until Phase 4 (#64) ships automatic routing. For named living people in memoir scenes, surface `consent_status` decisions explicitly — use `/storyforge:memoir-ethics-checker` (Phase 3 #65). For felt-sense gaps in chapter drafts, use `/storyforge:emotional-truth-prompt` (Phase 3 #66).
+20. **ALWAYS check `book_category` before creative work on a book** (Path E #54/#67). Read it from `get_book_full(slug).book_category`. All skills now branch automatically on `book_category` (Phase 4 #64 complete — no more manual load bridge needed). For named living people in memoir scenes, surface `consent_status` decisions explicitly — use `/storyforge:memoir-ethics-checker` (#65). For felt-sense gaps in chapter drafts, use `/storyforge:emotional-truth-prompt` (#66).
 
 ## Code Style
 

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -1,19 +1,27 @@
 ---
 name: brainstorm
 description: |
-  Brainstorm FICTION/BOOK/STORY ideas interactively. Develop premises, explore genres, ask "what if?" questions.
-  Use ONLY for fiction/book/novel/story concepts — NOT for software, code, video, or dev project ideas.
-  Use when: (1) User says "Buch-Idee", "Story-Idee", "Roman-Idee", "Fiction-Idee", "brainstorm a story/book/novel",
+  Brainstorm book ideas interactively — fiction (What if?) or memoir (What happened?).
+  Use ONLY for book/novel/memoir concepts — NOT for software, code, video, or dev project ideas.
+  Use when: (1) User says "Buch-Idee", "Story-Idee", "Roman-Idee", "Memoir-Idee", "brainstorm a story/book/novel/memoir",
   "was könnte ich schreiben", "neue Geschichte", (2) User explicitly invokes `/storyforge:brainstorm`,
-  (3) Context is clearly fiction (genre mentions, character/plot/world, reading material).
-  Do NOT trigger on bare "Idee" / "brainstorm" without fiction context — defer to a more specific plugin.
+  (3) Context is clearly a book (genre mentions, character/plot/world, memoir/life-writing, reading material).
+  Do NOT trigger on bare "Idee" / "brainstorm" without book context — defer to a more specific plugin.
 model: claude-opus-4-7
 user-invocable: true
 ---
 
 # Brainstorm
 
-## Workflow
+## Step 0 — Detect Book Category
+
+Ask: *"Is this a fiction idea or a memoir / life-writing idea?"* (or detect from context if clear).
+
+Branch the entire workflow on the answer.
+
+---
+
+## Fiction Mode
 
 ### Phase 1: Seed
 Ask the user what sparks their interest. Open-ended:
@@ -41,31 +49,69 @@ Once the user picks a direction:
 - **Comparable titles:** "X meets Y"
 
 ### Phase 4: Save
-Save the idea via the storyforge MCP server: call `mcp__plugin_storyforge_storyforge-mcp__create_idea`
-with `title`, `genres`, `logline`, and `concept` body.
+Save via MCP `create_idea` with `title`, `genres`, `logline`, `concept`, and `book_category: fiction`.
 
-**Server discipline:** ALWAYS use the `storyforge-mcp` server's `create_idea` (writes to
-`{content_root}/ideas/{slug}.md` as Markdown + YAML frontmatter). NEVER call `create_idea` from any
-other MCP server (e.g. `vidcraft-mcp.create_idea`, `mm-dev-toolkit-mcp.tool_create_idea`) —
-those write to different stores and corrupt the storyforge ideas directory.
+**Server discipline:** ALWAYS use the `storyforge-mcp` server's `create_idea`. NEVER call `create_idea` from any other MCP server — those write to different stores and corrupt the storyforge ideas directory.
 
-The idea gets status `raw` by default. If the user has fully developed it (logline + themes + comps),
-call `mcp__plugin_storyforge_storyforge-mcp__update_idea(slug, "status", "explored")` immediately after saving.
+The idea gets status `raw` by default. If fully developed (logline + themes + comps), call `update_idea(slug, "status", "explored")` immediately.
 
-Tell the user the slug so they can reference it later: "Saved as `{slug}`."
+Tell the user the slug. Ask: "Ready to turn this into a project? → `/storyforge:new-book --from-idea {slug}`"
 
-Ask: "Ready to turn this into a project? → `/storyforge:new-book --from-idea {slug}`"
-Or: "Want to let it marinate? Check your ideas with `/storyforge:ideas`."
+---
 
-### Phase 5: Resuming an idea (optional)
-If the user returns to an existing idea (e.g. "continue the clockmaker idea"):
-1. Load it via `mcp__plugin_storyforge_storyforge-mcp__get_idea(slug)`
-2. Continue development from where it left off
-3. Update fields via `mcp__plugin_storyforge_storyforge-mcp__update_idea()` as the concept grows
+## Memoir Mode
+
+Memoir brainstorming is fundamentally different from fiction. There is no "what if?" — only "what happened, and why does it matter to tell now?" The work here is not invention but *excavation and framing.*
+
+### Phase 1: Seed
+Ask open-ended questions to locate the material:
+- "What period of your life keeps pulling at you?"
+- "Is there a story you've told people at dinner a hundred times — but never written down?"
+- "What happened to you that you don't fully understand yet?"
+- "Who in your life made you who you are — for better or worse?"
+- "What's the thing you survived that others might need to read about?"
+
+Do NOT suggest topics. Wait for the user. Memoir ideas must come from the writer's own life — suggesting premises for memoir is inappropriate.
+
+### Phase 2: The Three Questions
+Once the user identifies the material, press on the three memoir foundation questions:
+
+1. **"Why this story?"** — What makes this particular experience worth a book-length treatment? Not "it was important to me" — that's true of everything. What's the specific gift this story could give a reader?
+
+2. **"Why you?"** — What gives this author the unique access to tell it? (They lived it is necessary but not sufficient — what did they *see* that others didn't?)
+
+3. **"Why now?"** — What has changed — in the author, in the world, or in their understanding — that makes this the right moment to write it?
+
+If the user can answer all three strongly, the memoir has a foundation. If they can't yet, help them discover the answers — don't let them proceed with a vague impulse.
+
+### Phase 3: Develop
+Once the three questions are answered:
+- **One-sentence premise:** What this memoir is about, in terms of the author's transformation or reckoning — not a plot summary
+- **Time window:** What period does it cover? (A year, a decade, a single event and its aftermath?)
+- **Scope tags:** What kind of memoir? (memoir-of-illness, memoir-of-family, memoir-of-place, memoir-of-addiction, memoir-of-reckoning, etc.)
+- **Structural instinct:** How does it want to be told? (Chronological? Thematic? Braided with a present-day frame?)
+- **The reader it's for:** Who needs to read this? "For anyone who has ever..." — complete that sentence.
+- **Comparable memoirs:** Real memoir comps, not fiction. (e.g., "Readers of *Educated* and *The Glass Castle* will recognize this.")
+
+### Phase 4: Save
+Save via MCP `create_idea` with `title`, `genres` (use scope tags as thematic anchors), `logline`, `concept`, and `book_category: memoir`.
+
+The idea gets status `raw`. If three questions are fully answered and scope is clear, call `update_idea(slug, "status", "explored")`.
+
+Tell the user the slug. Ask: "Ready to turn this into a memoir project? → `/storyforge:new-book --from-idea {slug}` (choose memoir when prompted)"
+
+---
+
+## Shared Phase 5: Resuming an idea (optional)
+If the user returns to an existing idea:
+1. Load via MCP `get_idea(slug)`
+2. Check `book_category` in the idea frontmatter and continue in the correct mode
+3. Update fields via `update_idea()` as the concept grows
 
 ## Rules
-- Be provocative and unexpected. Don't offer safe, generic ideas.
-- Push the user toward specificity — "a vampire story" is not enough. WHOSE vampire story? What makes it THEIRS?
-- Mix genres freely. The best ideas live at intersections.
-- Always save ideas — even rejected ones might resurface later.
-- Always fill in the logline before saving — a vague idea without a logline is hard to revisit.
+- **Fiction:** Be provocative and unexpected. Don't offer safe, generic ideas. Push toward specificity.
+- **Memoir:** Never invent or suggest material. The writer's life is the only valid source. Your job is to help them locate and frame what's already there.
+- Mix genres freely in fiction. In memoir, scope tags are anchors, not genre labels.
+- Always save ideas — even ones the user is uncertain about might clarify later.
+- Always resolve to a logline (fiction) or a one-sentence premise (memoir) before saving — a vague idea without a premise is hard to revisit.
+- **Never conflate fiction and memoir modes.** A memoir idea handled with "What if?" framing is being treated as fiction. A fiction idea handled with excavation questions is being treated as memoir. Hold the distinction.

--- a/skills/chapter-reviewer/SKILL.md
+++ b/skills/chapter-reviewer/SKILL.md
@@ -11,23 +11,44 @@ argument-hint: "<book-slug> <chapter-slug>"
 
 # Chapter Reviewer
 
+## Step 0 — Resolve Book Category
+
+Read `book_category` from the review brief (Step 1) — the brief carries it explicitly. Treat missing as `fiction`.
+
+If `book_category == "memoir"`, surface a one-line note: *"Working in memoir mode — loading memoir anti-AI patterns, skipping Travel Matrix checks, checking consent status for named people."*
+
+Branch Step 2 loads and checklist adjustments on `book_category`.
+
 ## Prerequisites — MANDATORY LOADS
 
 ### Step 1 — Load the review brief (single MCP call, replaces 6+ direct file reads)
 
 Call MCP `get_review_brief(book_slug, chapter_slug)`. This returns:
 
+- `book_category` — `fiction` or `memoir`
 - `chapter_timeline` — intra-day time grid for this chapter (start/end/scenes)
 - `previous_chapter_timeline` — same for the preceding chapter (cross-chapter time checks)
 - `canonical_timeline_entries` — parsed `plot/timeline.md` events (day/date/chapter/events)
-- `travel_matrix` — parsed `world/setting.md` Travel Matrix rows (from/to/distance/travel_time)
-- `canon_log_facts` — parsed `plot/canon-log.md` facts with status (ACTIVE / CHANGED)
+- `travel_matrix` — parsed `world/setting.md` Travel Matrix rows (**fiction only** — empty for memoir)
+- `canon_log_facts` — parsed `plot/canon-log.md` facts (**fiction only** — empty for memoir)
+- `consent_status_warnings` — people with non-approved consent status (**memoir only**)
 - `tonal_rules` — non-negotiable rules, litmus test, banned patterns, warning signs from `plot/tone.md`
 - `active_rules` — book CLAUDE.md ## Rules with severity (block / advisory)
 - `active_callbacks` — book CLAUDE.md ## Callback Register items
 - `errors` — graceful degrade: non-empty means some files were missing or unreadable
 
 Honor every populated field in the brief. Empty lists / null means "file missing — degrade gracefully, do not invent."
+
+**Memoir supplement:** Also directly read `{project}/plot/people-log.md` if it exists — the brief's `canon_log_facts` is empty for memoir; people-log is the memoir equivalent.
+
+### Step 1b — Memoir Consent Gate
+
+**Memoir only.** Before reviewing a single line of prose, check `consent_status_warnings` from the brief.
+
+- If any person appears with `consent_status: refused` — flag as **CRITICAL** in the review. The scene should not be published. Route the user to `/storyforge:memoir-ethics-checker` for the cut/anonymize/re-frame decision.
+- If `consent_status: missing` or `pending` — flag as **WARNING**. Surface the name and note that consent needs to be resolved before export.
+
+This is a review flag, not a halt — the review continues, but the consent issue must appear prominently at the top of the report.
 
 ### Step 2 — Load author and craft context (MCP calls)
 
@@ -40,6 +61,8 @@ Honor every populated field in the brief. Empty lists / null means "file missing
   - `dialog-craft` — **Why:** Subtext, voice differentiation, tag discipline — for points 9 and 15.
   - `show-dont-tell` — **Why:** Show/tell balance check for points 6 and 24.
   - `simile-discipline` — **Why:** The two-question test sub-point 10b runs.
+- **Memoir only** — additionally load via `get_book_category_dir("memoir")`:
+  - `memoir-anti-ai-patterns.md` — **Why:** Memoir-specific AI-tells the universal catalog misses (reflective platitudes, "looking back" hinges, tidy lesson endings, hedging-as-humility, therapeutic reframe, explanation-after-image). These run as a separate checklist section.
 - **Detect if this is Chapter 1:** Check chapter slug (starts with `01-` or `001-`) or frontmatter chapter number. If Chapter 1: also load `openings-and-endings` craft reference.
 
 ### Step 3 — Read the prose (direct file reads — this is the content under review)
@@ -101,13 +124,23 @@ If this is Chapter 1, run this checklist BEFORE the standard review. Rate each p
 14. **Sentence rhythm** — Varied length? Matches author's style?
 15. **Dialog voice** — Each character distinguishable without tags?
 
-### Continuity (5 points + 1 sub-point)
+### Continuity (5 points + 1 sub-point) — branched by book_category
+
+**Fiction:**
 16. **Canon consistency** — Does the chapter contradict any fact in the Canon Log? Pay special attention to `CHANGED` facts.
 17. **Timeline accuracy** — Do day/date references match `plot/timeline.md`?
 18. **Travel consistency** — Do distances/travel times match the Travel Matrix?
 19. **Stale references** — Is this chapter flagged as `[STALE]` in the Revision Impact Tracker? If so, list all outdated references.
 20. **Character facts** — Do character descriptions/behaviors match established facts? (e.g., does a vampire eat or not?)
-20a. **POV knowledge boundary** — Does the narration attribute domain knowledge (forensics, tactical combat, ballistics, medicine, automotive repair, ...) to the POV character that their `knowledge:` profile says they don't have? The `validate_chapter` hook surfaces these as `[WARN] pov_boundary` lines — review every one. Three remediation options: (a) move into dialog by a character who would know, (b) reframe as the POV character's lay observation, (c) cut. Skip when the POV character has no `knowledge:` block (graceful degrade).
+20a. **POV knowledge boundary** — Does the narration attribute domain knowledge the POV character's profile says they don't have? Three remediation options: (a) move into dialog, (b) reframe as lay observation, (c) cut.
+
+**Memoir (replace 16 and 18):**
+16. **People-Log consistency** — Does the chapter contradict any established fact in `plot/people-log.md`? Pay special attention to descriptions, relationships, or events recorded in earlier chapters.
+17. **Timeline accuracy** — Do date/year references match `plot/timeline.md`? In memoir this is real chronology — an error is not just a continuity problem, it's a factual error.
+18. **Real-world plausibility** — Do stated distances or travel times match real-world geography? (No Travel Matrix — use common sense. Flag implausible claims as WARNING.)
+19. **Stale references** — same as fiction.
+20. **Person facts** — Do descriptions and behaviors of named people match what was established in earlier chapters and the people-log?
+20a. **Dialog reconstruction honesty** — Is reconstructed dialog presented with appropriate epistemic humility? Does the chapter claim verbatim precision for conversations that happened decades ago? Flag any dialog rendered as if perfectly remembered without any qualifying framing.
 
 ### Tonal Consistency (5 points) — only if `plot/tone.md` exists
 21. **Dominant mode** — Does the chapter match the dominant mode defined in the Tonal Arc table for this chapter's position?
@@ -121,12 +154,25 @@ If this is Chapter 1, run this checklist BEFORE the standard review. Rate each p
 27. **Internal consistency** — Do all relative time references ("ten minutes later", "an hour ago") match the Chapter Timeline in README.md?
 28. **Cross-chapter consistency** — Do references to earlier events use durations that match the previous chapter's timeline?
 
-### Anti-AI (5 points)
+### Anti-AI (5 points — both modes)
 21. **AI vocabulary** — Any words from the banned list? (delve, tapestry, nuanced, etc.)
 22. **Structural uniformity** — Are paragraphs/sentences suspiciously uniform in length?
 23. **Generic descriptions** — Any "bustling city", "warm smile", "piercing gaze" clichés?
 24. **Emotional telling** — Any "he felt a wave of sadness" instead of showing?
 25. **Neat resolution** — Does every scene wrap up too tidily?
+
+### Memoir Anti-AI (6 points — memoir mode only, skip for fiction)
+
+Run this section only when `book_category: memoir`. Load `memoir-anti-ai-patterns.md` (loaded in Step 2). Grade each:
+
+26. **Reflective platitude** — Any generic wisdom claims ("family is complicated", "grief takes time", "I came to realize how much I'd grown")? These are the memoir equivalent of "bustling city". Flag every instance.
+27. **"Looking back" hinges** — Any phrases like "looking back now I can see", "in retrospect", "what I didn't know then was"? Occasional retrospective framing is valid; a pattern of it is evasion — the memoirist is summarizing instead of dramatizing.
+28. **Tidy lesson ending** — Does the chapter close with an explained moral or stated insight ("And that's when I understood that...")? The best memoir closes on a scene or image, not a lesson.
+29. **Hedging as humility** — Density of "perhaps", "in some way", "I think", "maybe", "I'm not sure but"? In memoir, persistent hedging reads as performative safety behavior, not authentic uncertainty. Flag if density exceeds 2 per 500 words as a pattern.
+30. **Therapeutic reframe** — Any "I came to understand that my anger was actually grief" / "what felt like fear was really longing" framing? These translate lived experience into therapy-speak and distance the reader from the raw event.
+31. **Explanation after image** — Does the chapter describe a scene or image and then immediately explain what it meant? (e.g., "The silence between us said everything. We had grown apart.") The image should land alone. The explanation undercuts it.
+
+Report memoir AI-tells in their own labeled section, separate from universal Anti-AI findings.
 
 ## Output Format
 
@@ -156,7 +202,7 @@ If this is Chapter 1, run this checklist BEFORE the standard review. Rate each p
 
 ---
 
-### Score: [X]/25 (core) + [X]/5 (tonal, if tone.md exists) + [X]/3 (timeline)
+### Score: [X]/25 (core) + [X]/5 (tonal, if tone.md exists) + [X]/3 (timeline) + [X]/6 (memoir AI-tells, memoir only)
 
 ### Strengths
 - *What works well*
@@ -174,10 +220,11 @@ If this is Chapter 1, run this checklist BEFORE the standard review. Rate each p
 - [Issue] — [Location] — [Suggested fix]
 
 ### Continuity Report
-- Canon conflicts: [count] — [details]
+- [Fiction] Canon conflicts / [Memoir] People-Log conflicts: [count] — [details]
 - Timeline conflicts: [count] — [details]
-- Travel Matrix conflicts: [count] — [details]
+- [Fiction] Travel Matrix conflicts / [Memoir] Real-world plausibility issues: [count] — [details]
 - Stale references (from revisions): [count] — [details]
+- [Memoir] Consent warnings: [list persons with non-approved consent_status, or "none"]
 
 ### Tonal Report (if tone.md exists)
 - Dominant mode match: [yes/no — expected: X, actual: Y]
@@ -195,6 +242,14 @@ If this is Chapter 1, run this checklist BEFORE the standard review. Rate each p
 - Flagged words: [list]
 - Sentence length variance: [high/medium/low]
 - Generic descriptions found: [count]
+
+### Memoir AI-Tell Report _(memoir mode only — omit section for fiction)_
+- Reflective platitudes: [count] — [examples]
+- "Looking back" hinges: [count] — [examples or "none"]
+- Tidy lesson endings: [found / not found]
+- Hedging density: [X per 500 words — flag if > 2]
+- Therapeutic reframes: [count] — [examples or "none"]
+- Explanation-after-image: [count] — [examples or "none"]
 
 ### Simile Report
 - Total simile markers found: [count]
@@ -218,3 +273,5 @@ If this is Chapter 1, run this checklist BEFORE the standard review. Rate each p
 - Suggest concrete rewrites, not just "make this better."
 - The AI-tell check runs as a hard gate — if banned words appear, flag the chapter as NEEDS REVISION regardless of other scores.
 - When the user flags an issue: VERIFY before accepting. Re-read the passage, check context from earlier chapters, and push back if the user misunderstood (especially English nuances). The user explicitly wants to be challenged, not blindly agreed with.
+- **Memoir:** run Dimension 26-31 (Memoir Anti-AI) and report in a separate labeled section. Do NOT fold memoir-specific tells into the universal Anti-AI section — the author needs the distinction between "bad prose" and "bad memoir prose."
+- **Memoir:** consent warnings from Step 1b must appear PROMINENTLY — as the first item in the Critical section if any person has `consent_status: refused`. This is a publication blocker, not a craft note.

--- a/skills/continuity-checker/SKILL.md
+++ b/skills/continuity-checker/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: continuity-checker
 description: |
-  Scan all chapter drafts and validate against the story timeline and travel matrix.
-  Reports temporal and spatial inconsistencies with chapter references.
+  Scan all chapter drafts and validate against the story timeline, travel matrix (fiction),
+  or people-log and real chronology (memoir).
   Use when: (1) User says "Continuity prüfen", "check continuity", "Zeitlinie prüfen",
   (2) After writing multiple chapters, (3) Before revision or export.
 model: claude-sonnet-4-6
@@ -12,33 +12,39 @@ argument-hint: "<book-slug>"
 
 # Continuity Checker
 
+## Step 0 — Resolve Book Category
+
+Load `book_category` from MCP `get_book_full(book_slug)`. Treat missing as `fiction`.
+Branch Prerequisites and Workflow Steps 3, 5, 6 on `book_category`.
+
 ## Purpose
-Systematically scan all chapter drafts for inconsistencies in:
-1. **Temporal continuity** — days, dates, durations, day-of-week claims
-2. **Spatial continuity** — distances, travel times, location descriptions
+
+**Fiction:** Scan for inconsistencies in invented chronology, Travel Matrix distances, and Canon Log facts.
+
+**Memoir:** Scan for inconsistencies in real chronology, people-log facts, and real-world geography claims. No Travel Matrix exists — spatial claims are checked for real-world plausibility instead.
 
 ## Prerequisites
 
-### Step 1 — Load the continuity brief (single MCP call, replaces 4+ direct file reads)
+### Step 1 — Load the continuity brief (single MCP call)
 
 Call MCP `get_continuity_brief(book_slug)`. This returns:
 
 - `canonical_calendar` — parsed `plot/timeline.md` events (story_day/real_date/chapter_slug/key_events)
-- `travel_matrix` — parsed `world/setting.md` Travel Matrix rows (from/to/distance/transport/travel_time/notes)
-- `canon_log_facts` — parsed `plot/canon-log.md` facts with status (ACTIVE / CHANGED / SUPERSEDED) and domain
-- `character_index` — all character files as flat list (slug/name/role/description)
-- `chapter_timelines` — intra-day timeline grids for ALL chapters (any status); use these as the source of truth for chapter start/end anchors and scene-level clock times instead of re-parsing each `README.md`
+- `travel_matrix` — parsed `world/setting.md` Travel Matrix rows (**fiction only** — empty for memoir)
+- `canon_log_facts` — parsed `plot/canon-log.md` facts (**fiction only** — empty for memoir)
+- `character_index` — all character/people files as flat list (slug/name/role/description)
+- `chapter_timelines` — intra-day timeline grids for ALL chapters
 - `errors` — graceful degrade: non-empty means some files were missing or unreadable
 
-Honor every populated field in the brief. Empty lists mean "file missing — degrade gracefully, do not invent."
+Honor every populated field. Empty lists mean "file missing — degrade gracefully, do not invent."
+
+**Memoir supplement:** If `book_category == "memoir"`, also directly read `{project}/plot/people-log.md` (analogue of canon-log for memoir). If it doesn't exist yet, note this in the report and proceed without it.
 
 ### Step 2 — Load book metadata
 
 - Load book data via MCP `get_book_full()`
 
-### Step 3 — Read the chapter drafts (direct file reads — this is the content under review)
-
-Chapter draft texts are intentionally NOT in the brief — they are the data being checked, not project-state metadata.
+### Step 3 — Read the chapter drafts (direct file reads)
 
 - Read ALL chapter drafts: `{project}/chapters/*/draft.md`
 
@@ -83,8 +89,11 @@ Flag as **WARNING** if:
 - The timeline doesn't have an entry for this chapter yet
 - A relative time reference is ambiguous
 
-### Step 3: Validate Against Travel Matrix
+### Step 3: Validate Against Travel Matrix / Real-World Geography
 
+Branch by `book_category`:
+
+**Fiction — Validate Against Travel Matrix:**
 For each spatial claim:
 1. Identify the route (From → To)
 2. Look up the route in `world/setting.md` Travel Matrix
@@ -98,6 +107,16 @@ Flag as **CONFLICT** if:
 Flag as **INFO** if:
 - Route exists but travel time varies within 30% (traffic, weather — acceptable)
 
+**Memoir — Real-World Plausibility Check:**
+No Travel Matrix exists for memoir. For each spatial claim with a stated travel time or distance:
+1. Use common-sense real-world geography (or WebSearch for specific routes if needed)
+2. Flag claims that are implausible (e.g., "the 10-minute walk to school" — if research shows the distance is 3km)
+3. Do NOT construct or propose a Travel Matrix for memoir
+
+Flag as **WARNING** if:
+- A stated travel time seems implausible for the described distance/mode of transport
+- A location's described size or layout contradicts what is known about the real place
+
 ### Step 4: Rebuild Timeline (if missing or incomplete)
 
 If `plot/timeline.md` is empty or incomplete:
@@ -106,49 +125,68 @@ If `plot/timeline.md` is empty or incomplete:
 3. Write the proposed timeline to `plot/timeline.md`
 4. Mark all entries as `[RECONSTRUCTED]` so the author can verify
 
-### Step 5: Rebuild Travel Matrix (if missing or incomplete)
+**Memoir note:** Memoir timelines use real dates. If chapters reference verifiable public events (news, seasons, school years), use those as anchors for the reconstructed timeline.
 
-If Travel Matrix in `world/setting.md` is empty or has gaps:
+### Step 5: Rebuild Travel Matrix (fiction only)
+
+**Skip entirely for memoir.**
+
+If Travel Matrix in `world/setting.md` is empty or has gaps (fiction only):
 1. Collect all travel references from chapters
 2. Build a proposed Travel Matrix (most frequently mentioned values win)
 3. Note conflicts in the matrix
 4. Add proposed entries with `[RECONSTRUCTED]` marker
 
-### Step 6: Validate Fact Consistency (Canon Log)
+### Step 6: Validate Fact Consistency
 
-**If `plot/canon-log.md` exists:**
+Branch by `book_category`:
+
+**Fiction — Canon Log:**
+
+If `plot/canon-log.md` exists:
 1. For each fact marked `CHANGED`, scan all chapters AFTER the revision for references to the OLD version
 2. For each fact marked `ACTIVE`, verify it isn't contradicted in any chapter
 
-**If `plot/canon-log.md` is empty or missing:**
+If `plot/canon-log.md` is empty or missing:
 1. Extract key facts from each chapter (character traits, abilities, relationships, rules)
 2. Build a proposed Canon Log organized by domain (Character, Relationship, World, Plot)
-3. Identify contradictions between chapters (e.g., Ch 4 says "eats normally" but Ch 8 says "doesn't eat")
-4. Write the proposed Canon Log to `{project}/plot/canon-log.md` with `[RECONSTRUCTED]` markers
+3. Identify contradictions between chapters
+4. Write to `{project}/plot/canon-log.md` with `[RECONSTRUCTED]` markers
 
-**Fact categories to extract:**
-- Character abilities/limitations (e.g., "can/cannot eat", "has/doesn't have powers")
-- Character descriptions (appearance, age, occupation)
-- Relationship status (who knows whom, family ties)
-- Rules of the world (how magic/supernatural elements work)
-- Object ownership/possession (who has the key, where is the artifact)
+Fact categories: character abilities/limitations, descriptions, relationship status, world rules, object ownership.
+
+**Memoir — People Log:**
+
+If `{project}/plot/people-log.md` exists:
+1. For each entry, verify that all chapters referencing that person are consistent with what the log records (what they did, said, believed in each chapter)
+2. Flag any chapter that contradicts an established people-log entry
+
+If `people-log.md` is missing:
+1. Extract key facts about named people from each chapter (descriptions, behaviors, quotes attributed to them, relationship status)
+2. Build a proposed People Log organized by person
+3. Identify contradictions between chapters (e.g., Ch 3 says "she never spoke about the accident" but Ch 7 has her describing it)
+4. Write to `{project}/plot/people-log.md` with `[RECONSTRUCTED]` markers
+
+People-log fact categories: physical description, relationship to author, what they said/did/believed in each chapter, consent_status if known.
 
 Flag as **FACT CONFLICT** if:
-- A chapter references the old version of a `CHANGED` fact
-- Two chapters make contradictory claims about the same fact
-- A character behaves inconsistently with established abilities/traits
+- Two chapters make contradictory claims about the same person or fact
+- A chapter contradicts an established people-log entry
 
 ### Step 7: Output Report
+
+Fiction report includes Travel Matrix section. Memoir replaces it with Real-World Plausibility and uses People Log instead of Canon Log.
 
 ```markdown
 # Continuity Check Report — {Book Title}
 Generated: {date}
+Book category: {fiction | memoir}
 
 ## Summary
 - Chapters scanned: X
 - Timeline entries: X
-- Travel Matrix routes: X
-- Canon facts tracked: X
+- [Fiction] Travel Matrix routes: X | [Memoir] Spatial plausibility checks: X
+- [Fiction] Canon facts tracked: X | [Memoir] People-log entries: X
 - CONFLICTS: X (temporal: X, spatial: X, fact: X)
 - WARNINGS: X
 
@@ -164,35 +202,38 @@ Generated: {date}
 
 ---
 
-## Spatial Conflicts
+## [Fiction] Spatial Conflicts — Travel Matrix
 
 ### CONFLICT: Chapter 5 vs Travel Matrix
 **Chapter 5:** "The city was only 12 km away, and the drive took 40 minutes"
 **Travel Matrix:** City → Campground = 120 km / 2h 30min
-**Analysis:** 12 km at normal speed = ~10 minutes, not 40. 40 minutes ≈ 40 km. Neither matches.
-**Suggested fix:** Update Chapter 5 to "120 km / 2.5 hours" or update Travel Matrix if 12 km is correct.
+**Suggested fix:** Update Chapter 5 or Travel Matrix for consistency.
+
+## [Memoir] Spatial Plausibility
+
+### WARNING: Chapter 5 — implausible travel time
+**Chapter 5:** "the 10-minute walk to school"
+**Real-world assessment:** ~3km distance = approx 35-40 minutes on foot.
+**Suggested fix:** Revise the stated duration or distance.
 
 ---
 
-## Fact Conflicts
+## [Fiction] Fact Conflicts — Canon Log / [Memoir] Fact Conflicts — People Log
 
-### CONFLICT: Chapter 4 (revised) vs Chapter 8
-**Canon Log:** "Marcus eats normal food" (CHANGED in Ch 4 revision, was: "Marcus doesn't eat")
-**Chapter 8:** "You don't eat, remember?" — Lena said, pushing her plate aside.
-**Analysis:** Chapter 8 still references pre-revision fact. Marcus now eats normally per Ch 4.
-**Suggested fix:** Rewrite Ch 8 dialog to reflect that Marcus eats.
+### CONFLICT: Chapter 4 vs Chapter 8
+**[Fiction] Canon Log / [Memoir] People Log:** [established fact]
+**Chapter 8:** [contradicting text]
+**Suggested fix:** [options]
 
 ---
 
 ## Warnings (verify manually)
-
 - Chapter 4: "a few days later" — ambiguous, not reflected in timeline.md
-- Chapter 9: travel route "downtown → warehouse" not in Travel Matrix
+- [Fiction] Chapter 9: travel route "downtown → warehouse" not in Travel Matrix
 
 ---
 
 ## Reconstructed Timeline
-
 *(Only shown if timeline.md was empty/incomplete)*
 ...
 ```
@@ -203,12 +244,17 @@ Write report to `{project}/research/continuity-report.md`.
 
 Suggest: Fix conflicts manually or ask chapter-reviewer to address specific chapters.
 
-### Step 9: Update Canon Log
+### Step 9: Update Fact Log
 
-If the Canon Log was reconstructed or new facts were discovered:
-1. Save the updated Canon Log to `{project}/plot/canon-log.md`
+**Fiction:** If the Canon Log was reconstructed or new facts were discovered:
+1. Save to `{project}/plot/canon-log.md`
 2. Populate the Revision Impact Tracker with chapters that need attention
 3. Report to the user which chapters are flagged as `[STALE]`
+
+**Memoir:** If the People Log was reconstructed or new facts were discovered:
+1. Save to `{project}/plot/people-log.md`
+2. Flag chapters that contradict the log as `[STALE]`
+3. If any person with `consent_status: refused` appears in a chapter — flag as CRITICAL, route to `/storyforge:memoir-ethics-checker`
 
 ## Rules
 - Report ALL conflicts, even minor ones. The author decides what to fix.

--- a/skills/cover-artist/SKILL.md
+++ b/skills/cover-artist/SKILL.md
@@ -3,6 +3,7 @@ name: cover-artist
 description: |
   Generate cover art prompts for DALL-E or Midjourney based on genre and story.
   Use when: (1) User says "Cover", "Buchcover", (2) Book needs a cover.
+  Works for both fiction and memoir books.
 model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<book-slug>"
@@ -14,19 +15,36 @@ argument-hint: "<book-slug>"
 
 ### Step 1: Context
 - Load book data via MCP `get_book_full()`
+- Read `book_category` — branch Step 2 and Step 3 on `fiction` vs `memoir`
 - Read `{project}/synopsis.md` for story summary
 - Load genre README(s) for visual conventions
 
 ### Step 2: Cover Brief
-Develop with user in `{project}/cover/brief.md`:
+
+Develop with user in `{project}/cover/brief.md`. Branch by `book_category`:
+
+**Fiction brief questions:**
 - **Mood/atmosphere:** What should the cover FEEL like?
 - **Key visual element:** One dominant image (don't overcrowd)
 - **Color palette:** Genre conventions (horror=dark, romance=warm, sci-fi=cool/neon)
 - **Typography style:** serif (literary/historical), sans-serif (modern/thriller), display (fantasy/horror)
 - **Comparable covers:** "I want it to look like covers of [author/book]"
 
+**Memoir brief questions:**
+- **Cover approach:** Photographic (personal/period photo), Typographic (bold text, minimal image), or Portrait (author-as-subject)?
+- **Photo availability:** Is there a meaningful real photo — author at the relevant age, a significant place, a family object?
+- **Time period feel:** Should the cover signal the era the memoir covers (vintage tones, period aesthetic) or feel contemporary?
+- **Author presence:** Should the author's face/image appear on the cover, or stay anonymous (place, object, silhouette)?
+- **Tone:** Intimate and personal? Weighty and serious? Warm and reflective?
+- **Comparable covers:** Memoir covers to reference (e.g., *The Glass Castle*, *Educated*, *Between the World and Me*, *When Breath Becomes Air*)
+
 ### Step 3: Generate Prompts
-Write to `{project}/cover/prompts.md`:
+
+Write to `{project}/cover/prompts.md`. Branch by `book_category`:
+
+---
+
+**Fiction prompts:**
 
 **For Midjourney:**
 ```
@@ -45,12 +63,48 @@ Composition: [centered/asymmetric/dramatic angle].
 No text on the image.
 ```
 
-Generate 3-5 prompt variations with different approaches:
+Fiction prompt variations (generate 3-5):
 1. **Symbolic:** Abstract representation of the theme
 2. **Scene:** Key moment from the story
 3. **Character:** Protagonist portrait/silhouette
 4. **Object:** Iconic object from the story
 5. **Atmospheric:** Mood/setting without characters
+
+---
+
+**Memoir prompts:**
+
+Memoir covers lean toward restraint — authenticity over drama. The cover should feel like the book: personal, honest, unguarded.
+
+**For Midjourney:**
+```
+/imagine [description], [period/mood], [color palette], [lighting],
+memoir book cover design, literary memoir cover, typographic emphasis,
+professional book cover, --ar 2:3 --stylize [value] --v 6
+```
+
+**For DALL-E:**
+```
+A professional book cover for a memoir titled "[Title]".
+[Description of the central visual element — photo, place, or portrait].
+[Time period and atmosphere]. [Color palette — muted/warm/high-contrast].
+[Lighting — soft and natural / dramatic / nostalgic].
+Style: [photorealistic / documentary photography aesthetic / vintage].
+Composition: [centered portrait / full-bleed place / object against plain background].
+No text on the image.
+```
+
+Memoir prompt variations (generate 3-4 — not all will apply):
+1. **Portrait approach:** Close or medium shot of a person at the relevant age/time period — evokes the human at the center of the story. If using AI: do not use a real person's likeness; generate an anonymous portrait in period-appropriate style.
+2. **Place approach:** A meaningful location from the memoir — a childhood home, a road, a landscape — rendered with emotional weight. Often the strongest memoir cover.
+3. **Object approach:** A significant personal object — a photograph, a letter, a worn item — on a plain or textured background. Works best for intimate, small-scope memoirs.
+4. **Typographic approach:** Minimal or no image — strong typography does the work. Bold author name + title, atmospheric paper/texture background. Common for literary and political memoirs.
+
+**Color palette guidance for memoir:**
+- Period memoir (pre-1980): desaturated, warm-sepia, faded tones, aged paper
+- Contemporary memoir: cleaner tones, high contrast, or muted naturalistic
+- Trauma/difficult subject memoir: high contrast, stark, monochrome + accent color
+- Warm/family memoir: soft warm tones, golden light, lived-in textures
 
 ### Step 4: Platform Specs
 Include size requirements:
@@ -64,3 +118,4 @@ Include size requirements:
 - Genre conventions matter: horror readers expect dark covers, romance expects warmth
 - Less is more — one strong visual > cluttered composition
 - The cover must work as a THUMBNAIL (social media, online stores)
+- **Memoir:** never generate a real person's likeness in AI prompts — use anonymous period portraits or places/objects instead. If the author wants their own photo on the cover, that's a separate production task (photographer or existing photo), not an AI-generation task.

--- a/skills/create-author/SKILL.md
+++ b/skills/create-author/SKILL.md
@@ -16,6 +16,18 @@ Author profiles are StoryForge's defense against generic AI output. Every stylis
 
 ## Workflow
 
+### Phase 0: Detect Primary Category
+
+Ask: *"Will this author primarily write fiction, memoir, or both?"*
+
+- **Fiction** → proceed through Phase 1–5 as-is (fiction path)
+- **Memoir** → Phase 1–3 branch into memoir-specific questions (memoir path)
+- **Both** → run fiction path first; then add memoir-specific fields at the end of Phase 3
+
+---
+
+## Fiction Path
+
 ### Phase 1: Identity
 Ask the user:
 1. **Pen name** — What should this author be called?
@@ -32,7 +44,7 @@ Guide the user through voice choices (use AskUserQuestion):
 5. **Vocabulary level:** simple, moderate, advanced, archaic
 6. **Dialog style:** naturalistic, stylized, minimal, heavy
 7. **Pacing:** slow-burn, tension-driven, breakneck, literary
-8. **Writing process (author_writing_mode):** How does this author approach planning?
+8. **Writing process (author_writing_mode):**
    - **Outliner** — Plans everything before writing (beats, chapter outlines, full plot map)
    - **Plantser (Hybrid)** — Knows the key story beats, discovers the rest scene by scene
    - **Discovery Writer (Pantser)** — Finds the story as they write; no outline before drafting
@@ -43,17 +55,80 @@ Ask open-ended questions:
 - "What does this author NEVER do?" (e.g., happy endings, love triangles, info-dumps)
 - "What's this author's signature move?" (e.g., unreliable narrators, gut-punch endings, dry wit in dark moments)
 
-### Phase 4: Create Profile
-1. Use MCP `create_author()` with collected data, then immediately call MCP `update_author(slug, "author_writing_mode", value)` to persist the writing mode
-2. Load the generated `profile.md` and `vocabulary.md`
-3. Review the banned words list (AI tells) — ask if user wants to add/remove any
-4. Show the complete profile to the user
-
-### Phase 5: Study (Optional)
+### Phase 5: Study (Fiction Optional)
 Ask: "Do you have PDFs or text files from authors whose style you want to channel? → `/storyforge:study-author`"
 
+---
+
+## Memoir Path
+
+Memoir profiles differ from fiction profiles in what matters: the author IS the material. Voice authenticity is even more non-negotiable — and the profile needs fields that fiction doesn't: relationship to material, subject position, and off-limits decisions.
+
+### Phase 1: Identity (Memoir)
+Ask the user:
+1. **Name / pen name** — What should this author be called? (May use real name)
+2. **Memoir scope tags** — What kind of memoir? (e.g., memoir-of-illness, memoir-of-family, memoir-of-place, memoir-of-addiction, memoir-of-work — these are not genres but thematic anchors)
+3. **Writing influences** — Which memoirists or essayists inspire this voice? (e.g., Mary Karr, Tara Westover, Carmen Maria Machado, Ta-Nehisi Coates, Kiese Laymon, Roxane Gay, Paul Kalanithi)
+
+### Phase 2: Voice Definition (Memoir)
+Same universal voice questions as fiction, plus memoir-specific additions:
+
+1. **Narrative voice:** first-person (default for memoir), or second-person (rare, experimental)
+2. **Tense:** past (most common), present (immersive), or mixed (past for events, present for reflection)
+3. **Tone:** Select 2-4 from: confessional, unflinching, elegiac, wry, tender, sardonic, reckoning, defiant, searching, intimate, measured, fierce
+4. **Sentence style:** short-punchy, long-flowing, varied, minimalist
+5. **Vocabulary level:** simple, moderate, advanced
+6. **Pacing:** slow-burn, reflective, urgent, episodic
+7. **Writing process (author_writing_mode):**
+   - **Structured** — Outlines the narrative arc before drafting scenes
+   - **Accumulative** — Writes scenes as they come, shapes structure in revision
+   - **Discovery** — Finds the story by writing toward it; structure emerges
+
+**Memoir-specific fields (ask separately):**
+
+8. **Subject position** — Whose story is primarily at the center?
+   - **Writing-self** — Primarily about the author's own experience and inner life (e.g., *Wild*, *Hunger*)
+   - **Writing-other** — The author as witness; another person or community is the center (e.g., *The Glass Castle*, *Between the World and Me*)
+   - **Shared story** — Author and another person equally central
+
+9. **Relationship to material** — How close are you to these events, emotionally and temporally?
+   - *Recent (< 5 years):* Still processing; emotional distance may be limited
+   - *Mid-range (5–20 years):* Some perspective, emotional residue still present
+   - *Distant (20+ years):* Full retrospective vantage; risk is sentimentalization
+   Ask: "This shapes how much retrospective commentary vs. in-scene immediacy the memoir will need."
+
+10. **Off-limits** — What is absolutely NOT going to appear in this memoir?
+    - Family members who have refused or would refuse consent?
+    - Events too raw to write about yet?
+    - Information that would harm living people if published?
+    Save these in the profile as `off_limits` — the chapter-writer and ethics-checker will honor them.
+
+### Phase 3: Deeper Character (Memoir)
+Ask open-ended questions tailored to memoir:
+- "What do you want readers to understand that only YOU could tell them?" (The unique access — what only this author could have witnessed or lived)
+- "What are you afraid to write?" (The avoidance points — often the most important material)
+- "What is your 'why now'?" (Why is this the right moment to write this memoir? What changed?)
+- "What will you protect?" (What relationships or people are you not willing to damage — and how does that shape the story you can tell?)
+
+---
+
+## Shared Phase 4: Create Profile
+
+1. Use MCP `create_author()` with collected data
+2. Call MCP `update_author(slug, "author_writing_mode", value)` to persist writing mode
+3. For memoir authors, also call `update_author(slug, "subject_position", value)` and `update_author(slug, "off_limits", value)`
+4. Load the generated `profile.md` and `vocabulary.md`
+5. Review the banned words list (AI tells) — ask if user wants to add/remove any
+6. For memoir: pre-populate memoir-specific AI tells from `book_categories/memoir/craft/memoir-anti-ai-patterns.md` (reflective platitudes, "looking back I realize", tidy lesson endings)
+7. Show the complete profile to the user
+
+## Shared Phase 5: Study (Optional)
+- **Fiction:** "Do you have PDFs from authors whose style you want to channel? → `/storyforge:study-author`"
+- **Memoir:** "Do you have personal journals, letters, or old writing to analyze for your authentic voice? → `/storyforge:study-author` (memoir mode)"
+
 ## Rules
-- **MANDATORY:** Every profile must have the "avoid" list pre-populated with AI-tell words from `anti-ai-patterns.md`. **Why:** AI-tell words are the most frequent authenticity-killers — without a per-author banlist, the chapter-writer falls back to generic AI register and the author profile becomes decorative.
-- Tone descriptors should be SPECIFIC, not generic ("sardonic with rural cadence" beats "edgy").
+- **MANDATORY:** Every profile must have the "avoid" list pre-populated with AI-tell words from `anti-ai-patterns.md`. For memoir, additionally pre-populate with memoir-specific AI tells.
+- Tone descriptors should be SPECIFIC, not generic ("searching with dry wit" beats "introspective").
 - Influences should be REAL authors the user has actually read.
 - The profile is a living document — it evolves as the author writes.
+- **Memoir:** off-limits decisions made here carry forward — they are not decoration. The ethics-checker and chapter-writer enforce them.

--- a/skills/promo-writer/SKILL.md
+++ b/skills/promo-writer/SKILL.md
@@ -12,11 +12,12 @@ argument-hint: "<book-slug> [platform]"
 # Promo Writer — Social Media Content Creator
 
 ## Prerequisites
-- Load book data via MCP `get_book_full()`
+- Load book data via MCP `get_book_full()` — read `book_category`
 - Read `{project}/synopsis.md` for pitch material
 - Load author profile via MCP `get_author()` — promo voice should match author brand
 - Load genre README(s) — genre audiences have different platform habits
-- Read `{project}/characters/INDEX.md` for character-driven content
+- **Fiction:** Read `{project}/characters/INDEX.md` for character-driven content
+- **Memoir:** Read `{project}/people/INDEX.md` (or `{project}/characters/INDEX.md` for legacy projects) — use real names as they appear in the memoir (or their anonymization aliases)
 - Read `{plugin_root}/reference/promo/platforms.md` — platform characteristics and content-type templates
 
 ## Workflow
@@ -29,7 +30,11 @@ The book blurb is the single most important marketing text — it must exist bef
 - `{project}/synopsis.md` — Short Synopsis section is the raw material
 - Genre README(s) — tone guidance for the blurb voice
 
-**Walk through the 5-element structure:**
+Branch the blurb structure on `book_category`:
+
+---
+
+**Fiction blurb — 5-element structure:**
 
 1. **Hook** — Opening line that captures the core premise. One sentence, written to grab a skimming reader.
 2. **Character Introduction** — Protagonist name + one defining characteristic. Enough to care, nothing more.
@@ -42,7 +47,31 @@ The book blurb is the single most important marketing text — it must exist bef
    - Literary Fiction: interiority, ambiguity, weight
 5. **Comp Titles** (optional) — "_X_ meets _Y_" format. Only include if the comparison is strong and both titles are recognizable.
 
-**Target:** 150–200 words. Rigorously edited. No spoilers. No ending revealed.
+---
+
+**Memoir blurb — 4-element structure:**
+
+Memoir blurbs sell a specific kind of trust: *this person lived through something, and they're going to tell you the truth about it.* The reader doesn't buy plot — they buy the author's voice and the promise of resonance.
+
+1. **Hook** — The most dramatic moment, the sharpest image, or the most distinctive angle of the memoir. One sentence that makes the reader think "I need to know more." Often drawn from a vivid scene rather than a thematic statement.
+2. **Personal Stake** — Why did THIS author have to write THIS story? The "why me, why now" that earns the reader's trust. What the author had to lose by not telling it.
+3. **Universal Theme** — The thing the reader will recognize from their own life. Not a lesson ("I learned that...") but a shared human experience ("For anyone who has ever..."). This is what moves memoir from personal to universal.
+4. **Tone Signal** — A closing phrase or sentence that sets the emotional register:
+   - Intimate and confessional: warm, direct, the author speaking to you personally
+   - Investigative/reckoning: measured, unsettling, questions that don't resolve neatly
+   - Defiant/reclaimed: energy, agency, transformation
+   - Elegiac/grief memoir: weight, tenderness, acceptance
+5. **Comp Titles** (optional) — Comp *memoirs*, not novels. e.g., "Readers of Tara Westover's *Educated* and Carmen Maria Machado's *In the Dream House* will recognize this voice." Only use comps you can defend.
+
+**Memoir blurb rules:**
+- Never call the book "a journey" or "a powerful story." These are death-blurb words.
+- Never use "lessons learned" framing — that promises therapeutic tidiness the best memoir avoids.
+- Keep the author's name in the blurb — memoir is the author, not a protagonist.
+- Do NOT reveal how the story ends. But unlike fiction, the resolution is usually known (the author survived, recovered, left) — the blurb's tension is about the reader's resonance, not plot mystery.
+
+---
+
+**Target for both modes:** 150–200 words. Rigorously edited.
 
 **Output:** Save to `{project}/export/blurb.md` using `templates/blurb.md` as scaffold.
 
@@ -56,6 +85,8 @@ Ask the user:
 - **Platforms:** Which ones? (or all)
 - **Tone:** Match author brand or separate marketing voice?
 - **Content types wanted:** (use AskUserQuestion, multiSelect)
+
+**Fiction content types:**
   - Teaser/Hook posts
   - Character introductions
   - Behind-the-scenes (writing process)
@@ -64,6 +95,15 @@ Ask the user:
   - Review/testimonial templates
   - Series announcement
   - Giveaway posts
+
+**Memoir content types (replace/supplement):**
+  - "True story" hook posts (the inciting moment, the most arresting scene)
+  - Author voice posts (the author speaking directly — not "meet the protagonist")
+  - Behind-the-memoir posts (why they wrote it, what it cost to write)
+  - Quote cards (memoir quotes land differently — first-person, raw)
+  - "You're not alone" resonance posts (universal theme framing)
+  - Launch announcement
+  - Review/testimonial templates (especially for readers who share similar experiences)
 
 ### Step 3: Generate Platform-Specific Content
 
@@ -79,11 +119,20 @@ Available platforms: `facebook.md`, `instagram.md`, `twitter.md`, `tiktok.md`, `
 ---
 
 ### Step 4: Quote Cards
-Extract 5-10 compelling quotes from the book for visual content:
+Extract 5-10 compelling quotes from the book for visual content.
+
+**Fiction:**
 - **Criteria:** Punchy, evocative, standalone (no context needed)
 - **Length:** 1-3 sentences max
 - **Types:** Dialog zingers, atmospheric descriptions, thematic statements
 - **Format:** Quote + character attribution + book title
+
+**Memoir:**
+- **Criteria:** Raw, honest, resonant — the sentences readers will screenshot and share
+- **Length:** 1-3 sentences. Fragments work well in memoir.
+- **Types:** First-person observations, moments of reckoning, the precise image that captures everything
+- **Format:** Quote + book title (no character attribution — the author is the narrator)
+- **Avoid:** Therapeutic wisdom quotes ("I learned that..."), inspirational-poster phrasing — memoir quote cards win on specificity and honesty, not uplift.
 
 Write to `{project}/promo/quotes.md`.
 

--- a/skills/researcher/SKILL.md
+++ b/skills/researcher/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: researcher
 description: |
-  Research topics for story authenticity via web search.
+  Research topics for story or memoir authenticity via web search.
   Use when: (1) User says "Recherche", "research", "find out about",
-  (2) Story requires factual accuracy (historical periods, locations, professions, etc.).
+  (2) Story requires factual accuracy (historical periods, locations, professions, etc.),
+  (3) Memoir author needs to verify dates, period details, or remembered facts.
 model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<topic> [book-slug]"
@@ -11,33 +12,76 @@ argument-hint: "<topic> [book-slug]"
 
 # Researcher
 
+## Step 0 — Resolve book category
+
+Load `book_category` from MCP `get_book_full(book_slug)`. Treat missing as `fiction`.
+Branch Step 1 on `book_category` — the research categories differ fundamentally.
+
 ## Workflow
 
-1. **Identify research needs** — What does the story require?
-   - Historical accuracy (dates, events, culture)
-   - Location authenticity (geography, architecture, atmosphere)
-   - Professional knowledge (how a job/skill works)
-   - Scientific plausibility (for sci-fi, medical thrillers)
-   - Cultural authenticity (customs, language, social norms)
-   - Mythology/lore (for supernatural, fantasy)
+### Step 1: Identify Research Needs
 
-2. **Research** — Use WebSearch to find authoritative sources
-   - Academic sources over blog posts
-   - Primary sources when possible
-   - Multiple perspectives on controversial topics
-   - Date-check: ensure information is current
+Branch by `book_category`:
 
-3. **Synthesize** — Write findings to `{project}/research/notes/{topic-slug}.md`
-   - Key facts relevant to the story
-   - Sensory details that can be woven into prose (sights, sounds, smells)
-   - Common misconceptions to avoid
-   - Source citations
+**Fiction** — What does the story require?
+- Historical accuracy (dates, events, culture)
+- Location authenticity (geography, architecture, atmosphere)
+- Professional knowledge (how a job/skill works)
+- Scientific plausibility (for sci-fi, medical thrillers)
+- Cultural authenticity (customs, language, social norms)
+- Mythology/lore (for supernatural, fantasy)
 
-4. **Update sources** — Add to `{project}/research/sources.md`
+**Memoir** — What does the memoirist need to verify or recover?
+- **Memory verification** — Are dates, names, and events as you remember them? (Newspapers, diaries, public records)
+- **Period detail** — What was the physical world actually like then? (Buildings, prices, technology, music, fashion)
+- **Place recovery** — What does archive material show about a place you remember? (Old maps, photographs, local histories)
+- **Timeline anchoring** — What publicly-documented events fix the chronology? (News events, school years, weather records)
+- **People context** (with care) — Public facts about real people relevant to the story (only public records; never private investigation)
+- **Cultural/historical context** — What was the social climate, political mood, or institutional reality at the time?
 
-5. **Connect to story** — How does this research serve the narrative?
+Note: Memoir research serves **verification and depth**, not world-building. The goal is to make remembered experience more accurate and more vivid — not to invent.
+
+### Step 2: Research
+
+Use WebSearch to find authoritative sources:
+- Academic sources over blog posts
+- Primary sources when possible (newspaper archives, official records, period photographs)
+- Multiple perspectives on contested or politically sensitive topics
+- Date-check: ensure information is current for contemporary memoir; period-accurate for historical memoir
+
+**Memoir note:** For people-related research, limit to publicly available information. Do not compile private details about living individuals beyond what is directly relevant to verifiable shared events.
+
+### Step 3: Synthesize
+
+Write findings to `{project}/research/notes/{topic-slug}.md`.
+
+**Fiction captures:**
+- Key facts relevant to the story
+- Sensory details that can be woven into prose (sights, sounds, smells)
+- Common misconceptions to avoid
+- Source citations
+
+**Memoir captures:**
+- Verified facts that confirm or correct memory
+- Period sensory details (what did it actually smell/sound/look like in that era?)
+- Documented timeline anchors (specific dates that fix when events happened)
+- Gaps where verification failed — note what could not be confirmed so it can be handled appropriately in prose
+- Source citations (for any factual claims in the finished memoir)
+
+### Step 4: Update sources
+
+Add to `{project}/research/sources.md`.
+
+### Step 5: Connect to story
+
+How does this research serve the narrative?
+
+**Fiction:** Does this detail create conflict, atmosphere, or authenticity? If it doesn't serve the story, it stays below the iceberg.
+
+**Memoir:** Does this verified detail strengthen the narrative's factual grounding? Does it resolve a memory gap? Note if the verified version differs from what the memoirist remembers — that gap itself may be narratively meaningful.
 
 ## Rules
-- Research serves the STORY, not the encyclopedia
-- Capture sensory details — those make fiction authentic
+- Research serves the STORY (fiction) or the TRUTH (memoir), not the encyclopedia
+- Capture sensory details — those make both fiction and memoir vivid
 - Flag anything that might need sensitivity review
+- **Memoir:** if research surfaces information that contradicts the memoirist's memory, report honestly — do not quietly align findings with memory. The memoirist decides how to handle the discrepancy in prose.

--- a/skills/rolling-planner/SKILL.md
+++ b/skills/rolling-planner/SKILL.md
@@ -5,6 +5,7 @@ description: |
   Use when: (1) User says "rolling planner", "next scene", "was kommt als nächstes",
   (2) author_writing_mode is "discovery" and user is about to write a chapter,
   (3) Plantser needs to plan the next 3-5 scenes before chapter-writer runs.
+  Works for both fiction and memoir books.
 model: claude-sonnet-4-6
 user-invocable: true
 argument-hint: "[book-slug]"
@@ -16,6 +17,12 @@ Purpose: Replace full upfront outlining with a lightweight, just-in-time scene r
 written *before* `chapter-writer` runs. Discovery writers and plantsers use this
 instead of `plot-architect`.
 
+## Step 0 — Resolve book category
+
+Read `book_category` from `get_book_full(book_slug)`. Treat missing as `fiction`.
+
+If `book_category == "memoir"`, surface a one-line note: *"Working in memoir mode — questions will focus on lived stakes and memory, not invented plot."*
+
 ## Prerequisites
 - Load book via MCP `get_book_full(book_slug)`
 - Load author profile via MCP `get_author(author_slug)`
@@ -24,31 +31,47 @@ instead of `plot-architect`.
 ## Workflow
 
 ### Step 1: Orient — What Has Happened
-Read chapter READMEs (in order) via MCP to build a quick "story so far" summary:
-- Who is where, and what do they want right now?
-- What was the last thing that happened (last chapter's consequence)?
-- What loose threads are active (unresolved conflicts, open questions)?
 
-Present a 3-sentence "previously on" to the user and ask: *"Does this match your sense of where we are?"*
+Read chapter READMEs (in order) via MCP to build a quick summary. Branch by `book_category`:
+
+**Fiction:** "Story so far" — who is where, what do they want, what loose threads are active (unresolved conflicts, open questions)?
+
+**Memoir:** "Life so far in this section" — where in the author's life are we, what has just been revealed or confronted, which emotional threads are still unresolved?
+
+Present a 3-sentence orient to the user and ask: *"Does this match your sense of where we are?"*
 
 ### Step 2: Define What Needs to Happen Next
-Ask the user (use AskUserQuestion or conversational flow):
+
+Ask the user (use AskUserQuestion or conversational flow). Branch by `book_category`:
+
+**Fiction:**
 - **What does the protagonist want in the next scene?** (concrete goal, not theme)
 - **What stands in their way?** (person, situation, internal resistance)
 - **What should change by the end of this scene?** (something must shift — status, knowledge, relationship, plan)
 
-If the user doesn't know the answer to any of these, that's fine — help them discover it:
+If the user doesn't know, help them discover it:
 - "What would feel wrong if it *didn't* happen soon?"
 - "What does the antagonist/situation need from this moment?"
 - "What would surprise you as a reader?"
 
+**Memoir:**
+- **What did you need or want in this moment of your life?** (concrete — safety, acknowledgment, escape, connection)
+- **What blocked you, constrained you, or surprised you?** (person, circumstance, your own avoidance)
+- **What shifts by the end of this scene?** (in you, in a relationship, in your understanding of what happened)
+
+If the user doesn't know, help them discover it:
+- "What do you remember about this moment that you haven't written down yet?"
+- "What are you hesitating to put on the page — and why?"
+- "If this scene ended right now, what would feel unfinished?"
+
 ### Step 3: Write the Scene Recipe
-Compose a 3-part scene recipe (one line each):
+
+Compose a 3-part scene recipe (one line each). The structure is identical for both modes:
 
 ```
-Goal:        [What the POV character is trying to achieve]
-Conflict:    [What blocks or complicates that goal]
-Consequence: [What changes — resolution or disaster that opens the next scene]
+Goal:        [What the POV character / memoir-self is trying to achieve or reach]
+Conflict:    [What blocks or complicates that]
+Consequence: [What changes — resolution or new complication that opens the next scene]
 ```
 
 Ask the user to confirm or adjust. This is the contract the chapter-writer will fulfill.
@@ -62,8 +85,10 @@ expansion:
 
 This is optional. Skip for straightforward scenes.
 
-### Step 4b: Tactical Sanity Check (combat/travel scenes only)
-If the scene recipe involves combat OR group movement through dangerous space (keywords like `walk`, `hike`, `drive`, `attack`, `mission`, `enter the building`, `approach` with multiple characters), call MCP `verify_tactical_setup(book_slug, scene_outline_text, characters_present)` before saving the recipe. Resolve every warn-severity warning by adjusting the scene plan — do not defer to the chapter-writer to fix walking-order or formation problems in prose. Capture the answers to the returned `questions_for_writer` (who scouts, who covers the protected character, fallback formation) directly in the recipe so the chapter-writer has them when drafting.
+### Step 4b: Tactical Sanity Check (fiction combat/travel scenes only)
+**Skip entirely for memoir** — tactical formation checks don't apply to lived experience.
+
+For fiction: if the scene recipe involves combat OR group movement through dangerous space (keywords like `walk`, `hike`, `drive`, `attack`, `mission`, `enter the building`, `approach` with multiple characters), call MCP `verify_tactical_setup(book_slug, scene_outline_text, characters_present)` before saving the recipe. Resolve every warn-severity warning by adjusting the scene plan — do not defer to the chapter-writer to fix walking-order or formation problems in prose. Capture the answers to the returned `questions_for_writer` directly in the recipe.
 
 Skip this step for kitchen-table dialogue, internal monologue, or any scene without group movement.
 
@@ -86,3 +111,4 @@ This builds a rolling 3-5 scene buffer — enough to write without planning the 
 - After saving the recipe, always suggest: "Ready to write? → `/storyforge:chapter-writer`"
 - Plantser users: this skill complements the minimal outline from `plot-architect` — it adds
   scene-level detail only when needed, not upfront
+- **Memoir:** questions about "what happens next" translate to "what do you remember next / what are you ready to write." Never invent or suggest fictional resolutions to memoir material.

--- a/skills/study-author/SKILL.md
+++ b/skills/study-author/SKILL.md
@@ -3,7 +3,8 @@ name: study-author
 description: |
   Analyze PDFs or text files to extract writing style and update an author profile.
   Use when: (1) User says "Buch studieren", "study this PDF", "Stil analysieren",
-  (2) User wants to feed reference material to an author profile.
+  (2) User wants to feed reference material to an author profile,
+  (3) Memoir author wants to analyze their own journals, letters, or past writing.
 model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<file-path> [author-slug]"
@@ -12,9 +13,21 @@ argument-hint: "<file-path> [author-slug]"
 # Study Author — Style Extraction
 
 ## Purpose
-Extract concrete writing patterns from existing books/texts and encode them into an author profile. This is what makes the author profile REAL — not just abstract descriptors but measurable patterns derived from actual prose.
+Extract concrete writing patterns from texts and encode them into an author profile. This is what makes the author profile REAL — not just abstract descriptors but measurable patterns derived from actual prose.
 
-## Workflow
+**Two modes:**
+- **Fiction mode** — Analyze a published author's work to extract craft patterns to emulate.
+- **Memoir mode** — Analyze the memoirist's own personal writing (journals, letters, old blog posts, emails) to excavate their *authentic* voice from before they started worrying about craft.
+
+## Step 0 — Detect Mode
+
+Ask: *"Is this a published book/text by another author (fiction mode), or is this your own personal writing — journal, letters, diary (memoir mode)?"*
+
+Alternatively, detect from context: if the book linked to the author slug has `book_category: memoir` AND the user provides their own writing, default to memoir mode.
+
+---
+
+## Fiction Mode
 
 ### Phase 1: Input
 1. **Get file path** — User provides path to PDF, EPUB, DOCX, TXT, or MD file (max 50 MB)
@@ -60,19 +73,19 @@ Analyze the text for these concrete patterns:
 
 Before writing analysis to disk, ask: **"Has this author profile already had an initial profile generated via `/storyforge:create-author`? (Yes/No)"**
 
-- **If No:** Stop here. Direct the user to `/storyforge:create-author` first. Style-extraction is meant to *refine* an existing profile, not to bootstrap one — bootstrapping from a single studied work risks copying that author's signature too closely. Wait for explicit confirmation that the base profile exists before continuing.
+- **If No:** Stop here. Direct the user to `/storyforge:create-author` first. Style-extraction is meant to *refine* an existing profile, not to bootstrap one — bootstrapping from a single studied work risks copying that author's signature too closely.
 - **If Yes:** Proceed to Phase 3.
 
 ### Phase 3: Write Analysis
 Save analysis as `~/.storyforge/authors/{slug}/studied-works/analysis-{title}.md`
 
-Format:
 ```markdown
 ---
 title: "Original Book Title"
 author_of_source: "Original Author Name"
 analyzed: "2026-04-03"
 word_count: 85000
+mode: fiction
 ---
 
 # Style Analysis: {Title}
@@ -104,7 +117,102 @@ Update the author's `profile.md` and `vocabulary.md` based on findings:
 ### Phase 5: Report
 Show the user a summary of what was learned and what changed in the profile.
 
-## Rules
+---
+
+## Memoir Mode
+
+The goal is opposite to fiction mode: instead of learning *someone else's* craft patterns, we excavate *the author's own unguarded voice* — the one they had before they started thinking about writing.
+
+### Phase 1: Input
+1. **Get file path** — User provides path to journals, letters, diary entries, old blog posts, emails, or any personal writing (PDF, TXT, MD)
+2. **Get author** — Which author profile to update? Show list via MCP `list_authors()`
+3. **Read the file** — Same file handling as fiction mode. If the journal is handwritten and photographed, ask the user to transcribe a representative excerpt (~2000–5000 words) first.
+
+**No Phase 2.5 gate in memoir mode.** Studying your own personal writing IS a valid way to build or enrich a memoir author profile — it's not copying someone else's voice.
+
+### Phase 2: Analysis (Memoir-Specific)
+
+Analyze for these patterns — focused on authentic personal voice, not craft performance:
+
+**Natural Voice Fingerprints:**
+- How do sentences start? (Subject-verb? Fragment? Question? Aside?)
+- What's the default tense for self-narration?
+- How does the author refer to themselves? (I / we / one / unnamed)
+- Recurring sentence starters, verbal tics, filler phrases
+- How do they end entries — trailing off, punctuation, abrupt stop?
+
+**Emotional Register:**
+- Vocabulary for feelings — specific words they reach for (not generic happy/sad)
+- How directly do they name emotions vs. describing action/body?
+- Do they reflect or narrate? (Commentary-heavy vs. scene-heavy)
+- Hedging patterns: "I think", "maybe", "I'm not sure but" — or confident assertion?
+
+**Time Handling:**
+- Do they skip time or dwell? (Weeks in a sentence or hours in a page?)
+- How do they mark time: dates, seasons, relative anchors, none?
+- Do they write in the moment or in retrospect?
+
+**People Writing:**
+- How do they introduce people — named, described, or thrown in with assumed context?
+- How do they render speech — quoted, paraphrased, or summary?
+- What adjectives do they reach for when describing someone they love / fear / resent?
+
+**Personal Preoccupations:**
+- Recurring themes, worries, joys — the things they return to unprompted
+- Vocabulary clusters that signal their deepest concerns
+- What do they *not* say but circle around? (absence patterns)
+
+### Phase 3: Write Analysis
+Save as `~/.storyforge/authors/{slug}/studied-works/analysis-{title}.md`
+
+```markdown
+---
+title: "{Source description — e.g., 'Personal journals 2018-2022'}"
+author_of_source: "{Author's own name}"
+analyzed: "{date}"
+word_count: {approximate}
+mode: memoir
+---
+
+# Voice Excavation: {Source Description}
+
+## Natural Voice Fingerprints
+[Sentence starters, tense, self-reference, verbal tics]
+
+## Emotional Register
+[How feelings are expressed — specific words, direct vs. indirect]
+
+## Time Handling
+[How the author moves through time in personal writing]
+
+## People Writing
+[How they introduce, describe, quote the people in their life]
+
+## Personal Preoccupations
+[Recurring themes and vocabulary clusters]
+
+## Unguarded Phrases to Preserve
+[Specific turns of phrase that are uniquely theirs — the ones that would get "corrected" by an editor]
+
+## What to Carry into the Memoir
+[Synthesis: the 3-5 voice traits most worth protecting in polished prose]
+```
+
+### Phase 4: Update Profile
+Update the author's `profile.md` and `vocabulary.md` based on findings:
+- Add unguarded personal phrases to "Signature Phrases"
+- Add personal vocabulary to "Preferred Words"
+- Note the natural tense and self-reference style
+- Flag hedging or avoidance patterns as memoir-specific risks to watch
+- Add preoccupation themes — these are the memoir's authentic emotional spine
+
+### Phase 5: Report
+Show the user what was found and what changed. Specifically: which phrases are uniquely theirs and should survive editing, and which patterns (hedging, reflective platitudes) the memoir-anti-ai checker will flag.
+
+---
+
+## Rules (Both Modes)
 - Extract PATTERNS only — verbatim text from studied works belongs nowhere in the profile. Verbatim copy is plagiarism risk and AI-tell.
 - Multiple studied works refine the profile further — merge, don't overwrite. Each studied work is evidence; the profile is the synthesis.
-- Flag any conflicts between studied works (e.g., one book uses first person, another uses third) — surface to the user before merging.
+- Flag any conflicts between studied works — surface to the user before merging.
+- **Memoir mode:** privacy first. Journals contain sensitive material about third parties. The analysis extracts voice patterns — it does not summarize events, record names of people mentioned, or store any personal facts from the journals in the analysis file.

--- a/skills/world-builder/SKILL.md
+++ b/skills/world-builder/SKILL.md
@@ -11,11 +11,18 @@ argument-hint: "<book-slug>"
 
 # World Builder
 
-## Iceberg Principle (Core Operating Mode)
+## Step 0 — Resolve Book Category
+
+Read `book_category` from MCP `get_book_full(book_slug)`. Treat missing as `fiction`.
+
+- `fiction` → standard world-building workflow below
+- `memoir` → **Setting Notes Mode** (see end of this skill) — memoir uses real places, not invented worlds
+
+## Iceberg Principle (Fiction Core Operating Mode)
 
 **Show ~10% of the world in-story. Keep the other 90% in `{project}/world/` for consistency checks.** The world files are the author's reference, not the reader's experience. Avoid info-dumps in prose — exposition disguised as world-building is the most common AI-tell in fantasy/sci-fi drafts. Every world fact you generate here either pays off in conflict, character, or atmosphere — or it stays below the surface as continuity ballast.
 
-## Prerequisites — MANDATORY LOADS
+## Prerequisites — MANDATORY LOADS (Fiction)
 - **Book data** via MCP `get_book_full()`. **Why:** Genre, premise, characters — world-building must serve the story, not exist in parallel to it.
 - **`world-building` craft reference** via MCP `get_craft_reference()`. **Why:** Sanderson's Laws, iceberg principle, conflict-driven culture — the framework Steps 3-5 apply.
 - **Genre README(s)**. **Why:** Fantasy needs full world rules, contemporary needs almost none — depth scales with genre.
@@ -98,9 +105,89 @@ Create a consistency checklist in `{project}/world/rules.md`:
 
 Update book status to "World Built" via MCP `update_field()`.
 
-## Rules
+## Rules (Fiction)
 - ICEBERG PRINCIPLE: Know 100%, show ~10% in-story. The reader discovers through scene; the author keeps the rest as reference.
 - World-building lands through STORY — character action, dialogue, sensory detail. Exposition chapters break the spell.
 - Every rule you create is a promise — keep it. Magic systems that bend mid-book signal authorial cheating.
 - Consistency > realism. A consistent fantasy world feels more real than an inconsistent realistic one.
 - If you can't explain how a cultural element creates conflict, cut it from the story (keep it in setting.md only if it's load-bearing for continuity).
+
+---
+
+## Memoir Mode — Setting Notes
+
+Memoir does not invent worlds — it recovers real places. The world-builder skill in memoir mode serves a different purpose: **sensory anchoring and period accuracy**, so that remembered environments can be rendered with specificity rather than generic reconstruction.
+
+Memoir books typically have no `world/` directory — settings live in `research/sources.md` and within chapter prose. This skill creates or enriches `research/notes/setting-{location-slug}.md` files for each significant place.
+
+### Prerequisites (Memoir)
+- **Book data** via MCP `get_book_full()`.
+- **Memoir craft** — Read `book_categories/memoir/craft/scene-vs-summary.md` via `get_book_category_dir("memoir")`. **Why:** Setting in memoir is dramatized through scene, not described in exposition. The notes here feed scene-writing, not an info-dump.
+- Read existing `research/sources.md` and any existing setting notes.
+
+### Workflow (Memoir)
+
+#### Step 1: Identify Significant Places
+Ask the user: "Which locations in your memoir are emotionally or narratively significant? List them — even briefly."
+
+For each location, assess whether it deserves a setting note:
+- Places where key events happen (ALWAYS document)
+- Places the memoirist returned to repeatedly (document)
+- Places that shaped the author's inner life (document)
+- Background/transit locations (skip — a paragraph in prose is enough)
+
+#### Step 2: For Each Significant Place — Four Questions
+Work through the four questions that unlock sensory specificity:
+
+1. **What is the physical truth of this place?** (Layout, size, material, light — what would a photograph show?)
+2. **What does it sound and smell like?** (The non-visual senses that photograph can't capture — what will readers hold onto?)
+3. **How does it feel to be there?** (Temperature, texture, emotional register — what does it do to a person's body to be in this space?)
+4. **What has changed?** (If the author revisits this place as an adult, what is different? What is gone? What remained? The gap between then and now is often more powerful than the place itself.)
+
+If the memoirist doesn't remember — say so in the notes with `[unverified]`. Do not invent. Gaps can be used explicitly in prose ("I no longer remember whether the kitchen smelled of...").
+
+#### Step 3: Period Research (Optional)
+If a place existed in a specific historical period and factual accuracy matters:
+- Research the era via WebSearch (architecture, signage, businesses, transport of the time)
+- Note period-accurate sensory details that the memoirist may not remember consciously but that were physically true
+- Mark as `[researched]` to distinguish from direct memory
+
+#### Step 4: Write Setting Notes
+Save to `{project}/research/notes/setting-{location-slug}.md`:
+
+```markdown
+---
+location: "{Name}"
+period: "{Years/decade covered}"
+status: direct-memory | researched | unverified
+---
+
+# Setting Notes: {Name}
+
+## Physical Truth
+[What the place looks like — layout, materials, light]
+
+## Sensory Palette
+[Sound, smell, texture, temperature]
+
+## Felt Sense
+[What it does to a person to be there]
+
+## Period Accuracy
+[Notes from research on era-specific details — tagged [researched]]
+
+## The Gap (Then vs. Now)
+[What changed, what remained — only if relevant to the memoir]
+
+## Unverified / Gaps
+[What the author doesn't remember — to be handled explicitly in prose]
+```
+
+#### Step 5: Connect to Sources
+Add real-world sources to `{project}/research/sources.md` — photographs, maps, local histories, newspaper archives that informed the notes.
+
+### Rules (Memoir Setting Notes)
+- **Never invent.** If a sensory detail is not remembered and not researched, leave a gap. A memoirist who fills gaps with plausible fiction is writing unreliable memoir — and readers can tell.
+- **Distinguish memory from research.** Use `[remembered]` and `[researched]` tags when mixing sources — especially for places the author hasn't seen in decades.
+- **Settings serve scenes.** These notes exist to make scenes vivid and verifiable, not to be read by the reader. The prose is the output; the notes are the scaffold.
+- **No Travel Matrix.** Memoir does not need a Travel Matrix — real-world geography is not invented. If transit times matter, note real-world facts (the drive from X to Y takes N hours by car circa 1980s).


### PR DESCRIPTION
## Summary

Closes #64 (Phase 4 of Epic #97 — Memoir as second `book_type`).

Adds `book_category: memoir` branching to the 10 supporting skills listed in #64. All skills read `book_category` from `get_book_full()` and branch their workflow, questions, craft loads, and output accordingly. Fiction behavior is unchanged (zero regression).

### Skills branched

- **`brainstorm`** — excavation mode (three-question framework: why this story / why you / why now); refuses to invent memoir material; saves with `book_category: memoir`
- **`create-author`** — Phase 0 category detection; memoir path adds `subject_position` field (writing-self / writing-other / shared), `relationship_to_material`, `off_limits`; memoir AI-tell banlist pre-populated from `memoir-anti-ai-patterns.md`
- **`researcher`** — memoir self-research categories (memory verification, period detail, place recovery, timeline anchoring); reports unverifiable gaps honestly
- **`world-builder`** — Setting Notes mode: four-question sensory anchoring per real location; memory vs. researched tagging; no Travel Matrix
- **`rolling-planner`** — life-stakes questions instead of plot-stakes in Step 2; skips tactical sanity check for memoir
- **`continuity-checker`** — people-log instead of canon-log; real-world plausibility check replaces Travel Matrix; no matrix reconstruction; refused-consent flag in Step 9
- **`chapter-reviewer`** — Step 1b consent gate; memoir anti-AI 6-point section (reflective platitudes, looking-back hinges, tidy lesson endings, hedging density, therapeutic reframe, explanation-after-image); people-log continuity; dialog reconstruction honesty check
- **`cover-artist`** — photographic/typographic/portrait brief branch; period color palette guidance; privacy rule against AI-generating real-person likenesses
- **`promo-writer`** — 4-element memoir blurb (hook / personal stake / universal theme / tone signal); memoir content type list; memoir quote card guidance
- **`study-author`** — memoir self-study mode for journals/letters/diaries; voice excavation analysis dimensions; no Phase 2.5 gate for memoir

### Also included

- `CLAUDE.md` updated: Memoir Workflows section lists all 10 Phase 4 skills as wired; Rule 20 removes outdated manual-load bridge note

## Test plan

- [ ] Manually verify each branched skill with a `book_category: memoir` book
- [ ] Confirm fiction behavior unchanged for all 10 skills (create a fiction book, run each skill, check no memoir-mode activates)
- [ ] `continuity-checker`: verify people-log branch runs without Travel Matrix
- [ ] `chapter-reviewer`: verify consent gate surfaces as CRITICAL for refused-tier persons
- [ ] `brainstorm`: verify skill declines to invent memoir material when asked

## Related

- Epic: #97
- Phase 3 (already merged): #61, #62, #65, #66
- Integration tests: #68 (next, after this PR merges)