### PR TITLE
feat: update_book_rule MCP tool with list/lint companions (#145)

### DIFF
--- a/servers/storyforge-server/routers/claudemd.py
+++ b/servers/storyforge-server/routers/claudemd.py
@@ -21,6 +21,14 @@ from tools.claudemd.manager import (
     update_book_facts as _update_book_facts_impl,
 )
 from tools.claudemd.parser import extract_prefixed_lines as _extract_prefixed_lines
+from tools.claudemd.rules_editor import (
+    AmbiguousMatchError,
+    DisagreeingResolutionError,
+    MarkersNotFoundError,
+    list_rules as _list_rules_impl,
+    update_rule as _update_rule_impl,
+)
+from tools.claudemd.rules_lint import lint_book_rules as _lint_book_rules_impl
 from tools.shared.paths import resolve_character_path, resolve_project_path
 
 from . import _app
@@ -121,6 +129,124 @@ def append_book_rule(book_slug: str, text: str) -> str:
     except (FileNotFoundError, ValueError) as exc:
         return json.dumps({"error": str(exc)})
     return json.dumps({"path": str(path), "kind": "rule", "text": text})
+
+
+@mcp.tool()
+def list_book_rules(book_slug: str) -> str:
+    """List all managed rules in the book's CLAUDE.md RULES block.
+
+    Returns one entry per bullet inside ``<!-- RULES:START -->`` /
+    ``<!-- RULES:END -->`` with index, title, raw_text, has_regex,
+    has_literals, and the patterns the manuscript-checker scanner
+    would extract from the rule.
+
+    Static rules above the marker block are intentionally not listed —
+    they're template boilerplate, not user-managed entries.
+    """
+    config = _app.load_config()
+    try:
+        rules = _list_rules_impl(config, book_slug)
+    except FileNotFoundError as exc:
+        return json.dumps({"error": str(exc)})
+    except MarkersNotFoundError as exc:
+        return json.dumps({"error": str(exc)})
+    return json.dumps(
+        {
+            "rules": [
+                {
+                    "index": r.index,
+                    "title": r.title,
+                    "raw_text": r.raw_text,
+                    "has_regex": r.has_regex,
+                    "has_literals": r.has_literals,
+                    "extracted_patterns": r.extracted_patterns,
+                }
+                for r in rules
+            ]
+        }
+    )
+
+
+@mcp.tool()
+def update_book_rule(
+    book_slug: str,
+    rule_index: int = -1,
+    rule_match: str = "",
+    new_text: str = "",
+    delete: bool = False,
+    validate: bool = True,
+) -> str:
+    """Replace or remove a rule in the book's CLAUDE.md RULES block.
+
+    Resolution: ``rule_match`` is matched first against bold titles
+    (``**Title**``), then against rule body substrings — case-insensitive.
+    ``rule_index`` is the unambiguous fallback. When both are given they
+    must agree on the same rule.
+
+    Args:
+        book_slug: Book slug.
+        rule_index: 0-based index in the RULES block. ``-1`` = unset.
+        rule_match: Substring to match against rule title or body. Empty
+            string = unset.
+        new_text: Replacement text for the rule body (without leading
+            ``- ``). Required unless ``delete=True``.
+        delete: If True, remove the matched rule. Mutually exclusive
+            with ``new_text``.
+        validate: If True, lint the new rule against the
+            manuscript-checker pattern contract and return warnings.
+
+    Returns: ``{found, changed, rule_index, old_text, new_text,
+    warnings, extracted_patterns}``. ``found=False`` means the rule did
+    not exist (file unchanged). ``changed=False`` means the new text
+    matched the existing text (idempotent no-op).
+    """
+    config = _app.load_config()
+    resolved_index = rule_index if rule_index >= 0 else None
+    resolved_match = rule_match.strip() or None
+    resolved_new_text = new_text if new_text else None
+    try:
+        result = _update_rule_impl(
+            config,
+            book_slug,
+            rule_index=resolved_index,
+            rule_match=resolved_match,
+            new_text=resolved_new_text,
+            delete=delete,
+            validate=validate,
+        )
+    except FileNotFoundError as exc:
+        return json.dumps({"error": str(exc)})
+    except MarkersNotFoundError as exc:
+        return json.dumps({"error": str(exc)})
+    except AmbiguousMatchError as exc:
+        return json.dumps({"error": str(exc), "code": "ambiguous_match"})
+    except DisagreeingResolutionError as exc:
+        return json.dumps({"error": str(exc), "code": "disagreeing_resolution"})
+    except ValueError as exc:
+        return json.dumps({"error": str(exc), "code": "invalid_args"})
+    return json.dumps(result)
+
+
+@mcp.tool()
+def lint_book_rules(book_slug: str) -> str:
+    """Audit every rule in the book's RULES block against the
+    manuscript-checker pattern contract.
+
+    Surfaces rules the scanner will silently ignore or misinterpret
+    (italic-wrapped examples with ban cues, mixed positive/negative
+    quotes, dead patterns, character-class typos in backtick bodies).
+
+    Returns ``{rules_total, issues: [{rule_index, title, warnings,
+    extracted_patterns}, ...]}``. Rules with no warnings are not listed.
+    """
+    config = _app.load_config()
+    try:
+        result = _lint_book_rules_impl(config, book_slug)
+    except FileNotFoundError as exc:
+        return json.dumps({"error": str(exc)})
+    except MarkersNotFoundError as exc:
+        return json.dumps({"error": str(exc)})
+    return json.dumps(result)
 
 
 @mcp.tool()

--- a/tests/claudemd/test_rules_editor.py
+++ b/tests/claudemd/test_rules_editor.py
@@ -1,0 +1,436 @@
+"""Tests for editing existing rules in a book's CLAUDE.md.
+
+Issue #145 — `update_book_rule`, `list_book_rules`. The editor operates only
+inside the ``<!-- RULES:START --> ... <!-- RULES:END -->`` block; static rules
+above the marker are surfaced via list_rules but cannot be edited.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.claudemd.manager import init_claudemd
+from tools.claudemd.rules_editor import (
+    AmbiguousMatchError,
+    DisagreeingResolutionError,
+    MarkersNotFoundError,
+    list_rules,
+    update_rule,
+)
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def book_config(tmp_path: Path) -> dict:
+    content_root = tmp_path / "books"
+    book_dir = content_root / "projects" / "my-book"
+    book_dir.mkdir(parents=True)
+    (book_dir / "README.md").write_text("# My Book\n", encoding="utf-8")
+    return {"paths": {"content_root": str(content_root)}}
+
+
+def _seed_rules(book_config: dict, rules: list[str]) -> Path:
+    """Initialize CLAUDE.md and seed the RULES block with raw bullets."""
+    from tools.claudemd.manager import resolve_claudemd_path
+
+    init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+    path = resolve_claudemd_path(book_config, "my-book")
+    content = path.read_text(encoding="utf-8")
+
+    bullets = "\n".join(f"- {r}" for r in rules)
+    new_content = content.replace(
+        "<!-- RULES:START -->\n<!-- RULES:END -->",
+        f"<!-- RULES:START -->\n{bullets}\n<!-- RULES:END -->",
+    )
+    path.write_text(new_content, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# list_rules
+# ---------------------------------------------------------------------------
+
+
+class TestListRules:
+    def test_empty_block(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        assert list_rules(book_config, "my-book") == []
+
+    def test_single_rule(self, book_config):
+        _seed_rules(book_config, ["**Rule 1** — avoid passive voice"])
+        rules = list_rules(book_config, "my-book")
+        assert len(rules) == 1
+        assert rules[0].index == 0
+        assert rules[0].title == "Rule 1"
+        assert "avoid passive voice" in rules[0].raw_text
+
+    def test_multiple_rules(self, book_config):
+        _seed_rules(
+            book_config,
+            [
+                "**Rule 1** — avoid `clocked`",
+                "**Rule 2** — limit adverbs",
+                "**Rule 3** — never use `began to`",
+            ],
+        )
+        rules = list_rules(book_config, "my-book")
+        assert len(rules) == 3
+        assert [r.index for r in rules] == [0, 1, 2]
+        assert [r.title for r in rules] == ["Rule 1", "Rule 2", "Rule 3"]
+
+    def test_rule_without_bold_title(self, book_config):
+        _seed_rules(book_config, ["avoid passive voice in dialog"])
+        rules = list_rules(book_config, "my-book")
+        assert len(rules) == 1
+        # Falls back to truncated body as title.
+        assert "avoid passive voice" in rules[0].title
+
+    def test_has_regex_and_has_literals_flags(self, book_config):
+        _seed_rules(
+            book_config,
+            [
+                "**R1** — avoid `clocked` as a verb",  # literal
+                r"**R2** — avoid `\bsuddenly\b` patterns",  # regex (\b)
+                "**R3** — narrative discipline only",  # neither
+            ],
+        )
+        rules = list_rules(book_config, "my-book")
+        assert rules[0].has_literals is True
+        assert rules[0].has_regex is False
+        assert rules[1].has_regex is True
+        assert rules[2].has_literals is False
+        assert rules[2].has_regex is False
+
+    def test_raises_if_markers_missing(self, book_config, tmp_path):
+        from tools.claudemd.manager import resolve_claudemd_path
+
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        path = resolve_claudemd_path(book_config, "my-book")
+        # Strip the markers entirely.
+        content = path.read_text(encoding="utf-8")
+        content = content.replace("<!-- RULES:START -->\n", "")
+        content = content.replace("<!-- RULES:END -->", "")
+        path.write_text(content, encoding="utf-8")
+
+        with pytest.raises(MarkersNotFoundError):
+            list_rules(book_config, "my-book")
+
+
+# ---------------------------------------------------------------------------
+# update_rule — by index
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateByIndex:
+    def test_replaces_rule_at_index(self, book_config):
+        _seed_rules(
+            book_config,
+            ["**R1** — first", "**R2** — second", "**R3** — third"],
+        )
+        result = update_rule(
+            book_config, "my-book",
+            rule_index=1, new_text="**R2** — replacement",
+        )
+        assert result["found"] is True
+        assert result["changed"] is True
+        assert result["rule_index"] == 1
+        assert "**R2** — second" == result["old_text"]
+        rules = list_rules(book_config, "my-book")
+        assert rules[1].raw_text == "**R2** — replacement"
+        # Other rules untouched.
+        assert rules[0].raw_text == "**R1** — first"
+        assert rules[2].raw_text == "**R3** — third"
+
+    def test_index_out_of_range(self, book_config):
+        _seed_rules(book_config, ["**R1** — only"])
+        result = update_rule(
+            book_config, "my-book",
+            rule_index=5, new_text="should fail",
+        )
+        assert result["found"] is False
+
+    def test_negative_index_rejected(self, book_config):
+        _seed_rules(book_config, ["**R1** — only"])
+        with pytest.raises(ValueError):
+            update_rule(
+                book_config, "my-book",
+                rule_index=-1, new_text="x",
+            )
+
+
+# ---------------------------------------------------------------------------
+# update_rule — by match
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateByMatch:
+    def test_match_against_bold_title(self, book_config):
+        _seed_rules(
+            book_config,
+            ["**Adverbs** — limit them", "**Cliches** — kill on sight"],
+        )
+        result = update_rule(
+            book_config, "my-book",
+            rule_match="Adverbs", new_text="**Adverbs** — limit to 1 per scene",
+        )
+        assert result["found"] is True
+        assert result["rule_index"] == 0
+        rules = list_rules(book_config, "my-book")
+        assert "1 per scene" in rules[0].raw_text
+
+    def test_match_substring_case_insensitive(self, book_config):
+        _seed_rules(book_config, ["**Adverbs** — limit them"])
+        result = update_rule(
+            book_config, "my-book",
+            rule_match="adverbs", new_text="**Adverbs** — none",
+        )
+        assert result["found"] is True
+
+    def test_match_falls_back_to_body(self, book_config):
+        _seed_rules(book_config, ["no bold title here, watch for clocked usage"])
+        result = update_rule(
+            book_config, "my-book",
+            rule_match="clocked", new_text="rewritten",
+        )
+        assert result["found"] is True
+
+    def test_ambiguous_match_raises(self, book_config):
+        _seed_rules(
+            book_config,
+            ["**Adverbs Hard** — strict", "**Adverbs Soft** — flexible"],
+        )
+        with pytest.raises(AmbiguousMatchError) as exc:
+            update_rule(
+                book_config, "my-book",
+                rule_match="Adverbs", new_text="x",
+            )
+        assert "Adverbs Hard" in str(exc.value)
+        assert "Adverbs Soft" in str(exc.value)
+
+    def test_no_match_returns_found_false(self, book_config):
+        _seed_rules(book_config, ["**R1** — first"])
+        result = update_rule(
+            book_config, "my-book",
+            rule_match="nonexistent", new_text="x",
+        )
+        assert result["found"] is False
+
+
+# ---------------------------------------------------------------------------
+# update_rule — by both (agree / disagree)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateByBoth:
+    def test_both_agree_succeeds(self, book_config):
+        _seed_rules(
+            book_config,
+            ["**R1** — first", "**R2** — second", "**R3** — third"],
+        )
+        result = update_rule(
+            book_config, "my-book",
+            rule_index=1, rule_match="R2",
+            new_text="**R2** — replaced",
+        )
+        assert result["found"] is True
+        assert result["rule_index"] == 1
+
+    def test_both_disagree_raises(self, book_config):
+        _seed_rules(
+            book_config,
+            ["**R1** — first", "**R2** — second"],
+        )
+        with pytest.raises(DisagreeingResolutionError):
+            update_rule(
+                book_config, "my-book",
+                rule_index=0, rule_match="R2", new_text="x",
+            )
+
+    def test_neither_provided_raises(self, book_config):
+        _seed_rules(book_config, ["**R1** — first"])
+        with pytest.raises(ValueError):
+            update_rule(book_config, "my-book", new_text="x")
+
+
+# ---------------------------------------------------------------------------
+# delete
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteRule:
+    def test_delete_by_index(self, book_config):
+        _seed_rules(
+            book_config,
+            ["**R1** — first", "**R2** — second", "**R3** — third"],
+        )
+        result = update_rule(book_config, "my-book", rule_index=1, delete=True)
+        assert result["found"] is True
+        assert result["changed"] is True
+        assert result["new_text"] == ""
+        rules = list_rules(book_config, "my-book")
+        assert len(rules) == 2
+        assert rules[0].title == "R1"
+        assert rules[1].title == "R3"
+
+    def test_delete_by_match(self, book_config):
+        _seed_rules(
+            book_config,
+            ["**Keep** — always", "**Drop** — never"],
+        )
+        update_rule(book_config, "my-book", rule_match="Drop", delete=True)
+        rules = list_rules(book_config, "my-book")
+        assert len(rules) == 1
+        assert rules[0].title == "Keep"
+
+    def test_delete_with_new_text_rejected(self, book_config):
+        _seed_rules(book_config, ["**R1** — first"])
+        with pytest.raises(ValueError):
+            update_rule(
+                book_config, "my-book",
+                rule_index=0, delete=True, new_text="x",
+            )
+
+    def test_delete_nonexistent_returns_found_false(self, book_config):
+        _seed_rules(book_config, ["**R1** — first"])
+        result = update_rule(
+            book_config, "my-book",
+            rule_match="ghost", delete=True,
+        )
+        assert result["found"] is False
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    def test_same_text_twice_no_op(self, book_config):
+        _seed_rules(book_config, ["**R1** — original"])
+        update_rule(
+            book_config, "my-book",
+            rule_index=0, new_text="**R1** — updated",
+        )
+        result2 = update_rule(
+            book_config, "my-book",
+            rule_index=0, new_text="**R1** — updated",
+        )
+        assert result2["found"] is True
+        assert result2["changed"] is False
+
+    def test_empty_new_text_rejected(self, book_config):
+        _seed_rules(book_config, ["**R1** — first"])
+        with pytest.raises(ValueError):
+            update_rule(
+                book_config, "my-book",
+                rule_index=0, new_text="   ",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Marker preservation
+# ---------------------------------------------------------------------------
+
+
+class TestMarkerPreservation:
+    def test_markers_unchanged_after_update(self, book_config):
+        path = _seed_rules(book_config, ["**R1** — first", "**R2** — second"])
+        update_rule(
+            book_config, "my-book",
+            rule_index=0, new_text="**R1** — replaced",
+        )
+        content = path.read_text(encoding="utf-8")
+        assert content.count("<!-- RULES:START -->") == 1
+        assert content.count("<!-- RULES:END -->") == 1
+        # Other markers also intact.
+        assert "<!-- WORKFLOW:START -->" in content
+        assert "<!-- CALLBACKS:END -->" in content
+
+    def test_markers_unchanged_after_delete(self, book_config):
+        path = _seed_rules(book_config, ["**R1** — first"])
+        update_rule(book_config, "my-book", rule_index=0, delete=True)
+        content = path.read_text(encoding="utf-8")
+        assert "<!-- RULES:START -->" in content
+        assert "<!-- RULES:END -->" in content
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_no_markers_raises_on_update(self, book_config):
+        from tools.claudemd.manager import resolve_claudemd_path
+
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        path = resolve_claudemd_path(book_config, "my-book")
+        content = path.read_text(encoding="utf-8")
+        content = content.replace("<!-- RULES:START -->\n", "")
+        content = content.replace("<!-- RULES:END -->", "")
+        path.write_text(content, encoding="utf-8")
+
+        with pytest.raises(MarkersNotFoundError):
+            update_rule(
+                book_config, "my-book",
+                rule_index=0, new_text="x",
+            )
+
+    def test_static_rules_above_marker_invisible_to_editor(self, book_config):
+        """Rules outside the RULES:START/END block are not user-managed."""
+        from tools.claudemd.manager import resolve_claudemd_path
+
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        path = resolve_claudemd_path(book_config, "my-book")
+        content = path.read_text(encoding="utf-8")
+        # Insert a static bullet ABOVE the markers.
+        content = content.replace(
+            "<!-- RULES:START -->",
+            "- **Static** — unmanaged static rule\n<!-- RULES:START -->",
+        )
+        path.write_text(content, encoding="utf-8")
+
+        rules = list_rules(book_config, "my-book")
+        # Editor only sees managed (in-marker) rules.
+        assert all("Static" not in r.title for r in rules)
+
+    def test_multiline_rule_body_preserved(self, book_config):
+        """A bullet that wraps across multiple lines is treated as one rule."""
+        from tools.claudemd.manager import resolve_claudemd_path
+
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        path = resolve_claudemd_path(book_config, "my-book")
+        content = path.read_text(encoding="utf-8")
+        # Manually inject a multi-line bullet block.
+        block = (
+            "<!-- RULES:START -->\n"
+            "- **R1** — first line of rule\n"
+            "  continuation on second line\n"
+            "  and third line\n"
+            "- **R2** — second rule\n"
+            "<!-- RULES:END -->"
+        )
+        content = content.replace(
+            "<!-- RULES:START -->\n<!-- RULES:END -->", block
+        )
+        path.write_text(content, encoding="utf-8")
+
+        rules = list_rules(book_config, "my-book")
+        assert len(rules) == 2
+        assert "continuation on second line" in rules[0].raw_text
+        assert "and third line" in rules[0].raw_text
+
+    def test_book_not_found(self, book_config):
+        with pytest.raises(FileNotFoundError):
+            update_rule(
+                book_config, "nonexistent",
+                rule_index=0, new_text="x",
+            )

--- a/tests/claudemd/test_rules_lint.py
+++ b/tests/claudemd/test_rules_lint.py
@@ -1,0 +1,248 @@
+"""Tests for linting rules in a book's CLAUDE.md.
+
+Issue #145 — `lint_book_rules` (bulk) + `update_book_rule(validate=True)`
+(single-rule) share the same per-rule linter so warnings are consistent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.claudemd.manager import init_claudemd
+from tools.claudemd.rules_editor import update_rule
+from tools.claudemd.rules_lint import (
+    LINT_BRACKET_PLACEHOLDER,
+    LINT_ITALIC_EXAMPLES_WITH_BAN_CUE,
+    LINT_MIXED_POSITIVE_NEGATIVE_QUOTES,
+    LINT_SCANNER_EXTRACTS_NOTHING,
+    lint_book_rules,
+    lint_rule_text,
+)
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+@pytest.fixture
+def book_config(tmp_path: Path) -> dict:
+    content_root = tmp_path / "books"
+    book_dir = content_root / "projects" / "my-book"
+    book_dir.mkdir(parents=True)
+    (book_dir / "README.md").write_text("# My Book\n", encoding="utf-8")
+    return {"paths": {"content_root": str(content_root)}}
+
+
+def _seed_rules(book_config: dict, rules: list[str]) -> Path:
+    from tools.claudemd.manager import resolve_claudemd_path
+
+    init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+    path = resolve_claudemd_path(book_config, "my-book")
+    content = path.read_text(encoding="utf-8")
+    bullets = "\n".join(f"- {r}" for r in rules)
+    new_content = content.replace(
+        "<!-- RULES:START -->\n<!-- RULES:END -->",
+        f"<!-- RULES:START -->\n{bullets}\n<!-- RULES:END -->",
+    )
+    path.write_text(new_content, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# lint_rule_text — single-rule linter (used by both single + bulk paths)
+# ---------------------------------------------------------------------------
+
+
+class TestLintBracketPlaceholder:
+    def test_flags_word_placeholder_in_backticks(self):
+        rule = "Avoid `[noun] of [noun]` constructions"
+        result = lint_rule_text(rule)
+        codes = [w["code"] for w in result["warnings"]]
+        assert LINT_BRACKET_PLACEHOLDER in codes
+
+    def test_flags_subj_verb_placeholder(self):
+        rule = r"Avoid `[subj] [verb]ed` patterns"
+        result = lint_rule_text(rule)
+        codes = [w["code"] for w in result["warnings"]]
+        assert LINT_BRACKET_PLACEHOLDER in codes
+
+    def test_does_not_flag_real_character_class(self):
+        # [a-z] is a legitimate character class.
+        rule = r"Avoid `[a-z]+\s+began` openers"
+        result = lint_rule_text(rule)
+        codes = [w["code"] for w in result["warnings"]]
+        assert LINT_BRACKET_PLACEHOLDER not in codes
+
+    def test_does_not_flag_when_no_brackets(self):
+        rule = "Avoid `clocked` as a verb"
+        result = lint_rule_text(rule)
+        codes = [w["code"] for w in result["warnings"]]
+        assert LINT_BRACKET_PLACEHOLDER not in codes
+
+
+class TestLintItalicExamplesWithBanCue:
+    def test_flags_italic_examples_when_ban_cue_present(self):
+        rule = (
+            'Avoid these phrases: *"clocked"*, *"registered"*, *"noticed it"*'
+        )
+        result = lint_rule_text(rule)
+        codes = [w["code"] for w in result["warnings"]]
+        assert LINT_ITALIC_EXAMPLES_WITH_BAN_CUE in codes
+
+    def test_does_not_flag_italic_without_ban_cue(self):
+        rule = 'Tone reference: *"like cold steel"* — keep this kind of weight'
+        result = lint_rule_text(rule)
+        codes = [w["code"] for w in result["warnings"]]
+        assert LINT_ITALIC_EXAMPLES_WITH_BAN_CUE not in codes
+
+    def test_does_not_flag_when_examples_already_in_backticks(self):
+        rule = "Avoid `clocked`, `registered`, `noticed it` as verbs"
+        result = lint_rule_text(rule)
+        codes = [w["code"] for w in result["warnings"]]
+        assert LINT_ITALIC_EXAMPLES_WITH_BAN_CUE not in codes
+
+
+class TestLintMixedPositiveNegativeQuotes:
+    def test_flags_mixed_quotes_with_ban_cue(self):
+        # Has ban cue + multiple quoted phrases — scanner can't tell
+        # bans from positive examples, both get extracted as bans.
+        rule = 'Avoid "clocked" — replace with "noticed" or "registered"'
+        result = lint_rule_text(rule)
+        codes = [w["code"] for w in result["warnings"]]
+        assert LINT_MIXED_POSITIVE_NEGATIVE_QUOTES in codes
+
+    def test_does_not_flag_single_quote_with_ban_cue(self):
+        rule = 'Avoid "clocked" as a verb'
+        result = lint_rule_text(rule)
+        codes = [w["code"] for w in result["warnings"]]
+        assert LINT_MIXED_POSITIVE_NEGATIVE_QUOTES not in codes
+
+    def test_does_not_flag_quotes_without_ban_cue(self):
+        rule = 'Compare "felt like steel" with "felt like ice" for tone'
+        result = lint_rule_text(rule)
+        codes = [w["code"] for w in result["warnings"]]
+        assert LINT_MIXED_POSITIVE_NEGATIVE_QUOTES not in codes
+
+
+class TestLintScannerExtractsNothing:
+    def test_flags_when_ban_cue_but_no_extractable_pattern(self):
+        # Has ban cue but no backticks and no quotes → scanner extracts nothing.
+        rule = "Avoid passive voice constructions in dialog"
+        result = lint_rule_text(rule)
+        codes = [w["code"] for w in result["warnings"]]
+        assert LINT_SCANNER_EXTRACTS_NOTHING in codes
+
+    def test_does_not_flag_when_pattern_extracted(self):
+        rule = "Avoid `clocked` as a verb"
+        result = lint_rule_text(rule)
+        codes = [w["code"] for w in result["warnings"]]
+        assert LINT_SCANNER_EXTRACTS_NOTHING not in codes
+
+    def test_does_not_flag_narrative_rules_without_ban_cue(self):
+        # Pure narrative rule, no ban cue — silent rules are fine.
+        rule = "Keep prose dense and concrete"
+        result = lint_rule_text(rule)
+        codes = [w["code"] for w in result["warnings"]]
+        assert LINT_SCANNER_EXTRACTS_NOTHING not in codes
+
+
+class TestExtractedPatterns:
+    def test_returns_extracted_patterns_for_valid_rule(self):
+        rule = "Avoid `clocked` and `began to`"
+        result = lint_rule_text(rule)
+        labels = [p["label"] for p in result["extracted_patterns"]]
+        assert "clocked" in labels
+        assert "began to" in labels
+
+    def test_empty_for_unscannable_rule(self):
+        rule = "Keep prose dense and concrete"
+        result = lint_rule_text(rule)
+        assert result["extracted_patterns"] == []
+
+
+# ---------------------------------------------------------------------------
+# lint_book_rules — bulk
+# ---------------------------------------------------------------------------
+
+
+class TestLintBookRules:
+    def test_returns_per_rule_findings(self, book_config):
+        _seed_rules(
+            book_config,
+            [
+                "Avoid `clocked` as a verb",  # clean
+                "Avoid passive voice constructions",  # SCANNER_EXTRACTS_NOTHING
+                'Avoid "clocked" — replace with "noticed"',  # MIXED_QUOTES
+            ],
+        )
+        result = lint_book_rules(book_config, "my-book")
+        assert result["rules_total"] == 3
+        # Issues only for rules with warnings.
+        issue_indices = [i["rule_index"] for i in result["issues"]]
+        assert 0 not in issue_indices  # clean rule, no warnings
+        assert 1 in issue_indices
+        assert 2 in issue_indices
+
+    def test_empty_when_no_rules(self, book_config):
+        init_claudemd(book_config, PLUGIN_ROOT, "my-book")
+        result = lint_book_rules(book_config, "my-book")
+        assert result["rules_total"] == 0
+        assert result["issues"] == []
+
+    def test_rule_12_firelight_regression(self, book_config):
+        """Reproduces the actual bug from `Blood & Binary Firelight` Rule 12:
+        eight banned-phrase examples wrapped in *"..."* — invisible to scanner.
+        """
+        _seed_rules(
+            book_config,
+            [
+                "**Body-part anti-patterns** — Avoid these constructions: "
+                '*"hand on chest"*, *"breath caught"*, *"chest tight"*'
+            ],
+        )
+        result = lint_book_rules(book_config, "my-book")
+        # The lint should flag this rule.
+        assert len(result["issues"]) == 1
+        codes = [w["code"] for w in result["issues"][0]["warnings"]]
+        assert LINT_ITALIC_EXAMPLES_WITH_BAN_CUE in codes
+
+
+# ---------------------------------------------------------------------------
+# Consistency: single-rule lint and bulk lint produce identical warnings
+# for the same rule.
+# ---------------------------------------------------------------------------
+
+
+class TestLintConsistency:
+    def test_single_and_bulk_warnings_identical(self, book_config):
+        rule_text = 'Avoid "clocked" — replace with "noticed"'
+        _seed_rules(book_config, [rule_text])
+
+        bulk = lint_book_rules(book_config, "my-book")
+        bulk_codes = sorted(w["code"] for w in bulk["issues"][0]["warnings"])
+
+        single = lint_rule_text(rule_text)
+        single_codes = sorted(w["code"] for w in single["warnings"])
+
+        assert bulk_codes == single_codes
+
+    def test_validate_flag_in_update_rule_runs_lint(self, book_config):
+        _seed_rules(book_config, ["**R1** — first"])
+        result = update_rule(
+            book_config, "my-book",
+            rule_index=0,
+            new_text="**R1** — Avoid passive voice constructions",
+            validate=True,
+        )
+        codes = [w["code"] for w in result["warnings"]]
+        assert LINT_SCANNER_EXTRACTS_NOTHING in codes
+
+    def test_validate_false_skips_lint(self, book_config):
+        _seed_rules(book_config, ["**R1** — first"])
+        result = update_rule(
+            book_config, "my-book",
+            rule_index=0,
+            new_text="**R1** — Avoid passive voice constructions",
+            validate=False,
+        )
+        assert result.get("warnings", []) == []

--- a/tools/claudemd/rules_editor.py
+++ b/tools/claudemd/rules_editor.py
@@ -1,0 +1,419 @@
+"""Edit existing rules in a book's CLAUDE.md.
+
+Issue #145 — companion to ``append_rule`` in ``manager.py``. Operates only on
+the bullets between ``<!-- RULES:START -->`` and ``<!-- RULES:END -->``;
+any static rules above the marker block are intentionally invisible to the
+editor (they're template boilerplate, not user-managed entries).
+
+The module exposes:
+
+- ``list_rules(config, book_slug)`` — returns ``ParsedRule`` objects with
+  index, title, raw_text, and pattern-extraction flags.
+- ``update_rule(config, book_slug, *, rule_index, rule_match, new_text,
+  delete, validate)`` — replaces or removes a rule. Identifier resolution
+  prefers ``rule_match`` (against bold title, falling back to body
+  substring); ``rule_index`` is the unambiguous fallback for refactor
+  scripts. When both are given they must agree.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from tools.analysis.manuscript.rules import _extract_patterns_from_rule
+from tools.claudemd.manager import resolve_claudemd_path
+from tools.claudemd.parser import SECTION_MARKERS
+
+START_MARKER, END_MARKER = SECTION_MARKERS["rule"]
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class RulesError(Exception):
+    """Base class for rule-editor errors."""
+
+
+class MarkersNotFoundError(RulesError):
+    """The CLAUDE.md is missing the RULES START/END markers."""
+
+
+class RuleNotFoundError(RulesError):
+    """The requested rule does not exist (signaled via ``found: False``)."""
+
+
+class AmbiguousMatchError(RulesError):
+    """``rule_match`` resolved to more than one rule."""
+
+
+class DisagreeingResolutionError(RulesError):
+    """``rule_index`` and ``rule_match`` resolved to different rules."""
+
+
+# ---------------------------------------------------------------------------
+# Data
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ParsedRule:
+    index: int
+    title: str
+    raw_text: str
+    has_regex: bool = False
+    has_literals: bool = False
+    extracted_patterns: list[dict[str, Any]] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+_TITLE_RE = re.compile(r"^\*\*(?P<title>[^*]+)\*\*")
+_REGEX_HINT_CHARS = set("|()[]\\^$?+*{}")
+_BACKTICK_CONTENT_RE = re.compile(r"`([^`\n]+)`")
+
+
+def _extract_block(content: str) -> tuple[str, int, int]:
+    """Return ``(block_text, start_offset, end_offset)`` for the inner
+    RULES block (between, but excluding, the marker lines).
+
+    Raises ``MarkersNotFoundError`` when either marker is missing.
+    """
+    start = content.find(START_MARKER)
+    end = content.find(END_MARKER)
+    if start == -1 or end == -1 or end <= start:
+        raise MarkersNotFoundError(
+            f"RULES markers missing or malformed (looking for "
+            f"{START_MARKER!r} and {END_MARKER!r})"
+        )
+    inner_start = start + len(START_MARKER)
+    # Skip a single trailing newline after the start marker so the inner
+    # block doesn't accidentally include it.
+    if content[inner_start : inner_start + 1] == "\n":
+        inner_start += 1
+    return content[inner_start:end], inner_start, end
+
+
+def _parse_bullets(block_text: str) -> list[str]:
+    """Split a RULES block body into bullet bodies.
+
+    A bullet starts at a line beginning with ``- ``. Continuation lines
+    (indented or non-list lines) are folded into the previous bullet.
+    Comment lines (``<!-- ... -->``) and blank lines act as separators.
+    Returns the bullet *bodies* (without the leading ``- ``).
+    """
+    bullets: list[list[str]] = []
+    current: list[str] | None = None
+
+    for raw_line in block_text.splitlines():
+        line = raw_line.rstrip("\n")
+        if line.lstrip().startswith("<!--"):
+            if current is not None:
+                bullets.append(current)
+                current = None
+            continue
+        if not line.strip():
+            if current is not None:
+                bullets.append(current)
+                current = None
+            continue
+        if line.startswith("- "):
+            if current is not None:
+                bullets.append(current)
+            current = [line[2:].rstrip()]
+        else:
+            if current is not None:
+                current.append(line.strip())
+            # Lines without a current bullet (orphans) are ignored.
+
+    if current is not None:
+        bullets.append(current)
+
+    return [_join_bullet_lines(parts) for parts in bullets]
+
+
+def _join_bullet_lines(parts: list[str]) -> str:
+    """Join multi-line bullet parts with single spaces (preserves text)."""
+    return " ".join(p for p in parts if p)
+
+
+def _build_parsed_rule(index: int, raw_text: str) -> ParsedRule:
+    title = _rule_title(raw_text)
+    patterns = _extract_patterns_from_rule(raw_text)
+    has_regex = False
+    has_literals = False
+    extracted: list[dict[str, Any]] = []
+    for label, compiled in patterns:
+        # Heuristic: the extractor escaped literal substrings. If the
+        # compiled pattern equals the escape of its label, it's a literal.
+        is_regex = compiled.pattern != re.escape(label)
+        if is_regex:
+            has_regex = True
+        else:
+            has_literals = True
+        extracted.append(
+            {"label": label, "pattern": compiled.pattern, "is_regex": is_regex}
+        )
+    # An additional check: explicit regex hint chars in any backtick body.
+    for m in _BACKTICK_CONTENT_RE.finditer(raw_text):
+        inner = m.group(1).strip()
+        if any(c in _REGEX_HINT_CHARS for c in inner):
+            has_regex = True
+    return ParsedRule(
+        index=index,
+        title=title,
+        raw_text=raw_text,
+        has_regex=has_regex,
+        has_literals=has_literals,
+        extracted_patterns=extracted,
+    )
+
+
+def _rule_title(raw_text: str, max_len: int = 80) -> str:
+    bold = _TITLE_RE.match(raw_text)
+    if bold:
+        return bold.group("title").strip()
+    title = re.sub(r"\s+", " ", raw_text).strip()
+    if len(title) > max_len:
+        title = title[: max_len - 1].rstrip() + "…"
+    return title
+
+
+# ---------------------------------------------------------------------------
+# Public: list
+# ---------------------------------------------------------------------------
+
+
+def list_rules(config: dict[str, Any], book_slug: str) -> list[ParsedRule]:
+    """Return the parsed rules from the RULES block in a book's CLAUDE.md.
+
+    Raises ``MarkersNotFoundError`` if the markers are missing.
+    """
+    path = resolve_claudemd_path(config, book_slug)
+    if not path.exists():
+        raise FileNotFoundError(f"CLAUDE.md not found for book '{book_slug}'")
+    content = path.read_text(encoding="utf-8")
+    block_text, _, _ = _extract_block(content)
+    bodies = _parse_bullets(block_text)
+    return [_build_parsed_rule(i, body) for i, body in enumerate(bodies)]
+
+
+# ---------------------------------------------------------------------------
+# Public: update
+# ---------------------------------------------------------------------------
+
+
+def update_rule(
+    config: dict[str, Any],
+    book_slug: str,
+    *,
+    rule_index: int | None = None,
+    rule_match: str | None = None,
+    new_text: str | None = None,
+    delete: bool = False,
+    validate: bool = True,
+) -> dict[str, Any]:
+    """Replace or remove a single rule in the book's RULES block.
+
+    Returns a result dict; on a ``found: False`` outcome the file is left
+    unchanged.
+
+    Validation:
+    - At least one of ``rule_index`` or ``rule_match`` must be provided.
+    - ``delete=True`` and ``new_text`` are mutually exclusive.
+    - When neither delete nor new_text is given, ``ValueError`` is raised.
+    - ``new_text`` must be non-empty after ``strip()``.
+    - ``rule_index`` must be ``>= 0``.
+    """
+    _validate_args(rule_index, rule_match, new_text, delete)
+
+    path = resolve_claudemd_path(config, book_slug)
+    if not path.exists():
+        raise FileNotFoundError(f"CLAUDE.md not found for book '{book_slug}'")
+    content = path.read_text(encoding="utf-8")
+    block_text, inner_start, inner_end = _extract_block(content)
+    bodies = _parse_bullets(block_text)
+    rules = [_build_parsed_rule(i, b) for i, b in enumerate(bodies)]
+
+    target_index = _resolve_target_index(rules, rule_index, rule_match)
+    if target_index is None:
+        return {
+            "found": False,
+            "changed": False,
+            "rule_index": -1,
+            "old_text": "",
+            "new_text": "",
+            "warnings": [],
+            "extracted_patterns": [],
+        }
+
+    old_text = bodies[target_index]
+
+    if delete:
+        new_bodies = bodies[:target_index] + bodies[target_index + 1 :]
+        result_new_text = ""
+    else:
+        assert new_text is not None
+        cleaned = _normalize_new_text(new_text)
+        if cleaned == old_text:
+            return {
+                "found": True,
+                "changed": False,
+                "rule_index": target_index,
+                "old_text": old_text,
+                "new_text": old_text,
+                "warnings": _maybe_lint(old_text, validate),
+                "extracted_patterns": _extracted_patterns_for(old_text),
+            }
+        new_bodies = list(bodies)
+        new_bodies[target_index] = cleaned
+        result_new_text = cleaned
+
+    new_block = _serialize_block(new_bodies)
+    new_content = content[:inner_start] + new_block + content[inner_end:]
+    path.write_text(new_content, encoding="utf-8")
+
+    return {
+        "found": True,
+        "changed": True,
+        "rule_index": target_index,
+        "old_text": old_text,
+        "new_text": result_new_text,
+        "warnings": _maybe_lint(result_new_text, validate) if not delete else [],
+        "extracted_patterns": _extracted_patterns_for(result_new_text)
+        if not delete
+        else [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _validate_args(
+    rule_index: int | None,
+    rule_match: str | None,
+    new_text: str | None,
+    delete: bool,
+) -> None:
+    if rule_index is None and rule_match is None:
+        raise ValueError("Either rule_index or rule_match must be provided")
+    if rule_index is not None and rule_index < 0:
+        raise ValueError("rule_index must be >= 0")
+    if delete and new_text is not None:
+        raise ValueError("delete=True and new_text are mutually exclusive")
+    if not delete and new_text is None:
+        raise ValueError("new_text is required when delete=False")
+    if new_text is not None and not new_text.strip():
+        raise ValueError("new_text must not be empty")
+
+
+def _normalize_new_text(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip())
+
+
+def _resolve_target_index(
+    rules: list[ParsedRule],
+    rule_index: int | None,
+    rule_match: str | None,
+) -> int | None:
+    """Resolve to a single rule index, or ``None`` if not found.
+
+    Raises ``AmbiguousMatchError`` or ``DisagreeingResolutionError``.
+    """
+    by_index = None
+    by_match = None
+
+    if rule_index is not None:
+        if 0 <= rule_index < len(rules):
+            by_index = rule_index
+        # Out-of-range index -> resolve to None (handled by caller).
+
+    if rule_match is not None:
+        match_indices = _match_indices(rules, rule_match)
+        if len(match_indices) > 1:
+            titles = [rules[i].title for i in match_indices]
+            raise AmbiguousMatchError(
+                f"rule_match '{rule_match}' matches {len(match_indices)} rules: "
+                f"{titles}"
+            )
+        if match_indices:
+            by_match = match_indices[0]
+
+    if by_index is not None and by_match is not None:
+        if by_index != by_match:
+            raise DisagreeingResolutionError(
+                f"rule_index={by_index} and rule_match='{rule_match}' "
+                f"(index={by_match}) point to different rules"
+            )
+        return by_index
+    if by_index is not None:
+        return by_index
+    if by_match is not None:
+        return by_match
+    return None
+
+
+def _match_indices(rules: list[ParsedRule], needle: str) -> list[int]:
+    needle_lower = needle.lower().strip()
+    if not needle_lower:
+        return []
+
+    title_hits = [
+        r.index for r in rules if needle_lower in r.title.lower()
+    ]
+    if title_hits:
+        return title_hits
+
+    body_hits = [
+        r.index for r in rules if needle_lower in r.raw_text.lower()
+    ]
+    return body_hits
+
+
+def _serialize_block(bodies: list[str]) -> str:
+    """Render the inner block text given a list of bullet bodies.
+
+    Always starts with a newline and ends with a newline so the marker line
+    that follows is on its own line. An empty list collapses to a single
+    blank line so the markers stay adjacent.
+    """
+    if not bodies:
+        return ""
+    return "\n".join(f"- {b}" for b in bodies) + "\n"
+
+
+def _maybe_lint(rule_text: str, validate: bool) -> list[dict[str, Any]]:
+    if not validate or not rule_text:
+        return []
+    # Imported lazily so the editor doesn't hard-depend on the lint module.
+    from tools.claudemd.rules_lint import lint_rule_text
+
+    return lint_rule_text(rule_text)["warnings"]
+
+
+def _extracted_patterns_for(rule_text: str) -> list[dict[str, Any]]:
+    if not rule_text:
+        return []
+    from tools.claudemd.rules_lint import lint_rule_text
+
+    return lint_rule_text(rule_text)["extracted_patterns"]
+
+
+__all__ = [
+    "AmbiguousMatchError",
+    "DisagreeingResolutionError",
+    "MarkersNotFoundError",
+    "ParsedRule",
+    "RuleNotFoundError",
+    "RulesError",
+    "list_rules",
+    "update_rule",
+]

--- a/tools/claudemd/rules_lint.py
+++ b/tools/claudemd/rules_lint.py
@@ -1,0 +1,192 @@
+"""Lint rules in a book's CLAUDE.md against the manuscript-checker contract.
+
+Issue #145 — surfaces rules that the scanner will silently ignore or
+misinterpret. The single-rule linter (``lint_rule_text``) is shared by
+``update_book_rule(validate=True)`` and ``lint_book_rules`` so warnings
+are consistent across both call paths.
+
+Warning codes:
+
+- ``bracket_placeholder`` — backtick-wrapped content that contains
+  word-shaped ``[X]`` placeholders that look like character classes but are
+  almost certainly meant as ``\\w+``-style placeholders. Common typos:
+  ``[noun]``, ``[verb]``, ``[subj]``.
+- ``italic_examples_with_ban_cue`` — rule has a ban cue and italics
+  containing quoted phrases. Italics are ignored by the scanner; the
+  examples are silently invisible.
+- ``mixed_positive_negative_quotes`` — rule has a ban cue and *multiple*
+  quoted phrases. The scanner extracts every quoted phrase as a banned
+  pattern, so positive rewrite examples (``replace with "X"``) get
+  flagged as bans too.
+- ``scanner_extracts_nothing`` — rule has a ban cue but no extractable
+  pattern (no backticks, no quoted phrases). The scanner sees nothing.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from tools.analysis.manuscript.rules import _extract_patterns_from_rule
+from tools.claudemd.rules_editor import list_rules
+
+LINT_BRACKET_PLACEHOLDER = "bracket_placeholder"
+LINT_ITALIC_EXAMPLES_WITH_BAN_CUE = "italic_examples_with_ban_cue"
+LINT_MIXED_POSITIVE_NEGATIVE_QUOTES = "mixed_positive_negative_quotes"
+LINT_SCANNER_EXTRACTS_NOTHING = "scanner_extracts_nothing"
+
+
+_BACKTICK_CONTENT_RE = re.compile(r"`([^`\n]+)`")
+_QUOTED_CONTENT_RE = re.compile(r'"([^"\n]{3,})"')
+_ITALIC_QUOTED_RE = re.compile(r'\*"[^"\n]+"\*')
+_BAN_CUE_RE = re.compile(
+    r"\b(banned|ban|avoid|never|don[’']?t\s+use|do\s+not\s+use|limit|"
+    r"no\s+\w+|stop\s+using)\b",
+    re.IGNORECASE,
+)
+# Inside a backtick body: a [WORD] token (alphabetic, length 2-12).
+# Real character classes use ranges (``[a-z]``), shorter shorthand
+# (``[A-Z0-9]``), or POSIX-style. ``[noun]`` / ``[verb]`` / ``[subj]``
+# are the typo pattern that motivated this lint.
+_WORDLIKE_BRACKET_RE = re.compile(r"\[([a-z]{2,12})\]", re.IGNORECASE)
+
+
+def lint_rule_text(rule_text: str) -> dict[str, Any]:
+    """Run the four lint checks on a single rule body.
+
+    Returns ``{"warnings": [...], "extracted_patterns": [...]}``. Each
+    warning has shape ``{"code": str, "message": str, "hint": str}``.
+    """
+    warnings: list[dict[str, str]] = []
+    has_ban_cue = bool(_BAN_CUE_RE.search(rule_text))
+
+    warnings.extend(_check_bracket_placeholders(rule_text))
+
+    if has_ban_cue:
+        if _ITALIC_QUOTED_RE.search(rule_text):
+            warnings.append(
+                {
+                    "code": LINT_ITALIC_EXAMPLES_WITH_BAN_CUE,
+                    "message": (
+                        "Italic-wrapped quoted examples are invisible to the "
+                        "manuscript-checker scanner."
+                    ),
+                    "hint": (
+                        "Wrap the banned phrases in backticks (``foo``) "
+                        "instead of italics (*\"foo\"*) so the scanner "
+                        "extracts them."
+                    ),
+                }
+            )
+
+        quoted = _QUOTED_CONTENT_RE.findall(rule_text)
+        if len(quoted) >= 2:
+            warnings.append(
+                {
+                    "code": LINT_MIXED_POSITIVE_NEGATIVE_QUOTES,
+                    "message": (
+                        "Multiple double-quoted phrases combined with a ban "
+                        "cue: every quoted phrase is extracted as a banned "
+                        "pattern, so positive rewrite examples will be "
+                        "wrongly flagged as bans."
+                    ),
+                    "hint": (
+                        "Put banned phrases in backticks and positive "
+                        "examples in italics (or move them out of the rule "
+                        "body)."
+                    ),
+                }
+            )
+
+    extracted = _extracted_patterns(rule_text)
+
+    if has_ban_cue and not extracted:
+        warnings.append(
+            {
+                "code": LINT_SCANNER_EXTRACTS_NOTHING,
+                "message": (
+                    "Rule has a ban cue but no extractable pattern — the "
+                    "scanner will see nothing and the rule won't enforce."
+                ),
+                "hint": (
+                    "Add the banned phrase in backticks (``foo``) or in "
+                    "double quotes (\"foo\")."
+                ),
+            }
+        )
+
+    return {"warnings": warnings, "extracted_patterns": extracted}
+
+
+def lint_book_rules(config: dict[str, Any], book_slug: str) -> dict[str, Any]:
+    """Run ``lint_rule_text`` over every rule in a book's RULES block.
+
+    Returns ``{"rules_total": N, "issues": [{rule_index, title, warnings,
+    extracted_patterns}, ...]}``. Only rules with at least one warning
+    appear in ``issues``.
+    """
+    rules = list_rules(config, book_slug)
+    issues: list[dict[str, Any]] = []
+    for rule in rules:
+        result = lint_rule_text(rule.raw_text)
+        if result["warnings"]:
+            issues.append(
+                {
+                    "rule_index": rule.index,
+                    "title": rule.title,
+                    "warnings": result["warnings"],
+                    "extracted_patterns": result["extracted_patterns"],
+                }
+            )
+    return {"rules_total": len(rules), "issues": issues}
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _check_bracket_placeholders(rule_text: str) -> list[dict[str, str]]:
+    warnings: list[dict[str, str]] = []
+    for m in _BACKTICK_CONTENT_RE.finditer(rule_text):
+        body = m.group(1)
+        for bracket in _WORDLIKE_BRACKET_RE.finditer(body):
+            placeholder = bracket.group(0)
+            warnings.append(
+                {
+                    "code": LINT_BRACKET_PLACEHOLDER,
+                    "message": (
+                        f"Backtick body contains {placeholder}, which is a "
+                        f"character class — the scanner reads it literally, "
+                        f"not as a placeholder."
+                    ),
+                    "hint": (
+                        "If you meant a placeholder, use \\w+ inside the "
+                        "backticks; if you meant a literal character "
+                        "class, the rule will only match those exact "
+                        "letters."
+                    ),
+                }
+            )
+            break  # one warning per backtick body is enough
+    return warnings
+
+
+def _extracted_patterns(rule_text: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for label, compiled in _extract_patterns_from_rule(rule_text):
+        is_regex = compiled.pattern != re.escape(label)
+        out.append(
+            {"label": label, "pattern": compiled.pattern, "is_regex": is_regex}
+        )
+    return out
+
+
+__all__ = [
+    "LINT_BRACKET_PLACEHOLDER",
+    "LINT_ITALIC_EXAMPLES_WITH_BAN_CUE",
+    "LINT_MIXED_POSITIVE_NEGATIVE_QUOTES",
+    "LINT_SCANNER_EXTRACTS_NOTHING",
+    "lint_book_rules",
+    "lint_rule_text",
+]


### PR DESCRIPTION
## Summary

Adds three MCP tools for managing rules in a book's `CLAUDE.md`:

- **`update_book_rule`** — replace or delete a rule by index, by match against the bold title / body substring, or both. Disagreeing identifiers raise a clear error. Idempotent: same `new_text` twice returns `changed=False`. Operates only inside `<!-- RULES:START -->` / `<!-- RULES:END -->`; static rules above the marker block stay invisible to the editor.
- **`list_book_rules`** — enumerate managed rules with `index`, `title`, `raw_text`, `has_regex` / `has_literals` flags, and the patterns the manuscript-checker scanner would extract.
- **`lint_book_rules`** — bulk audit. Surfaces rules the scanner silently ignores or misinterprets.

Closes #145.

## Lint warnings

| Code | Meaning |
|---|---|
| `bracket_placeholder` | Backtick body contains `[noun]`/`[verb]`/`[subj]`-style placeholders that read as character classes |
| `italic_examples_with_ban_cue` | Italic-wrapped examples (`*"foo"*`) under a ban cue — invisible to the scanner. The bug from the issue. |
| `mixed_positive_negative_quotes` | Ban cue + multiple double-quoted phrases — positive rewrite examples get extracted as bans |
| `scanner_extracts_nothing` | Ban cue without any backtick or quoted phrase — dead rule |

## Architecture

- New module `tools/claudemd/rules_editor.py` — block parsing, identifier resolution, marker-preserving rewrite. Custom exceptions (`MarkersNotFoundError`, `AmbiguousMatchError`, `DisagreeingResolutionError`).
- New module `tools/claudemd/rules_lint.py` — single-rule and bulk linter. Shared with `update_book_rule(validate=True)` so warnings stay consistent across both call paths.
- Pattern extraction reuses `tools/analysis/manuscript/rules.py::_extract_patterns_from_rule` — the scanner's contract is the linter's source of truth, preventing drift.
- MCP wiring in `servers/storyforge-server/routers/claudemd.py` follows the existing wrapper pattern (`json.dumps`, error envelope, sentinel-arg unpacking).

## Real-world validation

Running `lint_book_rules` against `blood-and-binary-firelight` surfaces **7 of 12 rules** with findings — including the Rule 12 body-part anti-pattern case from the issue body (eight banned phrases wrapped in `*"..."*`, all silently dropped by the scanner). The bug is now detectable, and individual rules can be fixed via `update_book_rule(rule_match=..., new_text=...)`.

## Acceptance (per issue)

- [x] `update_book_rule` MCP tool implemented
- [x] Idempotent: same `new_text` twice is a no-op
- [x] Preserves `<!-- RULES:START -->` / `<!-- RULES:END -->` markers
- [x] Smoke-tested against multi-rule CLAUDE.md (50 unit tests + real-world run)
- [x] Optional: `list_book_rules` + `lint_book_rules` companion tools

## Out of scope

- Migrating `register-callback` / `promote-rule` skills to use `update_book_rule` instead of `Edit` — separate follow-up.
- Auto-migration of CLAUDE.md files missing the RULES markers — `MarkersNotFoundError` with a clear message is the current contract; if the edge case shows up in practice, separate issue.

## Test plan

- [x] `pytest tests/claudemd/test_rules_editor.py` (28 tests)
- [x] `pytest tests/claudemd/test_rules_lint.py` (22 tests)
- [x] Full suite: `pytest tests/` — 1209/1209 green
- [x] `ruff check` — clean
- [x] MCP tool registration verified via `mcp.list_tools()`
- [x] Manual smoke against a real book: run `list_book_rules` / `lint_book_rules` / `update_book_rule(validate=True)` from a session, confirm the JSON envelopes are usable