### PR TITLE
feat: lint at rule append + push for documented alternative

### DIFF
--- a/servers/storyforge-server/routers/claudemd.py
+++ b/servers/storyforge-server/routers/claudemd.py
@@ -28,7 +28,10 @@ from tools.claudemd.rules_editor import (
     list_rules as _list_rules_impl,
     update_rule as _update_rule_impl,
 )
-from tools.claudemd.rules_lint import lint_book_rules as _lint_book_rules_impl
+from tools.claudemd.rules_lint import (
+    lint_book_rules as _lint_book_rules_impl,
+    lint_rule_text as _lint_rule_text_impl,
+)
 from tools.shared.paths import resolve_character_path, resolve_project_path
 
 from . import _app
@@ -121,14 +124,38 @@ def get_character(book_slug: str, character_slug: str) -> str:
 
 
 @mcp.tool()
-def append_book_rule(book_slug: str, text: str) -> str:
-    """Append a rule to the Rules section of a book's CLAUDE.md."""
+def append_book_rule(book_slug: str, text: str, validate: bool = True) -> str:
+    """Append a rule to the Rules section of a book's CLAUDE.md.
+
+    With ``validate=True`` (default) the rule text is run through the
+    same lint as ``update_book_rule`` and any warnings are returned in
+    the response. Warnings are advisory — the rule is appended either way.
+
+    Returns ``{path, kind, text, warnings, extracted_patterns}``.
+    """
     config = _app.load_config()
     try:
         path = _append_rule_impl(config, book_slug, text)
     except (FileNotFoundError, ValueError) as exc:
         return json.dumps({"error": str(exc)})
-    return json.dumps({"path": str(path), "kind": "rule", "text": text})
+
+    if validate:
+        lint = _lint_rule_text_impl(text)
+        warnings = lint["warnings"]
+        extracted = lint["extracted_patterns"]
+    else:
+        warnings = []
+        extracted = []
+
+    return json.dumps(
+        {
+            "path": str(path),
+            "kind": "rule",
+            "text": text,
+            "warnings": warnings,
+            "extracted_patterns": extracted,
+        }
+    )
 
 
 @mcp.tool()

