### PR TITLE
test: add coverage for zero-coverage modules (#124)

### DIFF
--- a/tests/analysis/test_continuity.py
+++ b/tests/analysis/test_continuity.py
@@ -1,0 +1,167 @@
+"""Tests for tools.analysis.continuity — Issue #124."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.analysis.continuity import (
+    check_character_consistency,
+    check_timeline,
+    extract_character_mentions,
+)
+
+
+# ---------------------------------------------------------------------------
+# extract_character_mentions — pure function
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCharacterMentions:
+    def test_finds_mention(self):
+        result = extract_character_mentions("Marcus walked in.", ["Marcus", "Lena"])
+        assert "Marcus" in result
+        assert result["Marcus"] == [1]
+
+    def test_case_insensitive(self):
+        result = extract_character_mentions("MARCUS said hello.", ["Marcus"])
+        assert "Marcus" in result
+
+    def test_multiple_lines(self):
+        text = "Marcus spoke.\nLena replied.\nMarcus left."
+        result = extract_character_mentions(text, ["Marcus", "Lena"])
+        assert result["Marcus"] == [1, 3]
+        assert result["Lena"] == [2]
+
+    def test_missing_character_excluded(self):
+        result = extract_character_mentions("Nobody here.", ["Marcus"])
+        assert "Marcus" not in result
+
+    def test_empty_text(self):
+        result = extract_character_mentions("", ["Marcus"])
+        assert result == {}
+
+    def test_empty_names(self):
+        result = extract_character_mentions("Marcus walked.", [])
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# check_character_consistency
+# ---------------------------------------------------------------------------
+
+
+def _make_book(tmp_path: Path) -> Path:
+    book = tmp_path / "my-book"
+    (book / "characters").mkdir(parents=True)
+    (book / "chapters").mkdir()
+    return book
+
+
+class TestCheckCharacterConsistency:
+    def test_unused_character_flagged(self, tmp_path):
+        book = _make_book(tmp_path)
+        (book / "characters" / "marcus.md").write_text(
+            '---\nname: "Marcus"\n---\n', encoding="utf-8"
+        )
+        ch = book / "chapters" / "01-intro"
+        ch.mkdir()
+        (ch / "draft.md").write_text("Nobody important here.", encoding="utf-8")
+
+        issues = check_character_consistency(book)
+        assert any(i["type"] == "unused_character" for i in issues)
+        assert any("Marcus" in i["message"] for i in issues)
+
+    def test_mentioned_character_not_flagged(self, tmp_path):
+        book = _make_book(tmp_path)
+        (book / "characters" / "marcus.md").write_text(
+            '---\nname: "Marcus"\n---\n', encoding="utf-8"
+        )
+        ch = book / "chapters" / "01-intro"
+        ch.mkdir()
+        (ch / "draft.md").write_text("Marcus walked in.", encoding="utf-8")
+
+        issues = check_character_consistency(book)
+        assert not any(i["type"] == "unused_character" for i in issues)
+
+    def test_no_chapters_dir_returns_empty(self, tmp_path):
+        book = tmp_path / "my-book"
+        (book / "characters").mkdir(parents=True)
+        (book / "characters" / "marcus.md").write_text(
+            '---\nname: "Marcus"\n---\n', encoding="utf-8"
+        )
+        # No chapters dir
+
+        issues = check_character_consistency(book)
+        assert issues == []
+
+    def test_no_characters_dir_returns_empty(self, tmp_path):
+        book = tmp_path / "my-book"
+        (book / "chapters").mkdir(parents=True)
+
+        issues = check_character_consistency(book)
+        assert issues == []
+
+    def test_index_md_skipped(self, tmp_path):
+        book = _make_book(tmp_path)
+        (book / "characters" / "INDEX.md").write_text("# Characters\n", encoding="utf-8")
+
+        issues = check_character_consistency(book)
+        assert issues == []
+
+    def test_character_without_name_field_uses_stem(self, tmp_path):
+        book = _make_book(tmp_path)
+        (book / "characters" / "lena.md").write_text("# Lena\n", encoding="utf-8")
+        ch = book / "chapters" / "01-intro"
+        ch.mkdir()
+        (ch / "draft.md").write_text("lena was there.", encoding="utf-8")
+
+        issues = check_character_consistency(book)
+        assert not any("lena" in i.get("message", "") for i in issues)
+
+    def test_chapter_without_draft_skipped(self, tmp_path):
+        book = _make_book(tmp_path)
+        (book / "characters" / "marcus.md").write_text(
+            '---\nname: "Marcus"\n---\n', encoding="utf-8"
+        )
+        ch = book / "chapters" / "01-intro"
+        ch.mkdir()
+        # No draft.md
+
+        issues = check_character_consistency(book)
+        assert any(i["type"] == "unused_character" for i in issues)
+
+    def test_severity_is_warning(self, tmp_path):
+        book = _make_book(tmp_path)
+        (book / "characters" / "ghost.md").write_text(
+            '---\nname: "Ghost"\n---\n', encoding="utf-8"
+        )
+        ch = book / "chapters" / "01-intro"
+        ch.mkdir()
+        (ch / "draft.md").write_text("Nobody.", encoding="utf-8")
+
+        issues = check_character_consistency(book)
+        assert all(i["severity"] == "warning" for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# check_timeline
+# ---------------------------------------------------------------------------
+
+
+class TestCheckTimeline:
+    def test_missing_timeline_returns_info(self, tmp_path):
+        book = tmp_path / "my-book"
+        book.mkdir()
+
+        issues = check_timeline(book)
+        assert len(issues) == 1
+        assert issues[0]["type"] == "missing_timeline"
+        assert issues[0]["severity"] == "info"
+
+    def test_present_timeline_returns_no_issues(self, tmp_path):
+        book = tmp_path / "my-book"
+        (book / "plot").mkdir(parents=True)
+        (book / "plot" / "timeline.md").write_text("# Timeline\n", encoding="utf-8")
+
+        issues = check_timeline(book)
+        assert issues == []

--- a/tests/author/test_pdf_extractor.py
+++ b/tests/author/test_pdf_extractor.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tools.author import pdf_extractor
 from tools.author.pdf_extractor import (
     MAX_FILE_SIZE_BYTES,
     _sample_text,

--- a/tests/author/test_pdf_extractor.py
+++ b/tests/author/test_pdf_extractor.py
@@ -1,0 +1,253 @@
+"""Tests for tools.author.pdf_extractor — Issue #124."""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.author import pdf_extractor
+from tools.author.pdf_extractor import (
+    MAX_FILE_SIZE_BYTES,
+    _sample_text,
+    extract_text_from_file,
+    get_supported_formats,
+    get_text_stats,
+)
+
+
+# ---------------------------------------------------------------------------
+# get_supported_formats
+# ---------------------------------------------------------------------------
+
+
+def test_get_supported_formats_returns_list():
+    result = get_supported_formats()
+    assert isinstance(result, list)
+    assert ".pdf" in result
+    assert ".epub" in result
+    assert ".txt" in result
+    assert ".docx" in result
+
+
+# ---------------------------------------------------------------------------
+# extract_text_from_file — error paths
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTextErrors:
+    def test_file_not_found_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            extract_text_from_file(tmp_path / "missing.txt")
+
+    def test_unsupported_format_raises(self, tmp_path):
+        f = tmp_path / "book.xyz"
+        f.write_text("content", encoding="utf-8")
+        with pytest.raises(ValueError, match="Unsupported format"):
+            extract_text_from_file(f)
+
+    def test_file_too_large_raises(self, tmp_path, monkeypatch):
+        f = tmp_path / "huge.txt"
+        f.write_text("x", encoding="utf-8")
+        # Patch stat so size exceeds MAX_FILE_SIZE_BYTES
+        mock_stat = MagicMock()
+        mock_stat.st_size = MAX_FILE_SIZE_BYTES + 1
+        monkeypatch.setattr(Path, "stat", lambda self, *, follow_symlinks=True: mock_stat)
+        with pytest.raises(ValueError, match="File too large"):
+            extract_text_from_file(f)
+
+
+# ---------------------------------------------------------------------------
+# extract_text_from_file — plain text formats
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTextPlain:
+    def test_txt_file(self, tmp_path):
+        f = tmp_path / "book.txt"
+        f.write_text("Hello world", encoding="utf-8")
+        assert extract_text_from_file(f) == "Hello world"
+
+    def test_md_file(self, tmp_path):
+        f = tmp_path / "book.md"
+        f.write_text("# Chapter\n\nContent.", encoding="utf-8")
+        assert "Content." in extract_text_from_file(f)
+
+    def test_markdown_extension(self, tmp_path):
+        f = tmp_path / "book.markdown"
+        f.write_text("Text here.", encoding="utf-8")
+        assert extract_text_from_file(f) == "Text here."
+
+
+# ---------------------------------------------------------------------------
+# extract_text_from_file — word-limit sampling
+# ---------------------------------------------------------------------------
+
+
+class TestWordLimitSampling:
+    def test_large_text_gets_sampled(self, tmp_path):
+        words = ["word"] * 210_000
+        f = tmp_path / "big.txt"
+        f.write_text(" ".join(words), encoding="utf-8")
+        result = extract_text_from_file(f)
+        assert "[--- BEGINNING" in result
+        assert "[--- MIDDLE" in result
+        assert "[--- END" in result
+
+    def test_small_text_not_sampled(self, tmp_path):
+        f = tmp_path / "small.txt"
+        f.write_text("Just a few words.", encoding="utf-8")
+        result = extract_text_from_file(f)
+        assert "[--- BEGINNING" not in result
+
+
+# ---------------------------------------------------------------------------
+# _sample_text — pure function
+# ---------------------------------------------------------------------------
+
+
+class TestSampleText:
+    def test_returns_all_three_sections(self):
+        words = ["w"] * 300_000
+        text = " ".join(words)
+        result = _sample_text(text, words)
+        assert "[--- BEGINNING" in result
+        assert "[--- MIDDLE" in result
+        assert "[--- END" in result
+
+    def test_sampled_text_shorter_than_original(self):
+        words = ["word"] * 300_000
+        text = " ".join(words)
+        result = _sample_text(text, words)
+        assert len(result.split()) < len(words)
+
+
+# ---------------------------------------------------------------------------
+# _extract_from_pdf — mocked
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFromPdf:
+    def test_pdf_extraction_calls_fitz(self, tmp_path):
+        f = tmp_path / "book.pdf"
+        f.write_bytes(b"%PDF-1.5\nfake pdf content")
+
+        mock_page = MagicMock()
+        mock_page.get_text.return_value = "Page text content."
+        mock_doc = MagicMock()
+        mock_doc.__iter__ = MagicMock(return_value=iter([mock_page]))
+        mock_fitz = MagicMock()
+        mock_fitz.open.return_value = mock_doc
+
+        with patch.dict("sys.modules", {"fitz": mock_fitz}):
+            result = extract_text_from_file(f)
+
+        assert "Page text content." in result
+        mock_doc.close.assert_called_once()
+
+    def test_pdf_missing_fitz_raises_import_error(self, tmp_path):
+        f = tmp_path / "book.pdf"
+        f.write_bytes(b"%PDF-1.5\nfake")
+
+        with patch.dict("sys.modules", {"fitz": None}):
+            with pytest.raises((ImportError, TypeError)):
+                extract_text_from_file(f)
+
+
+# ---------------------------------------------------------------------------
+# _extract_from_epub — real zip
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFromEpub:
+    def test_epub_extracts_html_content(self, tmp_path):
+        f = tmp_path / "book.epub"
+        with zipfile.ZipFile(str(f), "w") as zf:
+            zf.writestr(
+                "OEBPS/chapter1.xhtml",
+                "<html><body><p>" + "A" * 200 + "</p></body></html>",
+            )
+            zf.writestr("META-INF/container.xml", "<container/>")
+
+        result = extract_text_from_file(f)
+        assert "A" * 10 in result
+
+    def test_epub_skips_short_files(self, tmp_path):
+        f = tmp_path / "book.epub"
+        with zipfile.ZipFile(str(f), "w") as zf:
+            zf.writestr("OEBPS/toc.xhtml", "<nav><ol><li>TOC</li></ol></nav>")
+
+        result = extract_text_from_file(f)
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# _extract_from_docx — mocked
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFromDocx:
+    def test_docx_extraction_calls_docx(self, tmp_path):
+        f = tmp_path / "book.docx"
+        f.write_bytes(b"PK fake docx content")
+
+        mock_para1 = MagicMock()
+        mock_para1.text = "First paragraph."
+        mock_para2 = MagicMock()
+        mock_para2.text = ""
+        mock_para3 = MagicMock()
+        mock_para3.text = "Third paragraph."
+
+        mock_doc = MagicMock()
+        mock_doc.paragraphs = [mock_para1, mock_para2, mock_para3]
+        mock_docx_module = MagicMock()
+        mock_docx_module.Document.return_value = mock_doc
+
+        with patch.dict("sys.modules", {"docx": mock_docx_module}):
+            result = extract_text_from_file(f)
+
+        assert "First paragraph." in result
+        assert "Third paragraph." in result
+
+    def test_docx_missing_module_raises_import_error(self, tmp_path):
+        f = tmp_path / "book.docx"
+        f.write_bytes(b"PK fake")
+
+        with patch.dict("sys.modules", {"docx": None}):
+            with pytest.raises((ImportError, TypeError)):
+                extract_text_from_file(f)
+
+
+# ---------------------------------------------------------------------------
+# get_text_stats — pure function
+# ---------------------------------------------------------------------------
+
+
+class TestGetTextStats:
+    def test_word_count(self):
+        stats = get_text_stats("one two three")
+        assert stats["word_count"] == 3
+
+    def test_paragraph_count(self):
+        stats = get_text_stats("Para one.\n\nPara two.\n\nPara three.")
+        assert stats["paragraph_count"] == 3
+
+    def test_character_count(self):
+        text = "hello"
+        stats = get_text_stats(text)
+        assert stats["character_count"] == 5
+
+    def test_estimated_pages(self):
+        text = " ".join(["word"] * 500)
+        stats = get_text_stats(text)
+        assert stats["estimated_pages"] == 2
+
+    def test_sampled_flag_true(self):
+        stats = get_text_stats("[--- BEGINNING (words 1-30,000) ---]\n\ncontent")
+        assert stats["sampled"] is True
+
+    def test_sampled_flag_false(self):
+        stats = get_text_stats("Normal text.")
+        assert stats["sampled"] is False

--- a/tests/export/test_pandoc.py
+++ b/tests/export/test_pandoc.py
@@ -6,6 +6,9 @@ Audit M1 (#117): pandoc forwards LaTeX, and xelatex respects
 LaTeX injection (``\\input{/etc/passwd}``, ``\\write18{...}``) or
 shell-escape pivots. Tests pin the allowlist contract before
 subprocess is ever called.
+
+Issue #124: additional tests to cover check_pandoc, check_calibre,
+generate_epub, generate_mobi, assemble_manuscript, and _human_size.
 """
 
 from __future__ import annotations
@@ -197,3 +200,277 @@ class TestDefaults:
         assert any("mainfont=Linux Libertine O" in c for c in cmd)
         assert any("fontsize=11pt" in c for c in cmd)
         assert any("geometry:margin=1in" in c for c in cmd)
+
+
+# ---------------------------------------------------------------------------
+# check_pandoc / check_calibre
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_subprocess_run():
+    """Generic subprocess.run mock."""
+    with patch.object(pandoc.subprocess, "run") as mock:
+        yield mock
+
+
+class TestCheckPandoc:
+    def test_installed(self, mock_subprocess_run):
+        mock_subprocess_run.return_value = MagicMock(stdout="pandoc 3.1\n", returncode=0)
+        result = pandoc.check_pandoc()
+        assert result["installed"] is True
+        assert "pandoc" in result["version"]
+
+    def test_not_installed(self, mock_subprocess_run):
+        mock_subprocess_run.side_effect = FileNotFoundError
+        result = pandoc.check_pandoc()
+        assert result["installed"] is False
+        assert result["version"] is None
+
+    def test_timeout(self, mock_subprocess_run):
+        mock_subprocess_run.side_effect = pandoc.subprocess.TimeoutExpired("pandoc", 10)
+        result = pandoc.check_pandoc()
+        assert result["installed"] is False
+
+    def test_empty_stdout(self, mock_subprocess_run):
+        mock_subprocess_run.return_value = MagicMock(stdout="", returncode=0)
+        result = pandoc.check_pandoc()
+        assert result["installed"] is True
+        assert result["version"] == "unknown"
+
+
+class TestCheckCalibre:
+    def test_installed(self, mock_subprocess_run):
+        mock_subprocess_run.return_value = MagicMock(stdout="ebook-convert 6.0\n", returncode=0)
+        result = pandoc.check_calibre()
+        assert result["installed"] is True
+
+    def test_not_installed(self, mock_subprocess_run):
+        mock_subprocess_run.side_effect = FileNotFoundError
+        result = pandoc.check_calibre()
+        assert result["installed"] is False
+        assert result["version"] is None
+
+    def test_timeout(self, mock_subprocess_run):
+        mock_subprocess_run.side_effect = pandoc.subprocess.TimeoutExpired("ebook-convert", 10)
+        result = pandoc.check_calibre()
+        assert result["installed"] is False
+
+    def test_empty_stdout(self, mock_subprocess_run):
+        mock_subprocess_run.return_value = MagicMock(stdout="", returncode=0)
+        result = pandoc.check_calibre()
+        assert result["version"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# generate_epub
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_epub_subprocess(tmp_path: Path):
+    output = tmp_path / "out.epub"
+
+    def fake_run(cmd, *args, **kwargs):
+        out_idx = cmd.index("-o") + 1
+        Path(cmd[out_idx]).write_bytes(b"PK fake epub")
+        result = MagicMock()
+        result.returncode = 0
+        result.stderr = ""
+        return result
+
+    with patch.object(pandoc.subprocess, "run", side_effect=fake_run) as mock:
+        yield mock, output
+
+
+class TestGenerateEpub:
+    def test_success(self, mock_epub_subprocess, tmp_path: Path):
+        mock_run, output = mock_epub_subprocess
+        result = pandoc.generate_epub(tmp_path / "in.md", output, "My Book", "Author")
+        assert result["success"] is True
+        assert "path" in result
+        assert result["size_bytes"] > 0
+
+    def test_includes_metadata_flags(self, mock_epub_subprocess, tmp_path: Path):
+        mock_run, output = mock_epub_subprocess
+        pandoc.generate_epub(tmp_path / "in.md", output, "My Book", "Test Author", language="de")
+        cmd = mock_run.call_args[0][0]
+        assert "title=My Book" in " ".join(cmd)
+        assert "author=Test Author" in " ".join(cmd)
+        assert "lang=de" in " ".join(cmd)
+
+    def test_cover_image_included_when_exists(self, mock_epub_subprocess, tmp_path: Path):
+        mock_run, output = mock_epub_subprocess
+        cover = tmp_path / "cover.jpg"
+        cover.write_bytes(b"fake image")
+        pandoc.generate_epub(tmp_path / "in.md", output, "T", "A", cover_image=cover)
+        cmd = mock_run.call_args[0][0]
+        assert "--epub-cover-image" in cmd
+
+    def test_cover_image_skipped_when_missing(self, mock_epub_subprocess, tmp_path: Path):
+        mock_run, output = mock_epub_subprocess
+        pandoc.generate_epub(tmp_path / "in.md", output, "T", "A", cover_image=tmp_path / "nope.jpg")
+        cmd = mock_run.call_args[0][0]
+        assert "--epub-cover-image" not in cmd
+
+    def test_failure_returns_error(self, tmp_path: Path):
+        def fail_run(cmd, *args, **kwargs):
+            result = MagicMock()
+            result.returncode = 1
+            result.stderr = "pandoc error"
+            return result
+
+        with patch.object(pandoc.subprocess, "run", side_effect=fail_run):
+            result = pandoc.generate_epub(tmp_path / "in.md", tmp_path / "out.epub", "T", "A")
+        assert result["success"] is False
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# generate_pdf — failure path
+# ---------------------------------------------------------------------------
+
+
+class TestGeneratePdfFailure:
+    def test_pandoc_failure_returns_error(self, tmp_path: Path):
+        def fail_run(cmd, *args, **kwargs):
+            result = MagicMock()
+            result.returncode = 1
+            result.stderr = "xelatex not found"
+            return result
+
+        with patch.object(pandoc.subprocess, "run", side_effect=fail_run):
+            result = pandoc.generate_pdf(tmp_path / "in.md", tmp_path / "out.pdf", "T", "A")
+        assert result["success"] is False
+        assert "xelatex not found" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# generate_mobi
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateMobi:
+    def test_epub_not_found(self, tmp_path: Path):
+        result = pandoc.generate_mobi(tmp_path / "missing.epub", tmp_path / "out.mobi")
+        assert result["success"] is False
+        assert "not found" in result["error"]
+
+    def test_success(self, tmp_path: Path):
+        epub = tmp_path / "book.epub"
+        epub.write_bytes(b"PK fake epub")
+        output = tmp_path / "out.mobi"
+
+        def fake_run(cmd, *args, **kwargs):
+            Path(cmd[-1]).write_bytes(b"fake mobi")
+            result = MagicMock()
+            result.returncode = 0
+            result.stderr = ""
+            return result
+
+        with patch.object(pandoc.subprocess, "run", side_effect=fake_run):
+            result = pandoc.generate_mobi(epub, output)
+        assert result["success"] is True
+        assert result["size_bytes"] > 0
+
+    def test_failure(self, tmp_path: Path):
+        epub = tmp_path / "book.epub"
+        epub.write_bytes(b"PK fake")
+
+        def fail_run(cmd, *args, **kwargs):
+            result = MagicMock()
+            result.returncode = 1
+            result.stderr = "conversion failed"
+            return result
+
+        with patch.object(pandoc.subprocess, "run", side_effect=fail_run):
+            result = pandoc.generate_mobi(epub, tmp_path / "out.mobi")
+        assert result["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# assemble_manuscript
+# ---------------------------------------------------------------------------
+
+
+class TestAssembleManuscript:
+    def _make_project(self, tmp_path: Path) -> Path:
+        project = tmp_path / "my-book"
+        (project / "chapters" / "01-intro").mkdir(parents=True)
+        (project / "chapters" / "02-conflict").mkdir()
+        (project / "chapters" / "01-intro" / "draft.md").write_text(
+            "Chapter one content.", encoding="utf-8"
+        )
+        (project / "chapters" / "02-conflict" / "draft.md").write_text(
+            "Chapter two content.", encoding="utf-8"
+        )
+        return project
+
+    def test_includes_all_chapters(self, tmp_path: Path):
+        project = self._make_project(tmp_path)
+        output = tmp_path / "manuscript.md"
+        result = pandoc.assemble_manuscript(project, output)
+        assert result["chapters_included"] == 2
+        text = output.read_text(encoding="utf-8")
+        assert "Chapter one content." in text
+        assert "Chapter two content." in text
+
+    def test_includes_front_matter(self, tmp_path: Path):
+        project = self._make_project(tmp_path)
+        (project / "export").mkdir()
+        (project / "export" / "front-matter.md").write_text(
+            "---\ntitle: Test\n---\n\nDedication page.", encoding="utf-8"
+        )
+        output = tmp_path / "manuscript.md"
+        pandoc.assemble_manuscript(project, output)
+        text = output.read_text(encoding="utf-8")
+        assert "Dedication page." in text
+
+    def test_includes_back_matter(self, tmp_path: Path):
+        project = self._make_project(tmp_path)
+        (project / "export").mkdir()
+        (project / "export" / "back-matter.md").write_text(
+            "About the author.", encoding="utf-8"
+        )
+        output = tmp_path / "manuscript.md"
+        pandoc.assemble_manuscript(project, output)
+        text = output.read_text(encoding="utf-8")
+        assert "About the author." in text
+
+    def test_word_count_returned(self, tmp_path: Path):
+        project = self._make_project(tmp_path)
+        output = tmp_path / "manuscript.md"
+        result = pandoc.assemble_manuscript(project, output)
+        assert result["word_count"] > 0
+
+    def test_empty_project_no_chapters(self, tmp_path: Path):
+        project = tmp_path / "empty-book"
+        (project / "chapters").mkdir(parents=True)
+        output = tmp_path / "manuscript.md"
+        result = pandoc.assemble_manuscript(project, output)
+        assert result["chapters_included"] == 0
+
+    def test_creates_output_parent_dirs(self, tmp_path: Path):
+        project = self._make_project(tmp_path)
+        output = tmp_path / "deep" / "nested" / "out.md"
+        pandoc.assemble_manuscript(project, output)
+        assert output.exists()
+
+
+# ---------------------------------------------------------------------------
+# _human_size
+# ---------------------------------------------------------------------------
+
+
+class TestHumanSize:
+    def test_bytes(self):
+        assert pandoc._human_size(500) == "500.0 B"
+
+    def test_kilobytes(self):
+        assert pandoc._human_size(2048) == "2.0 KB"
+
+    def test_megabytes(self):
+        assert pandoc._human_size(3 * 1024 * 1024) == "3.0 MB"
+
+    def test_gigabytes(self):
+        assert pandoc._human_size(2 * 1024 * 1024 * 1024) == "2.0 GB"

--- a/tests/shared/test_config.py
+++ b/tests/shared/test_config.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
-from unittest.mock import patch
 
-import pytest
 import yaml
 
 from tools.shared import config as cfg_module

--- a/tests/shared/test_config.py
+++ b/tests/shared/test_config.py
@@ -1,0 +1,193 @@
+"""Tests for tools.shared.config — Issue #124."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from tools.shared import config as cfg_module
+from tools.shared.config import (
+    _deep_merge,
+    _default_config,
+    get_authors_root,
+    get_book_categories_dir,
+    get_content_root,
+    get_genres_dir,
+    get_plugin_root,
+    get_reference_dir,
+    get_review_handle,
+    get_templates_dir,
+    load_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# _default_config
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultConfig:
+    def test_has_paths_key(self):
+        cfg = _default_config()
+        assert "paths" in cfg
+
+    def test_has_content_root(self):
+        cfg = _default_config()
+        assert "content_root" in cfg["paths"]
+
+    def test_has_defaults_section(self):
+        cfg = _default_config()
+        assert cfg["defaults"]["language"] == "en"
+        assert cfg["defaults"]["book_type"] == "novel"
+        assert cfg["defaults"]["book_category"] == "fiction"
+        assert cfg["defaults"]["review_handle"] == "Author"
+
+    def test_has_export_section(self):
+        cfg = _default_config()
+        assert cfg["export"]["pdf_engine"] == "xelatex"
+
+
+# ---------------------------------------------------------------------------
+# _deep_merge
+# ---------------------------------------------------------------------------
+
+
+class TestDeepMerge:
+    def test_flat_override(self):
+        base = {"a": 1, "b": 2}
+        _deep_merge(base, {"b": 99, "c": 3})
+        assert base == {"a": 1, "b": 99, "c": 3}
+
+    def test_nested_merge(self):
+        base = {"paths": {"content_root": "/old", "authors_root": "/authors"}}
+        _deep_merge(base, {"paths": {"content_root": "/new"}})
+        assert base["paths"]["content_root"] == "/new"
+        assert base["paths"]["authors_root"] == "/authors"
+
+    def test_non_dict_override_replaces(self):
+        base = {"section": {"key": "value"}}
+        _deep_merge(base, {"section": "flat"})
+        assert base["section"] == "flat"
+
+
+# ---------------------------------------------------------------------------
+# load_config
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfig:
+    def test_no_config_file_returns_defaults(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(cfg_module, "CONFIG_PATH", tmp_path / "nonexistent.yaml")
+        result = load_config()
+        assert "paths" in result
+        assert result["defaults"]["language"] == "en"
+
+    def test_config_file_merges_into_defaults(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            yaml.dump({"defaults": {"language": "de"}}), encoding="utf-8"
+        )
+        monkeypatch.setattr(cfg_module, "CONFIG_PATH", config_file)
+        result = load_config()
+        assert result["defaults"]["language"] == "de"
+        # Other defaults preserved
+        assert result["defaults"]["book_type"] == "novel"
+
+    def test_config_path_expansion(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            yaml.dump({"paths": {"content_root": "~/books"}}), encoding="utf-8"
+        )
+        monkeypatch.setattr(cfg_module, "CONFIG_PATH", config_file)
+        result = load_config()
+        assert not result["paths"]["content_root"].startswith("~")
+        assert "books" in result["paths"]["content_root"]
+
+    def test_empty_yaml_returns_defaults(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("", encoding="utf-8")
+        monkeypatch.setattr(cfg_module, "CONFIG_PATH", config_file)
+        result = load_config()
+        assert result["defaults"]["language"] == "en"
+
+
+# ---------------------------------------------------------------------------
+# Accessor helpers
+# ---------------------------------------------------------------------------
+
+
+class TestAccessors:
+    def test_get_review_handle_default(self):
+        cfg = _default_config()
+        assert get_review_handle(cfg) == "Author"
+
+    def test_get_review_handle_custom(self):
+        cfg = {"defaults": {"review_handle": "Markus"}}
+        assert get_review_handle(cfg) == "Markus"
+
+    def test_get_review_handle_missing_key(self):
+        assert get_review_handle({}) == "Author"
+
+    def test_get_content_root_returns_path(self):
+        cfg = {"paths": {"content_root": "/some/path"}}
+        result = get_content_root(cfg)
+        assert isinstance(result, Path)
+        assert result == Path("/some/path")
+
+    def test_get_authors_root_returns_path(self):
+        cfg = {"paths": {"authors_root": "/authors"}}
+        result = get_authors_root(cfg)
+        assert isinstance(result, Path)
+        assert result == Path("/authors")
+
+
+# ---------------------------------------------------------------------------
+# get_plugin_root
+# ---------------------------------------------------------------------------
+
+
+class TestGetPluginRoot:
+    def test_env_var_overrides(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", "/custom/plugin/root")
+        result = get_plugin_root()
+        assert result == Path("/custom/plugin/root")
+
+    def test_fallback_without_env_var(self, monkeypatch):
+        monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+        result = get_plugin_root()
+        # Fallback goes up 3 levels from config.py which is in tools/shared/
+        assert result.is_absolute()
+        assert result.exists()
+
+    def test_fallback_is_storyforge_root(self, monkeypatch):
+        monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+        result = get_plugin_root()
+        # Should contain tools/ directory (plugin root)
+        assert (result / "tools").exists()
+
+
+# ---------------------------------------------------------------------------
+# Directory helpers
+# ---------------------------------------------------------------------------
+
+
+class TestDirectoryHelpers:
+    def test_get_genres_dir(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", "/plugin")
+        assert get_genres_dir() == Path("/plugin/genres")
+
+    def test_get_book_categories_dir(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", "/plugin")
+        assert get_book_categories_dir() == Path("/plugin/book_categories")
+
+    def test_get_reference_dir(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", "/plugin")
+        assert get_reference_dir() == Path("/plugin/reference")
+
+    def test_get_templates_dir(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", "/plugin")
+        assert get_templates_dir() == Path("/plugin/templates")


### PR DESCRIPTION
## Summary

- `tests/analysis/test_continuity.py` (new) — `extract_character_mentions`, `check_character_consistency`, `check_timeline`
- `tests/author/test_pdf_extractor.py` (new) — all extraction paths (txt/md/epub/pdf mock/docx mock), error paths, `_sample_text`, `get_text_stats`
- `tests/shared/test_config.py` (new) — `load_config`, `_deep_merge`, `_default_config`, all accessor helpers, `get_plugin_root` env-var + fallback
- `tests/export/test_pandoc.py` (expanded) — `check_pandoc`, `check_calibre`, `generate_epub`, `generate_mobi`, `assemble_manuscript`, `_human_size`, pdf failure path

## Coverage results

| Module | Before | After |
|--------|--------|-------|
| tools/analysis/continuity.py | 0% | 100% |
| tools/author/pdf_extractor.py | 0% | 100% |
| tools/shared/config.py | 51% | 100% |
| tools/export/pandoc.py | 39% | 98% |
| **Project total** | 86% | **90%** |

Target was ≥82%. 1159 tests, all green, suite completes in <3s.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)