### PR TITLE
refactor: extract chapter_writing_brief loaders into focused modules (#121)

### DIFF
--- a/tests/test_chapter_writing_brief_loaders.py
+++ b/tests/test_chapter_writing_brief_loaders.py
@@ -1,0 +1,316 @@
+"""Per-loader tests for the chapter_writing_brief decomposition (Issue #121).
+
+Each loader is small enough that a focused test surface is cheap. The
+end-to-end ``build_chapter_writing_brief`` integration is already
+covered by ``tests/test_chapter_writing_brief.py`` and
+``tests/test_chapter_writing_brief_memoir.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.state.loaders.chapter_meta import (
+    load_book_category,
+    load_chapter_meta,
+    parse_overview_table,
+    serialize_chapter_meta,
+)
+from tools.state.loaders.claudemd_sections import (
+    callback_register_bullets,
+    classify_rule,
+    litmus_questions,
+    rule_bullets,
+)
+from tools.state.loaders.people import (
+    consent_status_warnings,
+    person_payload,
+    scan_for_named_characters,
+)
+from tools.state.loaders.recent_chapters import (
+    collect_recent_chapters,
+    count_similes,
+    last_paragraph,
+)
+
+
+# ---------------------------------------------------------------------------
+# chapter_meta
+# ---------------------------------------------------------------------------
+
+
+class TestParseOverviewTable:
+    def test_extracts_lowercase_keys(self) -> None:
+        text = (
+            "## Overview\n\n"
+            "| Title | The Storm |\n"
+            "| POV | Lena |\n"
+        )
+        cells = parse_overview_table(text)
+        assert cells["title"] == "The Storm"
+        assert cells["pov"] == "Lena"
+
+    def test_skips_dash_only_values(self) -> None:
+        text = (
+            "| Title | - |\n"
+            "| POV | Lena |\n"
+        )
+        cells = parse_overview_table(text)
+        assert "title" not in cells
+        assert cells["pov"] == "Lena"
+
+    def test_no_table_returns_empty(self) -> None:
+        assert parse_overview_table("# Plain prose\n") == {}
+
+
+class TestLoadChapterMeta:
+    def test_overview_table_fills_missing_pov(self, tmp_path: Path) -> None:
+        chapter_dir = tmp_path / "chapters" / "01-storm"
+        chapter_dir.mkdir(parents=True)
+        readme = chapter_dir / "README.md"
+        readme.write_text(
+            "## Overview\n\n"
+            "| Field | Value |\n"
+            "|---|---|\n"
+            "| Title | The Storm |\n"
+            "| POV | Lena |\n",
+            encoding="utf-8",
+        )
+        meta, pov, overview = load_chapter_meta(readme, "01-storm")
+        assert pov == "Lena"
+        assert meta["title"] == "The Storm"
+        assert overview["title"] == "The Storm"
+        assert overview["pov"] == "Lena"
+
+    def test_missing_readme_returns_empty(self, tmp_path: Path) -> None:
+        meta, pov, overview = load_chapter_meta(
+            tmp_path / "nope.md", "01-storm"
+        )
+        assert meta == {}
+        assert pov == ""
+        assert overview == {}
+
+
+class TestSerializeChapterMeta:
+    def test_passes_through_safe_keys(self) -> None:
+        out = serialize_chapter_meta({
+            "slug": "01", "title": "Opening", "number": 1,
+            "extra_key": "ignored",
+        })
+        assert out == {"slug": "01", "title": "Opening", "number": 1}
+
+    def test_coerces_non_scalars_to_str(self) -> None:
+        out = serialize_chapter_meta({"title": ["x", "y"]})
+        assert isinstance(out["title"], str)
+
+
+class TestLoadBookCategory:
+    def test_reads_frontmatter(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text(
+            "---\nbook_category: memoir\n---\n\n# Book\n",
+            encoding="utf-8",
+        )
+        assert load_book_category(tmp_path) == "memoir"
+
+    def test_defaults_to_fiction(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text("# No frontmatter\n", encoding="utf-8")
+        assert load_book_category(tmp_path) == "fiction"
+
+    def test_missing_readme_defaults_to_fiction(self, tmp_path: Path) -> None:
+        assert load_book_category(tmp_path) == "fiction"
+
+
+# ---------------------------------------------------------------------------
+# claudemd_sections
+# ---------------------------------------------------------------------------
+
+
+CLAUDEMD = """\
+# Book CLAUDE.md
+
+## Rules
+
+- Avoid `passive voice` in action scenes.
+- Always anchor the POV to the character's senses.
+
+## Callback Register
+
+- The cracked lantern (introduced Ch. 2)
+- Lena's promise to her mother (Ch. 4)
+"""
+
+
+class TestClaudeMdSections:
+    def test_rule_bullets_extracts_each(self) -> None:
+        bullets = rule_bullets(CLAUDEMD)
+        assert len(bullets) == 2
+        assert "passive voice" in bullets[0]
+
+    def test_callback_register_bullets(self) -> None:
+        bullets = callback_register_bullets(CLAUDEMD)
+        assert len(bullets) == 2
+        assert "cracked lantern" in bullets[0]
+
+    @pytest.mark.parametrize(
+        "rule,expected",
+        [
+            ("Avoid `dropdown` phrasing", "block"),
+            ("Banned: `synergy`", "block"),
+            ("Anchor every scene to senses", "advisory"),
+            ("Use `quotes` for emphasis", "advisory"),  # has backtick but no ban cue
+        ],
+    )
+    def test_classify_rule(self, rule: str, expected: str) -> None:
+        assert classify_rule(rule) == expected
+
+
+class TestLitmusQuestions:
+    def test_extracts_numbered(self) -> None:
+        text = (
+            "# Tone\n\n"
+            "## Litmus Test\n\n"
+            "1. Does the POV character earn the realisation?\n"
+            "2. Is the metaphor anchored to a sense?\n"
+        )
+        questions = litmus_questions(text)
+        assert len(questions) == 2
+        assert "POV character" in questions[0]
+
+    def test_no_section_returns_empty(self) -> None:
+        assert litmus_questions("# unrelated\n") == []
+
+
+# ---------------------------------------------------------------------------
+# people
+# ---------------------------------------------------------------------------
+
+
+def _write_person(path: Path, **fields: str) -> None:
+    fm_lines = [f"{k}: {v}" for k, v in fields.items()]
+    path.write_text(
+        "---\n" + "\n".join(fm_lines) + "\n---\n\n# Person\n",
+        encoding="utf-8",
+    )
+
+
+class TestPersonPayload:
+    def test_excludes_real_name(self, tmp_path: Path) -> None:
+        path = tmp_path / "alice.md"
+        _write_person(
+            path,
+            name="Alice",
+            real_name="Alice Smith",  # private — must not leak
+            consent_status="confirmed-consent",
+            person_category="public-figure",
+            anonymization="none",
+            relationship="mentor",
+            description="poet",
+        )
+        payload = person_payload(path)
+        assert payload["slug"] == "alice"
+        assert payload["name"] == "Alice"
+        assert "real_name" not in payload
+        assert payload["consent_status"] == "confirmed-consent"
+
+
+class TestScanForNamedCharacters:
+    def test_finds_by_name_not_slug(self, tmp_path: Path) -> None:
+        chars_dir = tmp_path / "characters"
+        chars_dir.mkdir()
+        (chars_dir / "lena.md").write_text(
+            "---\nname: Lena\n---\n\n# Lena\n", encoding="utf-8"
+        )
+        (chars_dir / "bystander.md").write_text(
+            "---\nname: Otto\n---\n\n# Otto\n", encoding="utf-8"
+        )
+        outline = "Lena confronts the antagonist."
+        assert scan_for_named_characters(outline, chars_dir) == ["lena"]
+
+    def test_skips_index(self, tmp_path: Path) -> None:
+        chars_dir = tmp_path / "characters"
+        chars_dir.mkdir()
+        (chars_dir / "INDEX.md").write_text(
+            "---\nname: Lena\n---\n", encoding="utf-8"
+        )
+        assert scan_for_named_characters("Lena fights.", chars_dir) == []
+
+
+class TestConsentStatusWarnings:
+    @pytest.mark.parametrize(
+        "consent_status,expected_tier",
+        [
+            ("", "missing"),
+            ("pending", "pending"),
+            ("refused", "refused"),
+        ],
+    )
+    def test_warns_on_unsafe_status(
+        self, consent_status: str, expected_tier: str,
+    ) -> None:
+        warnings = consent_status_warnings([
+            {"name": "Bob", "consent_status": consent_status},
+        ])
+        assert len(warnings) == 1
+        assert warnings[0]["tier"] == expected_tier
+
+    @pytest.mark.parametrize(
+        "consent_status",
+        ["confirmed-consent", "not-required", "not-asking"],
+    )
+    def test_silent_on_safe_status(self, consent_status: str) -> None:
+        assert consent_status_warnings([
+            {"name": "Bob", "consent_status": consent_status},
+        ]) == []
+
+
+# ---------------------------------------------------------------------------
+# recent_chapters
+# ---------------------------------------------------------------------------
+
+
+def _write_draft(chapter_dir: Path, body: str) -> None:
+    chapter_dir.mkdir(parents=True, exist_ok=True)
+    (chapter_dir / "draft.md").write_text(body, encoding="utf-8")
+
+
+class TestRecentChapters:
+    def test_count_similes_strips_frontmatter(self, tmp_path: Path) -> None:
+        draft = tmp_path / "draft.md"
+        draft.write_text(
+            "---\nlike a thief: front-matter only\n---\n\n"
+            "She moved like a shadow. The wind howled like a wolf.\n",
+            encoding="utf-8",
+        )
+        # Two simile markers in body; the frontmatter line ignored.
+        assert count_similes(draft) == 2
+
+    def test_last_paragraph_truncates(self, tmp_path: Path) -> None:
+        draft = tmp_path / "draft.md"
+        long = "x " * 700
+        draft.write_text(f"# Ch\n\nIntro paragraph.\n\n{long}\n", encoding="utf-8")
+        assert last_paragraph(draft).endswith("...")
+
+    def test_collect_recent_chapters_orders_numerically(
+        self, tmp_path: Path,
+    ) -> None:
+        chapters = tmp_path / "chapters"
+        for slug in ("01-a", "02-b", "03-c", "10-j"):
+            (chapters / slug).mkdir(parents=True)
+        recent = collect_recent_chapters(chapters, "10-j", n=3)
+        assert [r.name for r in recent] == ["01-a", "02-b", "03-c"]
+
+    def test_collect_excludes_current(self, tmp_path: Path) -> None:
+        chapters = tmp_path / "chapters"
+        for slug in ("01-a", "02-b", "03-c"):
+            (chapters / slug).mkdir(parents=True)
+        recent = collect_recent_chapters(chapters, "02-b", n=3)
+        assert [r.name for r in recent] == ["01-a"]
+
+    def test_collect_when_current_not_on_disk(self, tmp_path: Path) -> None:
+        chapters = tmp_path / "chapters"
+        for slug in ("01-a", "02-b", "03-c"):
+            (chapters / slug).mkdir(parents=True)
+        recent = collect_recent_chapters(chapters, "99-future", n=2)
+        assert [r.name for r in recent] == ["02-b", "03-c"]

--- a/tools/state/chapter_writing_brief.py
+++ b/tools/state/chapter_writing_brief.py
@@ -1,4 +1,4 @@
-"""Chapter-writing brief assembler — Issue #78 (Sprint 2 keystone).
+"""Chapter-writing brief assembler — orchestrator (Issue #78, refactored #121).
 
 Replaces the 16 prose prereq-loads in ``chapter-writer`` with a single
 structured JSON brief. The brief gathers data from every Sprint 1/2
@@ -7,25 +7,22 @@ POV knowledge boundary) plus the older book-context sources (book
 CLAUDE.md rules + callbacks, tone litmus questions, character
 profiles) into one deterministic payload.
 
-Design principles:
+This file is a thin orchestrator (#121). Each sub-source lives in its
+own loader under ``tools/state/loaders/`` and is independently
+testable. The orchestrator wraps every loader call in a recorder so a
+single failure records itself in ``errors`` and the brief still ships
+with partial data.
 
-* Each sub-component is wrapped in try/except. A single failure
-  records itself in the ``errors`` list and the brief still ships.
-* Output is plain dicts/lists/strings — JSON-serializable without
-  custom encoders.
-* No I/O outside the book root and the plugin root. Skill prompts
-  consume the brief directly; nothing in the brief points back at
-  on-disk paths the writer would need to re-resolve.
+Output is plain dicts/lists/strings — JSON-serializable without
+custom encoders.
 """
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from tools.analysis.pov_boundary_checker import parse_character_knowledge
 from tools.analysis.tactical_checker import (
     is_tactical_scene,
     load_tactical_profiles,
@@ -33,18 +30,35 @@ from tools.analysis.tactical_checker import (
 )
 from tools.shared.paths import resolve_people_dir, slugify
 from tools.state.chapter_timeline_parser import get_recent_chapter_timelines
-from tools.state.parsers import parse_chapter_readme, parse_frontmatter
+from tools.state.loaders.banlist import collect_banned_phrases
+from tools.state.loaders.chapter_meta import (
+    load_book_category,
+    load_chapter_meta,
+    serialize_chapter_meta,
+)
+from tools.state.loaders.claudemd_sections import (
+    callback_register_bullets,
+    classify_rule,
+    litmus_questions,
+    rule_bullets,
+)
+from tools.state.loaders.people import (
+    character_payload,
+    consent_status_warnings,
+    person_payload,
+    scan_for_named_characters,
+)
+from tools.state.loaders.recent_chapters import (
+    collect_recent_chapters,
+    count_similes,
+    last_paragraph,
+)
 from tools.timeline_anchor import get_story_anchor
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 
 @dataclass
 class _Recorder:
-    """Collects sub-tool errors so the brief can ship with partial data."""
+    """Collects sub-loader errors so the brief can ship with partial data."""
 
     errors: list[dict[str, str]]
 
@@ -59,274 +73,157 @@ class _Recorder:
             return default
 
 
-# Fallback parser for Blood & Binary-style Overview tables. Older
-# chapter READMEs encode metadata in a markdown table under
-# ``## Overview`` instead of YAML frontmatter. Honor both.
-_OVERVIEW_CELL_RE = re.compile(
-    r"^\|\s*(?P<key>[A-Za-z][A-Za-z ]+?)\s*\|\s*(?P<value>[^|]+?)\s*\|\s*$",
-    re.MULTILINE,
-)
+def _gather_characters(
+    book_root: Path,
+    chapter_readme: Path,
+    pov_character: str,
+    *,
+    is_memoir: bool,
+    recorder: _Recorder,
+) -> list[dict[str, Any]]:
+    """POV first, then any other named characters mentioned in the outline."""
+    chars_dir = (
+        resolve_people_dir(book_root, "memoir") if is_memoir
+        else book_root / "characters"
+    )
+    payload_loader = person_payload if is_memoir else character_payload
+    characters: list[dict[str, Any]] = []
+    pov_added = False
 
+    if pov_character:
+        pov_slug = slugify(pov_character)
+        pov_path = chars_dir / f"{pov_slug}.md"
+        if pov_path.is_file():
+            payload = recorder.run(
+                "characters.pov",
+                lambda: payload_loader(pov_path),
+                None,
+            )
+            if payload:
+                characters.append(payload)
+                pov_added = True
 
-def _parse_overview_table(readme_text: str) -> dict[str, str]:
-    """Pull key/value pairs from a chapter README's ``## Overview`` table.
-
-    Returns an empty dict when the table is absent. Header rows (the
-    ``Field/Value`` and the dashes line) are filtered out by the
-    caller's key whitelist.
-    """
-    cells: dict[str, str] = {}
-    for match in _OVERVIEW_CELL_RE.finditer(readme_text):
-        key = match.group("key").strip().lower()
-        value = match.group("value").strip()
-        if not value or value.startswith("-"):
-            continue
-        cells[key] = value
-    return cells
-
-
-_RULES_SECTION_RE = re.compile(
-    r"^##\s+Rules\s*$(.*?)^##\s+",
-    re.MULTILINE | re.DOTALL,
-)
-_CALLBACKS_SECTION_RE = re.compile(
-    r"^##\s+Callback Register\s*$(.*?)(?=^---\s*$|\Z)",
-    re.MULTILINE | re.DOTALL,
-)
-_LITMUS_SECTION_RE = re.compile(
-    r"^##\s+Litmus Test\s*$(.*?)(?=^##\s+|\Z)",
-    re.MULTILINE | re.DOTALL,
-)
-_BULLET_RE = re.compile(r"^\s*[-*]\s+(?P<body>.+?)\s*$", re.MULTILINE)
-_NUMBERED_RE = re.compile(r"^\s*\d+[.)]\s+(?P<body>.+?)\s*$", re.MULTILINE)
-_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
-
-
-def _section_bullets(text: str, regex: re.Pattern[str]) -> list[str]:
-    match = regex.search(text)
-    if not match:
-        return []
-    body = _COMMENT_RE.sub("", match.group(1))
-    items: list[str] = []
-    for m in _BULLET_RE.finditer(body):
-        item = re.sub(r"\s+", " ", m.group("body")).strip()
-        if item:
-            items.append(item)
-    return items
-
-
-def _litmus_questions(text: str) -> list[str]:
-    """Litmus tests are typically numbered, sometimes bulleted."""
-    match = _LITMUS_SECTION_RE.search(text)
-    if not match:
-        return []
-    body = match.group(1)
-    items: list[str] = []
-    for regex in (_NUMBERED_RE, _BULLET_RE):
-        for m in regex.finditer(body):
-            item = re.sub(r"\s+", " ", m.group("body")).strip()
-            if item and item not in items:
-                items.append(item)
-    return items
-
-
-# ---------------------------------------------------------------------------
-# Rule severity classifier
-# ---------------------------------------------------------------------------
-
-# Same heuristic as the hook: a rule that looks like a banned-phrase
-# declaration is block-severity, everything else is advisory.
-_BAN_CUE_RE = re.compile(
-    r"\b(banned|ban|avoid|never|don[’']?t\s+use|do\s+not\s+use|"
-    r"limit|stop\s+using)\b",
-    re.IGNORECASE,
-)
-
-
-def _classify_rule(rule: str) -> str:
-    if "`" in rule and _BAN_CUE_RE.search(rule):
-        return "block"
-    return "advisory"
-
-
-# ---------------------------------------------------------------------------
-# Simile counter (regex-only — same heuristic as manuscript-checker)
-# ---------------------------------------------------------------------------
-
-_SIMILE_RE = re.compile(
-    r"\b(?:like\s+a|like\s+the|as\s+if|as\s+though|"
-    r"as\s+\w+\s+as)\b",
-    re.IGNORECASE,
-)
-
-
-def _count_similes(draft_path: Path) -> int:
-    if not draft_path.is_file():
-        return 0
-    try:
-        text = draft_path.read_text(encoding="utf-8")
-    except OSError:
-        return 0
-    # Strip frontmatter to avoid counting metadata.
-    _, body = parse_frontmatter(text)
-    return len(_SIMILE_RE.findall(body))
-
-
-# ---------------------------------------------------------------------------
-# Last-paragraph extractor for recent_chapter_endings
-# ---------------------------------------------------------------------------
-
-
-def _last_paragraph(draft_path: Path) -> str:
-    if not draft_path.is_file():
-        return ""
-    try:
-        text = draft_path.read_text(encoding="utf-8")
-    except OSError:
-        return ""
-    _, body = parse_frontmatter(text)
-    paragraphs = [p.strip() for p in re.split(r"\n\s*\n", body) if p.strip()]
-    if not paragraphs:
-        return ""
-    last = paragraphs[-1]
-    # Cap to a reasonable preview size; the writer only needs the
-    # closing beat, not the whole paragraph.
-    if len(last) > 600:
-        last = last[:600].rstrip() + " ..."
-    return last
-
-
-# ---------------------------------------------------------------------------
-# Character roster derivation
-# ---------------------------------------------------------------------------
-
-
-def _scan_for_named_characters(text: str, characters_dir: Path) -> list[str]:
-    """Find character slugs whose ``name:`` appears in the chapter outline.
-
-    Lightweight heuristic — reads each character's frontmatter ``name``
-    and checks for substring presence in the outline text. Avoids
-    pulling in characters that aren't in this chapter.
-    """
-    if not characters_dir.is_dir():
-        return []
-    found: list[str] = []
-    for path in sorted(characters_dir.iterdir()):
-        if path.suffix.lower() != ".md" or path.name.upper() == "INDEX.MD":
-            continue
+    outline_text = ""
+    if chapter_readme.is_file():
         try:
-            char_text = path.read_text(encoding="utf-8")
+            outline_text = chapter_readme.read_text(encoding="utf-8")
         except OSError:
+            outline_text = ""
+
+    other_slugs = recorder.run(
+        "characters.scan",
+        lambda: scan_for_named_characters(outline_text, chars_dir),
+        [],
+    )
+    for slug in other_slugs:
+        if pov_added and slug == slugify(pov_character):
             continue
-        meta, _body = parse_frontmatter(char_text)
-        name = str(meta.get("name", path.stem))
-        if name and name in text:
-            found.append(path.stem)
-    return found
+        path = chars_dir / f"{slug}.md"
+        if not path.is_file():
+            continue
+        payload = recorder.run(
+            f"characters.{slug}",
+            lambda p=path: payload_loader(p),
+            None,
+        )
+        if payload:
+            characters.append(payload)
+    return characters
 
 
-def _character_payload(path: Path) -> dict[str, Any]:
-    """Full character payload: frontmatter + knowledge + tactical (if present)."""
-    text = path.read_text(encoding="utf-8")
-    meta, _body = parse_frontmatter(text)
-    payload: dict[str, Any] = {
-        "slug": path.stem,
-        "name": str(meta.get("name", path.stem)),
-        "role": str(meta.get("role", "supporting")),
-        "description": str(meta.get("description", "")),
-    }
-    knowledge = parse_character_knowledge(path)
-    if knowledge is not None and knowledge.has_knowledge_data:
-        payload["knowledge"] = {
-            "expert": list(knowledge.expert),
-            "competent": list(knowledge.competent),
-            "layperson": list(knowledge.layperson),
-            "none": list(knowledge.none),
-        }
-    tactical = meta.get("tactical")
-    if isinstance(tactical, dict) and tactical:
-        payload["tactical"] = tactical
-    return payload
-
-
-# Path E #57: memoir mode pulls real-people profiles (not character profiles)
-# from `people/`. The schema is different — no role/knowledge/tactical;
-# instead relationship + person_category + consent_status + anonymization.
-# Surfaced separately so chapter-writer can apply ethics-aware drafting.
-
-def _person_payload(path: Path) -> dict[str, Any]:
-    """Full real-person payload for memoir mode.
-
-    Shape mirrors what `parse_person_file` returns. The brief consumer
-    (chapter-writer in memoir mode) reads `consent_status` and surfaces
-    a warning before drafting any scene with a `pending` or `refused`
-    person. `real_name` is intentionally excluded — it stays private to
-    the people file and never enters the writing brief.
-    """
-    text = path.read_text(encoding="utf-8")
-    meta, _body = parse_frontmatter(text)
-    return {
-        "slug": path.stem,
-        "name": str(meta.get("name", path.stem)),
-        "relationship": str(meta.get("relationship", "")),
-        "person_category": str(meta.get("person_category", "")),
-        "consent_status": str(meta.get("consent_status", "")),
-        "anonymization": str(meta.get("anonymization", "none")),
-        "description": str(meta.get("description", "")),
-    }
-
-
-def _consent_status_warnings(people: list[dict[str, Any]]) -> list[dict[str, str]]:
-    """Surface consent issues for memoir scenes (Path E #57).
-
-    Three warning tiers:
-      - missing  — no consent_status set; user must decide before drafting
-      - pending  — consent intended but not yet asked; flag if scene is
-                   sensitive
-      - refused  — consent was refused; the person should be cut,
-                   anonymized, or re-framed before this scene drafts
-
-    Confirmed-consent / not-required / not-asking statuses produce no
-    warning. The skill consumes the full list; an empty list means the
-    chapter passes the consent gate.
-    """
-    warnings: list[dict[str, str]] = []
-    for person in people:
-        status = str(person.get("consent_status", "")).strip()
-        if not status:
-            warnings.append({
-                "person": person.get("name", person.get("slug", "")),
-                "tier": "missing",
-                "message": (
-                    "consent_status is unset — decide before drafting any "
-                    "scene with this person on the page."
-                ),
+def _gather_recent(
+    book_root: Path, chapter_slug: str, *, recorder: _Recorder,
+) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    """Last-paragraph + simile-count for the three chapters before this one."""
+    recent_endings: list[dict[str, Any]] = []
+    simile_counts: dict[str, int] = {}
+    chapters_dir = book_root / "chapters"
+    for ch in collect_recent_chapters(chapters_dir, chapter_slug, n=3):
+        draft = ch / "draft.md"
+        if not draft.is_file():
+            continue
+        ending = recorder.run(
+            f"endings.{ch.name}",
+            lambda d=draft: last_paragraph(d),
+            "",
+        )
+        if ending:
+            recent_endings.append({
+                "chapter": ch.name,
+                "last_paragraph": ending,
             })
-        elif status == "pending":
-            warnings.append({
-                "person": person.get("name", person.get("slug", "")),
-                "tier": "pending",
-                "message": (
-                    "consent_status is pending — drafting is allowed, "
-                    "but the request must happen before publication."
-                ),
-            })
-        elif status == "refused":
-            warnings.append({
-                "person": person.get("name", person.get("slug", "")),
-                "tier": "refused",
-                "message": (
-                    "consent_status is refused — cut the scene, "
-                    "anonymize the portrayal, or re-frame from a different "
-                    "angle before drafting."
-                ),
-            })
-    return warnings
+        count = recorder.run(
+            f"similes.{ch.name}",
+            lambda d=draft: count_similes(d),
+            0,
+        )
+        simile_counts[ch.name] = count
+    return recent_endings, simile_counts
 
 
-# ---------------------------------------------------------------------------
-# Public assembler
-# ---------------------------------------------------------------------------
+def _gather_claudemd(
+    book_root: Path, *, recorder: _Recorder,
+) -> tuple[list[dict[str, str]], list[str]]:
+    """Rules (with severity) and callbacks from the book CLAUDE.md."""
+    rules_to_honor: list[dict[str, str]] = []
+    callbacks_in_register: list[str] = []
+    claudemd_path = book_root / "CLAUDE.md"
+    if not claudemd_path.is_file():
+        return rules_to_honor, callbacks_in_register
+
+    claudemd_text = recorder.run(
+        "claudemd.read",
+        lambda: claudemd_path.read_text(encoding="utf-8"),
+        "",
+    )
+    if not claudemd_text:
+        return rules_to_honor, callbacks_in_register
+
+    for rule_text in rule_bullets(claudemd_text):
+        rules_to_honor.append({
+            "text": rule_text,
+            "severity": classify_rule(rule_text),
+        })
+    callbacks_in_register = callback_register_bullets(claudemd_text)
+    return rules_to_honor, callbacks_in_register
+
+
+def _gather_tone(
+    book_root: Path, *, recorder: _Recorder,
+) -> list[str]:
+    tone_path = book_root / "plot" / "tone.md"
+    if not tone_path.is_file():
+        return []
+    tone_text = recorder.run(
+        "tone.read",
+        lambda: tone_path.read_text(encoding="utf-8"),
+        "",
+    )
+    return litmus_questions(tone_text) if tone_text else []
+
+
+def _gather_tactical(
+    book_root: Path,
+    outline_text: str,
+    characters: list[dict[str, Any]],
+    *,
+    recorder: _Recorder,
+) -> dict[str, Any] | None:
+    if not outline_text or not is_tactical_scene(outline_text):
+        return None
+    present_slugs = [c["slug"] for c in characters]
+    if not present_slugs:
+        return None
+    profiles = recorder.run(
+        "tactical.load_profiles",
+        lambda: load_tactical_profiles(book_root, present_slugs),
+        [],
+    )
+    return recorder.run(
+        "tactical.analyze",
+        lambda: analyze_tactical_setup(outline_text, profiles).to_dict(),
+        None,
+    )
 
 
 def build_chapter_writing_brief(
@@ -346,249 +243,80 @@ def build_chapter_writing_brief(
     chapter_dir = book_root / "chapters" / chapter_slug
     chapter_readme = chapter_dir / "README.md"
 
-    # ----- chapter metadata -------------------------------------------------
-    chapter_meta: dict[str, Any] = {}
-    if chapter_readme.is_file():
-        chapter_meta = recorder.run(
-            "chapter",
-            lambda: parse_chapter_readme(chapter_readme),
-            {},
-        )
-    else:
+    chapter_meta, pov_character, _overview = recorder.run(
+        "chapter",
+        lambda: load_chapter_meta(chapter_readme, chapter_slug),
+        ({}, "", {}),
+    )
+    if not chapter_readme.is_file():
         recorder.errors.append({
             "component": "chapter",
             "error": f"chapter README missing: {chapter_readme}",
         })
 
-    pov_character = str(chapter_meta.get("pov_character", "")).strip()
-
-    # Fallback for older Blood & Binary chapters whose POV / title
-    # live in a markdown ``## Overview`` table rather than YAML
-    # frontmatter. Only consulted when the frontmatter path was empty.
-    overview: dict[str, str] = {}
-    title_from_meta = str(chapter_meta.get("title", "")).strip()
-    title_is_default = title_from_meta == chapter_slug
-    if chapter_readme.is_file():
-        try:
-            overview = _parse_overview_table(
-                chapter_readme.read_text(encoding="utf-8")
-            )
-        except OSError:
-            overview = {}
-        if not pov_character:
-            pov_character = overview.get("pov", "").strip()
-        if (not title_from_meta or title_is_default) and overview.get("title"):
-            chapter_meta["title"] = overview["title"]
-        if not chapter_meta.get("number") and overview.get("chapter"):
-            try:
-                chapter_meta["number"] = int(re.sub(r"\D", "", overview["chapter"]) or 0)
-            except ValueError:
-                pass
-
-    # ----- book category --------------------------------------------------
-    # Path E #57: chapter-writer behavior branches on book_category. The
-    # field lives in the book's README frontmatter; missing defaults to
-    # fiction (legacy books pre-#54).
-    book_category = "fiction"
-    book_readme = book_root / "README.md"
-    if book_readme.is_file():
-        book_text = recorder.run(
-            "book.read",
-            lambda: book_readme.read_text(encoding="utf-8"),
-            "",
-        )
-        if book_text:
-            book_meta, _ = parse_frontmatter(book_text)
-            book_category = str(book_meta.get("book_category", "fiction"))
-
+    book_category = recorder.run(
+        "book.read",
+        lambda: load_book_category(book_root),
+        "fiction",
+    )
     is_memoir = book_category == "memoir"
 
-    # ----- characters / people present -------------------------------------
-    # Memoir books look in `people/` (with `characters/` fallback for
-    # legacy memoir books written before #59). Fiction stays at
-    # `characters/`. The same `characters_present` key carries both —
-    # consumers branch on `book_category` from the brief.
-    characters: list[dict[str, Any]] = []
+    characters = _gather_characters(
+        book_root, chapter_readme, pov_character,
+        is_memoir=is_memoir, recorder=recorder,
+    )
+
     consent_warnings: list[dict[str, str]] = []
-    chars_dir = (
-        resolve_people_dir(book_root, book_category) if is_memoir
-        else book_root / "characters"
-    )
-    pov_added = False
-
-    payload_loader = _person_payload if is_memoir else _character_payload
-
-    if pov_character:
-        pov_slug = slugify(pov_character)
-        pov_path = chars_dir / f"{pov_slug}.md"
-        if pov_path.is_file():
-            payload = recorder.run(
-                "characters.pov",
-                lambda: payload_loader(pov_path),
-                None,
-            )
-            if payload:
-                characters.append(payload)
-                pov_added = True
-
-    # Best-effort: surface any other named characters appearing in the
-    # chapter outline / summary (chapter README body).
-    outline_text = ""
-    if chapter_readme.is_file():
-        try:
-            outline_text = chapter_readme.read_text(encoding="utf-8")
-        except OSError:
-            outline_text = ""
-
-    other_slugs = recorder.run(
-        "characters.scan",
-        lambda: _scan_for_named_characters(outline_text, chars_dir),
-        [],
-    )
-    for slug in other_slugs:
-        if pov_added and slug == slugify(pov_character):
-            continue
-        path = chars_dir / f"{slug}.md"
-        if not path.is_file():
-            continue
-        payload = recorder.run(
-            f"characters.{slug}",
-            lambda p=path: payload_loader(p),
-            None,
-        )
-        if payload:
-            characters.append(payload)
-
-    # Memoir consent gate: surface any present-in-scene people whose
-    # consent_status is missing, pending, or refused. The skill must
-    # show these warnings to the user before drafting.
     if is_memoir:
         consent_warnings = recorder.run(
             "consent_status_warnings",
-            lambda: _consent_status_warnings(characters),
+            lambda: consent_status_warnings(characters),
             [],
         )
 
-    # ----- story anchor ---------------------------------------------------
     story_anchor = recorder.run(
         "story_anchor",
         lambda: get_story_anchor(book_root, chapter_slug).to_dict(),
         None,
     )
 
-    # ----- recent chapter timelines ---------------------------------------
     recent_timelines = recorder.run(
         "recent_chapter_timelines",
         lambda: [g.to_dict() for g in get_recent_chapter_timelines(book_root, n=3)],
         [],
     )
 
-    # ----- recent chapter endings + simile counts -------------------------
-    recent_endings: list[dict[str, Any]] = []
-    simile_counts: dict[str, int] = {}
-    chapters_dir = book_root / "chapters"
-    if chapters_dir.is_dir():
-        all_chapters: list[tuple[int, Path]] = []
-        current_number: int | None = None
-        for entry in chapters_dir.iterdir():
-            if not entry.is_dir():
-                continue
-            m = re.match(r"^(\d{1,3})-", entry.name)
-            if not m:
-                continue
-            num = int(m.group(1))
-            all_chapters.append((num, entry))
-            if entry.name == chapter_slug:
-                current_number = num
-        all_chapters.sort()
-        # Last 3 chapters strictly before the current one (chronologically).
-        if current_number is not None:
-            prior = [ch for num, ch in all_chapters if num < current_number][-3:]
-        else:
-            # New chapter not yet on disk — take the last 3 we have.
-            prior = [ch for _, ch in all_chapters][-3:]
-        for ch in prior:
-            draft = ch / "draft.md"
-            if not draft.is_file():
-                continue
-            ending = recorder.run(
-                f"endings.{ch.name}",
-                lambda d=draft: _last_paragraph(d),
-                "",
-            )
-            if ending:
-                recent_endings.append({
-                    "chapter": ch.name,
-                    "last_paragraph": ending,
-                })
-            count = recorder.run(
-                f"similes.{ch.name}",
-                lambda d=draft: _count_similes(d),
-                0,
-            )
-            simile_counts[ch.name] = count
+    recent_endings, simile_counts = _gather_recent(
+        book_root, chapter_slug, recorder=recorder,
+    )
 
-    # ----- rules + callbacks from book CLAUDE.md --------------------------
-    rules_to_honor: list[dict[str, str]] = []
-    callbacks_in_register: list[str] = []
-    claudemd_path = book_root / "CLAUDE.md"
-    if claudemd_path.is_file():
-        claudemd_text = recorder.run(
-            "claudemd.read",
-            lambda: claudemd_path.read_text(encoding="utf-8"),
-            "",
-        )
-        if claudemd_text:
-            for rule_text in _section_bullets(claudemd_text, _RULES_SECTION_RE):
-                rules_to_honor.append({
-                    "text": rule_text,
-                    "severity": _classify_rule(rule_text),
-                })
-            callbacks_in_register = _section_bullets(
-                claudemd_text, _CALLBACKS_SECTION_RE,
-            )
+    rules_to_honor, callbacks_in_register = _gather_claudemd(
+        book_root, recorder=recorder,
+    )
 
-    # ----- banned phrases -------------------------------------------------
-    banned_phrases: list[dict[str, str]] = []
     banned_phrases = recorder.run(
         "banned_phrases",
-        lambda: _collect_banned_phrases(book_root, plugin_root),
+        lambda: collect_banned_phrases(book_root, plugin_root),
         [],
     )
 
-    # ----- tone litmus questions ------------------------------------------
-    tone_questions: list[str] = []
-    tone_path = book_root / "plot" / "tone.md"
-    if tone_path.is_file():
-        tone_text = recorder.run(
-            "tone.read",
-            lambda: tone_path.read_text(encoding="utf-8"),
-            "",
-        )
-        if tone_text:
-            tone_questions = _litmus_questions(tone_text)
+    tone_questions = _gather_tone(book_root, recorder=recorder)
 
-    # ----- tactical constraints (only if outline triggers detection) ------
-    tactical: dict[str, Any] | None = None
-    if outline_text and is_tactical_scene(outline_text):
-        present_slugs = [c["slug"] for c in characters]
-        if present_slugs:
-            profiles = recorder.run(
-                "tactical.load_profiles",
-                lambda: load_tactical_profiles(book_root, present_slugs),
-                [],
-            )
-            tactical = recorder.run(
-                "tactical.analyze",
-                lambda: analyze_tactical_setup(outline_text, profiles).to_dict(),
-                None,
-            )
+    outline_text = ""
+    if chapter_readme.is_file():
+        try:
+            outline_text = chapter_readme.read_text(encoding="utf-8")
+        except OSError:
+            outline_text = ""
+    tactical = _gather_tactical(
+        book_root, outline_text, characters, recorder=recorder,
+    )
 
     return {
         "book_slug": book_slug,
         "book_category": book_category,
         "chapter_slug": chapter_slug,
-        "chapter": _serialize_chapter_meta(chapter_meta),
+        "chapter": serialize_chapter_meta(chapter_meta),
         "pov_character": pov_character,
         "story_anchor": story_anchor,
         "recent_chapter_timelines": recent_timelines,
@@ -606,88 +334,4 @@ def build_chapter_writing_brief(
     }
 
 
-def _serialize_chapter_meta(meta: dict[str, Any]) -> dict[str, Any]:
-    """Trim chapter meta to JSON-safe keys."""
-    if not meta:
-        return {}
-    out: dict[str, Any] = {}
-    for key in ("slug", "title", "number", "status", "pov_character",
-                "summary", "word_count_target"):
-        if key in meta:
-            value = meta[key]
-            if isinstance(value, (str, int, float, bool)) or value is None:
-                out[key] = value
-            else:
-                out[key] = str(value)
-    return out
-
-
-def _collect_banned_phrases(
-    book_root: Path, plugin_root: Path,
-) -> list[dict[str, str]]:
-    """Surface a deduplicated banned-phrase summary for the brief.
-
-    Pulls from three sources, in order: book CLAUDE.md ## Rules with
-    backticked phrases (block-severity), author vocabulary.md
-    (block-severity), and the global anti-AI tells (warn-severity).
-    Returns up to ~50 entries — anything past that is noise the writer
-    won't read.
-    """
-    from tools.analysis.manuscript_checker import (
-        _read_book_rules, _extract_patterns_from_rule,
-    )
-    from tools.banlist_loader import (
-        author_slug_from_book, load_author_vocab, load_global_ai_tells,
-    )
-
-    seen: set[str] = set()
-    out: list[dict[str, str]] = []
-
-    for rule in _read_book_rules(book_root):
-        for label, _pattern in _extract_patterns_from_rule(rule):
-            key = label.lower()
-            if key in seen:
-                continue
-            seen.add(key)
-            out.append({
-                "phrase": label,
-                "source": "book CLAUDE.md ## Rules",
-                "severity": "block",
-            })
-
-    author_slug = author_slug_from_book(book_root)
-    if author_slug:
-        # load_author_vocab takes home-dir override so tests can
-        # patch it; in production it reads ~/.storyforge/...
-        try:
-            patterns = load_author_vocab(author_slug)
-        except Exception:  # pylint: disable=broad-except
-            patterns = []
-        for p in patterns:
-            key = p.label.lower()
-            if key in seen:
-                continue
-            seen.add(key)
-            out.append({
-                "phrase": p.label,
-                "source": "author vocabulary.md",
-                "severity": p.severity,
-            })
-
-    try:
-        global_tells = load_global_ai_tells(plugin_root)
-    except Exception:  # pylint: disable=broad-except
-        global_tells = []
-    for p in global_tells:
-        key = p.label.lower()
-        if key in seen:
-            continue
-        seen.add(key)
-        out.append({
-            "phrase": p.label,
-            "source": "anti-ai-patterns.md",
-            "severity": p.severity,
-        })
-        if len(out) >= 50:
-            break
-    return out
+__all__ = ["build_chapter_writing_brief"]

--- a/tools/state/loaders/__init__.py
+++ b/tools/state/loaders/__init__.py
@@ -1,0 +1,12 @@
+"""Per-source loaders for chapter_writing_brief (Issue #121).
+
+Each loader exposes a small, independently-testable function (or a
+handful of them) that the orchestrator in
+``tools/state/chapter_writing_brief.py`` calls once and dispatches the
+result into the brief.
+
+Loaders never reach beyond the book root or the plugin root, never call
+each other, and surface failures as exceptions — the orchestrator wraps
+them in a try/except recorder so a single failure cannot break the
+whole brief.
+"""

--- a/tools/state/loaders/banlist.py
+++ b/tools/state/loaders/banlist.py
@@ -1,0 +1,94 @@
+"""Banned-phrase aggregator for the chapter-writing brief (Issue #121).
+
+Collects up to 50 deduplicated banned-phrase entries from three
+sources, in priority order:
+
+1. Book CLAUDE.md ``## Rules`` with backticked phrases (block severity).
+2. Author ``vocabulary.md`` (block severity).
+3. Global anti-AI tells from ``reference/craft/anti-ai-patterns.md``
+   (warn severity).
+
+Each entry is ``{"phrase": str, "source": str, "severity": str}``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def collect_banned_phrases(
+    book_root: Path, plugin_root: Path, *, cap: int = 50,
+) -> list[dict[str, str]]:
+    """Return up to ``cap`` deduplicated banned-phrase entries.
+
+    Imports are lazy so the loader stays usable even when the optional
+    banlist-loader chain is unavailable (tests that monkey-patch
+    sub-modules, partial installs).
+    """
+    # ``manuscript_checker`` exposes the same private helpers the hook
+    # uses; stay consistent with the linter's view of the rules.
+    from tools.analysis.manuscript_checker import (
+        _read_book_rules,
+        _extract_patterns_from_rule,
+    )
+    from tools.banlist_loader import (
+        author_slug_from_book,
+        load_author_vocab,
+        load_global_ai_tells,
+    )
+
+    seen: set[str] = set()
+    out: list[dict[str, str]] = []
+
+    for rule in _read_book_rules(book_root):
+        for label, _pattern in _extract_patterns_from_rule(rule):
+            key = label.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append({
+                "phrase": label,
+                "source": "book CLAUDE.md ## Rules",
+                "severity": "block",
+            })
+
+    author_slug = author_slug_from_book(book_root)
+    if author_slug:
+        # ``load_author_vocab`` accepts a ``storyforge_home`` override
+        # so tests can redirect away from ``~/.storyforge``; production
+        # uses the default home directory.
+        try:
+            patterns = load_author_vocab(author_slug)
+        except Exception:  # pylint: disable=broad-except
+            patterns = []
+        for p in patterns:
+            key = p.label.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append({
+                "phrase": p.label,
+                "source": "author vocabulary.md",
+                "severity": p.severity,
+            })
+
+    try:
+        global_tells = load_global_ai_tells(plugin_root)
+    except Exception:  # pylint: disable=broad-except
+        global_tells = []
+    for p in global_tells:
+        key = p.label.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append({
+            "phrase": p.label,
+            "source": "anti-ai-patterns.md",
+            "severity": p.severity,
+        })
+        if len(out) >= cap:
+            break
+    return out
+
+
+__all__ = ["collect_banned_phrases"]

--- a/tools/state/loaders/chapter_meta.py
+++ b/tools/state/loaders/chapter_meta.py
@@ -1,0 +1,131 @@
+"""Chapter metadata loader (Issue #121).
+
+Resolves a chapter README into a flat metadata dict, honoring two
+encodings:
+
+- YAML frontmatter — the canonical source.
+- ``## Overview`` markdown table — the legacy Blood & Binary layout.
+  Used as a fallback for fields that are missing from the frontmatter.
+
+Also serializes the metadata into a JSON-safe shape for the brief.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from tools.state.parsers import parse_chapter_readme, parse_frontmatter
+
+# Fallback parser for Blood & Binary-style Overview tables. Older
+# chapter READMEs encode metadata in a markdown table under
+# ``## Overview`` instead of YAML frontmatter. Honor both.
+_OVERVIEW_CELL_RE = re.compile(
+    r"^\|\s*(?P<key>[A-Za-z][A-Za-z ]+?)\s*\|\s*(?P<value>[^|]+?)\s*\|\s*$",
+    re.MULTILINE,
+)
+
+
+def parse_overview_table(readme_text: str) -> dict[str, str]:
+    """Pull key/value pairs from a chapter README's ``## Overview`` table.
+
+    Returns an empty dict when the table is absent. Header rows (the
+    ``Field/Value`` and the dashes line) are filtered out by the
+    caller's key whitelist.
+    """
+    cells: dict[str, str] = {}
+    for match in _OVERVIEW_CELL_RE.finditer(readme_text):
+        key = match.group("key").strip().lower()
+        value = match.group("value").strip()
+        if not value or value.startswith("-"):
+            continue
+        cells[key] = value
+    return cells
+
+
+def load_chapter_meta(
+    chapter_readme: Path, chapter_slug: str
+) -> tuple[dict[str, Any], str, dict[str, str]]:
+    """Load chapter frontmatter + overview-table fallback.
+
+    Returns ``(meta, pov_character, overview)`` where:
+
+    - ``meta`` is the merged metadata dict
+    - ``pov_character`` is the resolved POV (may be ``""`` if neither
+      source declares one)
+    - ``overview`` is the raw overview-table dict for callers that need
+      to inspect specific cells beyond the merged meta
+    """
+    meta: dict[str, Any] = {}
+    overview: dict[str, str] = {}
+
+    if chapter_readme.is_file():
+        meta = parse_chapter_readme(chapter_readme)
+        try:
+            overview = parse_overview_table(
+                chapter_readme.read_text(encoding="utf-8")
+            )
+        except OSError:
+            overview = {}
+
+    pov_character = str(meta.get("pov_character", "")).strip()
+    title_from_meta = str(meta.get("title", "")).strip()
+    title_is_default = title_from_meta == chapter_slug
+
+    if not pov_character:
+        pov_character = overview.get("pov", "").strip()
+    if (not title_from_meta or title_is_default) and overview.get("title"):
+        meta["title"] = overview["title"]
+    if not meta.get("number") and overview.get("chapter"):
+        try:
+            meta["number"] = int(re.sub(r"\D", "", overview["chapter"]) or 0)
+        except ValueError:
+            pass
+
+    return meta, pov_character, overview
+
+
+def serialize_chapter_meta(meta: dict[str, Any]) -> dict[str, Any]:
+    """Trim chapter meta to JSON-safe keys."""
+    if not meta:
+        return {}
+    out: dict[str, Any] = {}
+    for key in (
+        "slug", "title", "number", "status", "pov_character",
+        "summary", "word_count_target",
+    ):
+        if key in meta:
+            value = meta[key]
+            if isinstance(value, (str, int, float, bool)) or value is None:
+                out[key] = value
+            else:
+                out[key] = str(value)
+    return out
+
+
+def load_book_category(book_root: Path) -> str:
+    """Read the book's ``book_category`` from its README frontmatter.
+
+    Defaults to ``fiction`` for legacy books pre-#54 that don't carry
+    the field.
+    """
+    book_readme = book_root / "README.md"
+    if not book_readme.is_file():
+        return "fiction"
+    try:
+        text = book_readme.read_text(encoding="utf-8")
+    except OSError:
+        return "fiction"
+    if not text:
+        return "fiction"
+    book_meta, _ = parse_frontmatter(text)
+    return str(book_meta.get("book_category", "fiction"))
+
+
+__all__ = [
+    "load_book_category",
+    "load_chapter_meta",
+    "parse_overview_table",
+    "serialize_chapter_meta",
+]

--- a/tools/state/loaders/claudemd_sections.py
+++ b/tools/state/loaders/claudemd_sections.py
@@ -1,0 +1,88 @@
+"""Loader for book CLAUDE.md sections (Issue #121).
+
+Pulls bullets from ``## Rules`` and ``## Callback Register``, plus
+litmus questions from a tone document. Each section parser is a small
+pure function so the orchestrator (and tests) can call them in
+isolation.
+"""
+
+from __future__ import annotations
+
+import re
+
+_RULES_SECTION_RE = re.compile(
+    r"^##\s+Rules\s*$(.*?)^##\s+",
+    re.MULTILINE | re.DOTALL,
+)
+_CALLBACKS_SECTION_RE = re.compile(
+    r"^##\s+Callback Register\s*$(.*?)(?=^---\s*$|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+_LITMUS_SECTION_RE = re.compile(
+    r"^##\s+Litmus Test\s*$(.*?)(?=^##\s+|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+_BULLET_RE = re.compile(r"^\s*[-*]\s+(?P<body>.+?)\s*$", re.MULTILINE)
+_NUMBERED_RE = re.compile(r"^\s*\d+[.)]\s+(?P<body>.+?)\s*$", re.MULTILINE)
+_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+# Same heuristic the linter hook uses: a rule that looks like a
+# banned-phrase declaration is block-severity, everything else advisory.
+_BAN_CUE_RE = re.compile(
+    r"\b(banned|ban|avoid|never|don[’']?t\s+use|do\s+not\s+use|"
+    r"limit|stop\s+using)\b",
+    re.IGNORECASE,
+)
+
+
+def _section_bullets(text: str, regex: re.Pattern[str]) -> list[str]:
+    match = regex.search(text)
+    if not match:
+        return []
+    body = _COMMENT_RE.sub("", match.group(1))
+    items: list[str] = []
+    for m in _BULLET_RE.finditer(body):
+        item = re.sub(r"\s+", " ", m.group("body")).strip()
+        if item:
+            items.append(item)
+    return items
+
+
+def rule_bullets(claudemd_text: str) -> list[str]:
+    """Bullets from the book CLAUDE.md ``## Rules`` section."""
+    return _section_bullets(claudemd_text, _RULES_SECTION_RE)
+
+
+def callback_register_bullets(claudemd_text: str) -> list[str]:
+    """Bullets from the book CLAUDE.md ``## Callback Register`` section."""
+    return _section_bullets(claudemd_text, _CALLBACKS_SECTION_RE)
+
+
+def litmus_questions(tone_text: str) -> list[str]:
+    """Litmus tests are typically numbered, sometimes bulleted."""
+    match = _LITMUS_SECTION_RE.search(tone_text)
+    if not match:
+        return []
+    body = match.group(1)
+    items: list[str] = []
+    for regex in (_NUMBERED_RE, _BULLET_RE):
+        for m in regex.finditer(body):
+            item = re.sub(r"\s+", " ", m.group("body")).strip()
+            if item and item not in items:
+                items.append(item)
+    return items
+
+
+def classify_rule(rule: str) -> str:
+    """Return ``"block"`` for backtick-wrapped ban-cued rules, else ``"advisory"``."""
+    if "`" in rule and _BAN_CUE_RE.search(rule):
+        return "block"
+    return "advisory"
+
+
+__all__ = [
+    "callback_register_bullets",
+    "classify_rule",
+    "litmus_questions",
+    "rule_bullets",
+]

--- a/tools/state/loaders/people.py
+++ b/tools/state/loaders/people.py
@@ -1,0 +1,144 @@
+"""Character / real-people loader for the chapter-writing brief (Issue #121).
+
+Branches by ``book_category``:
+
+- Fiction books read ``characters/{slug}.md`` — full payload includes
+  knowledge taxonomy and tactical frontmatter when present.
+- Memoir books read ``people/{slug}.md`` — payload includes
+  ``person_category``, ``consent_status`` and ``anonymization``;
+  ``real_name`` is intentionally excluded so it never enters the brief.
+
+Also surfaces the consent-status warning list for memoir scenes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from tools.analysis.pov_boundary_checker import parse_character_knowledge
+from tools.state.parsers import parse_frontmatter
+
+
+def character_payload(path: Path) -> dict[str, Any]:
+    """Full character payload: frontmatter + knowledge + tactical (if present)."""
+    text = path.read_text(encoding="utf-8")
+    meta, _body = parse_frontmatter(text)
+    payload: dict[str, Any] = {
+        "slug": path.stem,
+        "name": str(meta.get("name", path.stem)),
+        "role": str(meta.get("role", "supporting")),
+        "description": str(meta.get("description", "")),
+    }
+    knowledge = parse_character_knowledge(path)
+    if knowledge is not None and knowledge.has_knowledge_data:
+        payload["knowledge"] = {
+            "expert": list(knowledge.expert),
+            "competent": list(knowledge.competent),
+            "layperson": list(knowledge.layperson),
+            "none": list(knowledge.none),
+        }
+    tactical = meta.get("tactical")
+    if isinstance(tactical, dict) and tactical:
+        payload["tactical"] = tactical
+    return payload
+
+
+def person_payload(path: Path) -> dict[str, Any]:
+    """Full real-person payload for memoir mode.
+
+    ``real_name`` is intentionally excluded — it stays private to the
+    people file and never enters the writing brief.
+    """
+    text = path.read_text(encoding="utf-8")
+    meta, _body = parse_frontmatter(text)
+    return {
+        "slug": path.stem,
+        "name": str(meta.get("name", path.stem)),
+        "relationship": str(meta.get("relationship", "")),
+        "person_category": str(meta.get("person_category", "")),
+        "consent_status": str(meta.get("consent_status", "")),
+        "anonymization": str(meta.get("anonymization", "none")),
+        "description": str(meta.get("description", "")),
+    }
+
+
+def scan_for_named_characters(text: str, characters_dir: Path) -> list[str]:
+    """Find character/person slugs whose ``name:`` appears in ``text``.
+
+    Lightweight heuristic — reads each character file's frontmatter
+    ``name`` and checks for substring presence in the outline text.
+    Avoids pulling in characters that aren't in this chapter.
+    """
+    if not characters_dir.is_dir():
+        return []
+    found: list[str] = []
+    for path in sorted(characters_dir.iterdir()):
+        if path.suffix.lower() != ".md" or path.name.upper() == "INDEX.MD":
+            continue
+        try:
+            char_text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        meta, _body = parse_frontmatter(char_text)
+        name = str(meta.get("name", path.stem))
+        if name and name in text:
+            found.append(path.stem)
+    return found
+
+
+def consent_status_warnings(
+    people: list[dict[str, Any]],
+) -> list[dict[str, str]]:
+    """Surface consent issues for memoir scenes (Path E #57).
+
+    Three warning tiers:
+      - ``missing`` — no consent_status set; user must decide before drafting
+      - ``pending`` — consent intended but not yet asked; flag if scene
+        is sensitive
+      - ``refused`` — consent was refused; the person should be cut,
+        anonymized, or re-framed before this scene drafts
+
+    Confirmed-consent / not-required / not-asking statuses produce no
+    warning. An empty list means the chapter passes the consent gate.
+    """
+    warnings: list[dict[str, str]] = []
+    for person in people:
+        status = str(person.get("consent_status", "")).strip()
+        if not status:
+            warnings.append({
+                "person": person.get("name", person.get("slug", "")),
+                "tier": "missing",
+                "message": (
+                    "consent_status is unset — decide before drafting any "
+                    "scene with this person on the page."
+                ),
+            })
+        elif status == "pending":
+            warnings.append({
+                "person": person.get("name", person.get("slug", "")),
+                "tier": "pending",
+                "message": (
+                    "consent_status is pending — drafting is allowed, "
+                    "but the request must happen before publication."
+                ),
+            })
+        elif status == "refused":
+            warnings.append({
+                "person": person.get("name", person.get("slug", "")),
+                "tier": "refused",
+                "message": (
+                    "consent_status is refused — cut the scene, "
+                    "anonymize the portrayal, or re-frame from a different "
+                    "angle before drafting."
+                ),
+            })
+    return warnings
+
+
+__all__ = [
+    "character_payload",
+    "consent_status_warnings",
+    "person_payload",
+    "scan_for_named_characters",
+]

--- a/tools/state/loaders/recent_chapters.py
+++ b/tools/state/loaders/recent_chapters.py
@@ -1,0 +1,87 @@
+"""Loader for recent-chapter signals: endings + simile counts (Issue #121).
+
+Both signals are per-chapter heuristics over ``draft.md``. They live in
+the same module because they share input (the previous chapter's draft)
+and the same frontmatter-stripping step.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from tools.state.parsers import parse_frontmatter
+
+# Same heuristic as manuscript-checker — keep regex local so we never
+# import private helpers from the checker.
+_SIMILE_RE = re.compile(
+    r"\b(?:like\s+a|like\s+the|as\s+if|as\s+though|"
+    r"as\s+\w+\s+as)\b",
+    re.IGNORECASE,
+)
+
+
+def count_similes(draft_path: Path) -> int:
+    """Count simile markers in a chapter draft. Returns 0 on any I/O error."""
+    if not draft_path.is_file():
+        return 0
+    try:
+        text = draft_path.read_text(encoding="utf-8")
+    except OSError:
+        return 0
+    _, body = parse_frontmatter(text)
+    return len(_SIMILE_RE.findall(body))
+
+
+def last_paragraph(draft_path: Path, *, max_length: int = 600) -> str:
+    """Return the last paragraph of a chapter draft, truncated to ``max_length``.
+
+    Returns ``""`` when the file is missing, unreadable, or contains no
+    non-empty paragraph after frontmatter stripping.
+    """
+    if not draft_path.is_file():
+        return ""
+    try:
+        text = draft_path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    _, body = parse_frontmatter(text)
+    paragraphs = [p.strip() for p in re.split(r"\n\s*\n", body) if p.strip()]
+    if not paragraphs:
+        return ""
+    last = paragraphs[-1]
+    if len(last) > max_length:
+        last = last[:max_length].rstrip() + " ..."
+    return last
+
+
+def collect_recent_chapters(
+    chapters_dir: Path, current_slug: str, *, n: int = 3,
+) -> list[Path]:
+    """Return up to ``n`` chapter directories strictly before ``current_slug``.
+
+    When ``current_slug`` is not yet on disk (new chapter), returns the
+    last ``n`` chapters that *are* on disk. Sorted by chapter number
+    ascending.
+    """
+    if not chapters_dir.is_dir():
+        return []
+    all_chapters: list[tuple[int, Path]] = []
+    current_number: int | None = None
+    for entry in chapters_dir.iterdir():
+        if not entry.is_dir():
+            continue
+        m = re.match(r"^(\d{1,3})-", entry.name)
+        if not m:
+            continue
+        num = int(m.group(1))
+        all_chapters.append((num, entry))
+        if entry.name == current_slug:
+            current_number = num
+    all_chapters.sort()
+    if current_number is not None:
+        return [ch for num, ch in all_chapters if num < current_number][-n:]
+    return [ch for _, ch in all_chapters][-n:]
+
+
+__all__ = ["collect_recent_chapters", "count_similes", "last_paragraph"]


### PR DESCRIPTION
## Summary

Closes #121 — splits the 693-LOC chapter_writing_brief monolith into a thin orchestrator plus five focused loader modules under [tools/state/loaders/](tools/state/loaders/).

| Module | LOC | Responsibility |
|---|---|---|
| [chapter_meta.py](tools/state/loaders/chapter_meta.py) | 131 | Chapter README parsing (frontmatter + ## Overview table fallback), JSON-safe meta serializer, book_category resolver |
| [people.py](tools/state/loaders/people.py) | 144 | Character / real-people payload builders, named-character scan, memoir consent_status warning matrix |
| [recent_chapters.py](tools/state/loaders/recent_chapters.py) | 87 | last_paragraph, count_similes, collect_recent_chapters |
| [claudemd_sections.py](tools/state/loaders/claudemd_sections.py) | 88 | rule_bullets, callback_register_bullets, litmus_questions, classify_rule |
| [banlist.py](tools/state/loaders/banlist.py) | 94 | collect_banned_phrases (book rules + author vocab + global tells, deduped, capped) |

The orchestrator [chapter_writing_brief.py](tools/state/chapter_writing_brief.py) drops to 337 LOC. The 200-LOC target from the issue is missed because the orchestrator carries five `_gather_*` helpers that compose multiple loader calls per section — splitting those further would scatter the brief assembly logic. The remaining LOC is all orchestration, not loader content.

**Audit note from the issue body** — line 661 referenced `~/.storyforge/...` in a docstring. Verified: `load_author_vocab` accepts a `storyforge_home` override (`tools/banlist_loader.py:103`), so the comment is descriptive, not a hardcoded fallback. Comment carried over to the new banlist loader unchanged.

## Test plan

- [x] **Behaviour parity** — all 27 existing tests in [test_chapter_writing_brief.py](tests/test_chapter_writing_brief.py) and [test_chapter_writing_brief_memoir.py](tests/test_chapter_writing_brief_memoir.py) pass against the refactored orchestrator without modification.
- [x] **New per-loader tests** — [test_chapter_writing_brief_loaders.py](tests/test_chapter_writing_brief_loaders.py) adds 32 focused tests:
  - parse_overview_table edge cases (lowercase keys, dash-only filtering)
  - load_chapter_meta merge (frontmatter + overview table fallback for POV/title)
  - serialize_chapter_meta whitelist + non-scalar coercion
  - load_book_category default behaviour
  - rule_bullets / callback_register_bullets / litmus_questions extraction
  - classify_rule parameterised matrix (block vs advisory)
  - person_payload excludes `real_name` (privacy invariant)
  - scan_for_named_characters by display name + INDEX skip
  - consent_status_warnings tier matrix (missing / pending / refused / safe)
  - count_similes strips frontmatter
  - last_paragraph truncation + ellipsis
  - collect_recent_chapters numeric ordering, current-slug-on-disk and not-on-disk
- [x] Full suite: **995 tests pass** in 2.01s (was 963; +32 new, no regressions).
- [x] `ruff check .` — clean.

## Out of scope

- Pushing the orchestrator below 200 LOC by inlining the `_gather_*` helpers — those compose multi-loader sections; inlining would obscure the brief structure.
- Migrating internal API consumers — only `build_chapter_writing_brief` was exported externally, so no skill / tool / test outside the brief itself was affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)