### PR TITLE
chore: add coverage.py outputs to .gitignore (#125)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,13 @@ venv/
 .pytest_cache/
 .mypy_cache/
 .ruff_cache/
+
+# coverage.py outputs — data file, parallel-mode shards, HTML report,
+# and the XML report some CI integrations consume.
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
 *.swp
 *.swo
 *~


### PR DESCRIPTION
Closes #125. Refile of #130 (closed pending CLA — now signed:
https://github.com/markus-michalski/storyforge/pull/130#event-24975919596).

## Summary

After running \`pytest --cov\`, the coverage.py data file
(\`.coverage\`) showed up as untracked in \`git status\` and risked
being committed by mistake. Add the standard coverage.py output set
to \`.gitignore\`:

| Pattern | What it ignores |
|---|---|
| \`.coverage\` | the data file |
| \`.coverage.*\` | parallel-mode shards |
| \`htmlcov/\` | HTML report directory |
| \`coverage.xml\` | XML report consumed by some CI integrations |

Placed next to the existing test-runner caches (\`.pytest_cache/\`,
\`.mypy_cache/\`, \`.ruff_cache/\`) so the coverage block is
colocated with the rest of the test infra.

## Test plan

- [x] \`git status\` is clean after running \`pytest --cov\` against
      the change.
- [x] Diff is six lines (one comment + four ignore patterns + one
      blank line).