--- a/tests/server/test_append_book_rule_lint.py
+++ b/tests/server/test_append_book_rule_lint.py
@@ -1,0 +1,159 @@
+"""Tests for ``append_book_rule(validate=True)`` lint behavior.
+
+Issue follow-up to #145: rule append should run the same lint as
+update_book_rule so we don't accept new rules that the manuscript-checker
+will silently ignore.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import routers._app as _app
+from routers.claudemd import append_book_rule, init_book_claudemd
+from tools.claudemd.rules_lint import (
+    LINT_ITALIC_EXAMPLES_WITH_BAN_CUE,
+    LINT_MIXED_POSITIVE_NEGATIVE_QUOTES,
+    LINT_SCANNER_EXTRACTS_NOTHING,
+)
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+@pytest.fixture
+def book_config(tmp_path: Path) -> dict:
+    content_root = tmp_path / "books"
+    book_dir = content_root / "projects" / "my-book"
+    book_dir.mkdir(parents=True)
+    (book_dir / "README.md").write_text("# My Book\n", encoding="utf-8")
+    return {"paths": {"content_root": str(content_root)}}
+
+
+@pytest.fixture
+def initialized_book(
+    book_config: dict, monkeypatch: pytest.MonkeyPatch
+) -> dict:
+    """Initialize CLAUDE.md and patch load_config so MCP tools see the
+    test config."""
+    monkeypatch.setattr(_app, "load_config", lambda: book_config)
+    init_book_claudemd("my-book", book_title="My Book")
+    return book_config
+
+
+class TestAppendBookRuleValidateDefault:
+    def test_default_returns_warnings_field(self, initialized_book):
+        result = json.loads(append_book_rule("my-book", "Avoid `clocked` as a verb"))
+        assert "warnings" in result
+        assert isinstance(result["warnings"], list)
+
+    def test_clean_rule_no_warnings(self, initialized_book):
+        result = json.loads(append_book_rule("my-book", "Avoid `clocked` as a verb"))
+        assert result["warnings"] == []
+
+    def test_extracted_patterns_present_for_scannable_rule(self, initialized_book):
+        result = json.loads(append_book_rule("my-book", "Avoid `clocked` as a verb"))
+        labels = [p["label"] for p in result["extracted_patterns"]]
+        assert "clocked" in labels
+
+
+class TestAppendBookRuleWarningsForBadRules:
+    def test_italic_examples_with_ban_cue_warns(self, initialized_book):
+        result = json.loads(
+            append_book_rule(
+                "my-book",
+                'Avoid these phrases: *"clocked"*, *"registered"*',
+            )
+        )
+        codes = [w["code"] for w in result["warnings"]]
+        assert LINT_ITALIC_EXAMPLES_WITH_BAN_CUE in codes
+
+    def test_mixed_quotes_warning(self, initialized_book):
+        result = json.loads(
+            append_book_rule(
+                "my-book",
+                'Avoid "clocked" — replace with "noticed" or "registered"',
+            )
+        )
+        codes = [w["code"] for w in result["warnings"]]
+        assert LINT_MIXED_POSITIVE_NEGATIVE_QUOTES in codes
+
+    def test_scanner_extracts_nothing_warning(self, initialized_book):
+        result = json.loads(
+            append_book_rule("my-book", "Avoid passive voice constructions")
+        )
+        codes = [w["code"] for w in result["warnings"]]
+        assert LINT_SCANNER_EXTRACTS_NOTHING in codes
+
+
+class TestAppendStillHappensWithWarnings:
+    """Lint warnings are advisory — the rule is still appended."""
+
+    def test_rule_appended_despite_warnings(self, initialized_book):
+        result = json.loads(
+            append_book_rule(
+                "my-book",
+                'Avoid these: *"clocked"*, *"registered"*',
+            )
+        )
+        # Append succeeded.
+        assert "path" in result
+        assert "error" not in result
+        # And we got warnings back.
+        assert len(result["warnings"]) > 0
+
+
+class TestValidateFalseSkipsLint:
+    def test_validate_false_returns_empty_warnings(self, initialized_book):
+        result = json.loads(
+            append_book_rule(
+                "my-book",
+                "Avoid passive voice constructions",
+                validate=False,
+            )
+        )
+        assert result["warnings"] == []
+        assert result["extracted_patterns"] == []
+
+
+class TestEnrichedScannerExtractsNothingHint:
+    """When a rule has a ban cue but no extractable pattern AND no
+    discernible alternative ('use X instead', 'replace with', '→'),
+    the hint should call out both gaps explicitly so the user knows
+    to add either a backticked phrase OR an alternative."""
+
+    def test_hint_mentions_alternative_when_missing(self, initialized_book):
+        result = json.loads(
+            append_book_rule(
+                "my-book",
+                "Avoid passive voice constructions",  # no alternative
+            )
+        )
+        warnings = [
+            w for w in result["warnings"] if w["code"] == LINT_SCANNER_EXTRACTS_NOTHING
+        ]
+        assert warnings
+        hint = warnings[0]["hint"].lower()
+        assert "alternative" in hint or "instead" in hint or "replace" in hint
+
+    def test_hint_does_not_demand_alternative_when_present(
+        self, initialized_book
+    ):
+        # Rule has 'replace with' — alternative is documented, even though
+        # the scanner still can't extract anything. Hint should NOT push for
+        # an alternative (that's already there).
+        result = json.loads(
+            append_book_rule(
+                "my-book",
+                "Avoid passive voice — replace with active constructions",
+            )
+        )
+        warnings = [
+            w for w in result["warnings"] if w["code"] == LINT_SCANNER_EXTRACTS_NOTHING
+        ]
+        if warnings:
+            hint = warnings[0]["hint"].lower()
+            # No demand for an alternative — it's already in the rule.
+            assert "alternative" not in hint or "backtick" in hint

--- a/tools/claudemd/rules_lint.py
+++ b/tools/claudemd/rules_lint.py
@@ -44,6 +44,14 @@ _BAN_CUE_RE = re.compile(
     r"no\s+\w+|stop\s+using)\b",
     re.IGNORECASE,
 )
+# Phrases that indicate the rule already documents what to do instead.
+# When present, the scanner_extracts_nothing hint should not nag for an
+# alternative — only push for a scannable pattern.
+_ALTERNATIVE_CUE_RE = re.compile(
+    r"(replace\s+with|use\s+\S+\s+instead|instead\s+of|"
+    r"prefer\s+\S|→|->|rewrite\s+as|swap\s+for)",
+    re.IGNORECASE,
+)
 # Inside a backtick body: a [WORD] token (alphabetic, length 2-12).
 # Real character classes use ranges (``[a-z]``), shorter shorthand
 # (``[A-Z0-9]``), or POSIX-style. ``[noun]`` / ``[verb]`` / ``[subj]``
@@ -101,6 +109,21 @@ def lint_rule_text(rule_text: str) -> dict[str, Any]:
     extracted = _extracted_patterns(rule_text)
 
     if has_ban_cue and not extracted:
+        has_alternative = bool(_ALTERNATIVE_CUE_RE.search(rule_text))
+        if has_alternative:
+            hint = (
+                "Add the banned phrase in backticks (``foo``) so the "
+                "scanner can enforce it. The alternative is already "
+                "documented."
+            )
+        else:
+            hint = (
+                "Add the banned phrase in backticks (``foo``) so the "
+                "scanner can enforce it, AND document an alternative "
+                "(e.g. 'replace with ...', 'use ... instead', '→ ...') "
+                "so the rule tells the writer what to do, not just what "
+                "to avoid."
+            )
         warnings.append(
             {
                 "code": LINT_SCANNER_EXTRACTS_NOTHING,
@@ -108,10 +131,7 @@ def lint_rule_text(rule_text: str) -> dict[str, Any]:
                     "Rule has a ban cue but no extractable pattern — the "
                     "scanner will see nothing and the rule won't enforce."
                 ),
-                "hint": (
-                    "Add the banned phrase in backticks (``foo``) or in "
-                    "double quotes (\"foo\")."
-                ),
+                "hint": hint,
             }
         )
 


### PR DESCRIPTION
## Summary

Two follow-ups to #146 — same scope, both small.

### 1. `append_book_rule(validate=True)` defaults to validating

Without this, the same scanner-blind shapes that `update_book_rule` catches at edit time slip through silently when a brand-new rule is added. Now both paths run identical lint and return the same `warnings` / `extracted_patterns` envelope. Lint is **advisory** — the rule is appended either way.

Use `validate=False` to opt out (e.g. for bulk-import migrations where lint runs separately).

### 2. `scanner_extracts_nothing` hint differentiates on whether an alternative is documented

The previous hint only pushed for a scannable pattern. New behavior:

- Rule has no extractable pattern AND no alternative phrase (`replace with`, `use X instead`, `→`, etc.) → hint asks for **both**: a backticked phrase, AND a documented alternative. Reasoning: a rule that says only what to avoid is a halt-sign, not a tool. The writer needs to know what to reach for.
- Rule has no extractable pattern but already documents an alternative → hint only pushes for the scannable pattern. The "what to do instead" part is already there.

## Real-world demo

```
--- 'Avoid passive voice constructions' ---
hint: Add the banned phrase in backticks (``foo``) so the scanner can
      enforce it, AND document an alternative (e.g. 'replace with ...',
      'use ... instead', '→ ...') so the rule tells the writer what to
      do, not just what to avoid.

--- 'Avoid passive voice — replace with active constructions' ---
hint: Add the banned phrase in backticks (``foo``) so the scanner can
      enforce it. The alternative is already documented.
```

## Test plan

- [x] `pytest tests/server/test_append_book_rule_lint.py` — 10 new tests
- [x] Full suite 1219/1219 green
- [x] `ruff check` clean
- [x] Manual: append a rule with and without `validate=False` from a session, confirm the JSON envelope matches `update_book_rule`'s shape