### PR TITLE
feat(mcp): add update_character_snapshot + chapter-writer step 7b write-back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- MCP: `update_character_snapshot` tool — persists end-of-chapter POV character state (inventory, clothing, injuries, altered states, environmental limiters, as_of_chapter) back to `characters/{slug}.md` / `people/{slug}.md` frontmatter so the next chapter brief picks them up from the highest-priority `frontmatter` source; supports fiction and memoir layouts (#157 prerequisite / #160 prerequisite)
+- Skills: `chapter-writer` Step 7.8 "Update POV character snapshot" — Option-C hybrid write-back: brief extracts state from the completed draft, proposes a snapshot to the user, waits for confirmation/correction, then persists via `update_character_snapshot`; runs on `Review`/`Final` closes only, skipped for mid-chapter Draft saves (#157 / #160 prerequisite)
 - MCP: `pov_character_inventory` field in `get_chapter_writing_brief` — deterministic extraction of the POV character's last established physical inventory (frontmatter > timeline_regex > draft_heuristic > none) so the chapter-writer surfaces gaps instead of inventing items (#157)
 - Skills: `chapter-writer` Pre-Scene Logic Audit — mandatory pre-prose audit block (inventory / geography / character biography / banned phrases + tics / sensory plausibility) emitted to chat before each scene (Mode A) or once per chapter (Mode B), so source-discipline is structurally enforced instead of being a passive rule the model overlooks under context pressure (#155)
 

--- a/servers/storyforge-server/routers/claudemd.py
+++ b/servers/storyforge-server/routers/claudemd.py
@@ -1,8 +1,10 @@
-"""Per-book CLAUDE.md tools + ``get_character`` (which reads the character
-profile that the CLAUDE.md context references).
+"""Per-book CLAUDE.md tools + character read/write tools.
 
 The CLAUDE.md tools wrap ``tools.claudemd.manager`` — they're the only
 state-mutating MCP entry points that touch the per-book CLAUDE.md.
+
+Character tools: ``get_character`` (read) and ``update_character_snapshot``
+(write-back of end-of-chapter POV state — Issues #157 / #160).
 """
 
 from __future__ import annotations
@@ -32,7 +34,11 @@ from tools.claudemd.rules_lint import (
     lint_book_rules as _lint_book_rules_impl,
     lint_rule_text as _lint_rule_text_impl,
 )
-from tools.shared.paths import resolve_character_path, resolve_project_path
+from tools.shared.paths import (
+    resolve_character_path,
+    resolve_people_dir,
+    resolve_project_path,
+)
 
 from . import _app
 from ._app import mcp
@@ -121,6 +127,125 @@ def get_character(book_slug: str, character_slug: str) -> str:
         return json.dumps({"content": legacy.read_text(encoding="utf-8")})
 
     return json.dumps({"error": f"Character '{character_slug}' not found in book '{book_slug}'"})
+
+
+# Snapshot fields written back to the character file at chapter close.
+# ``as_of_chapter`` is a string (chapter slug); all others are list[str].
+_SNAPSHOT_FIELDS: frozenset[str] = frozenset(
+    {
+        "current_inventory",
+        "current_clothing",
+        "current_injuries",
+        "altered_states",
+        "environmental_limiters",
+        "as_of_chapter",
+    }
+)
+
+
+@mcp.tool()
+def update_character_snapshot(
+    book_slug: str,
+    character_slug: str,
+    snapshot_json: str,
+    book_category: str = "fiction",
+) -> str:
+    """Persist end-of-chapter POV character snapshot to the character file.
+
+    Writes the structured list fields that the chapter-writing brief extracts
+    (``pov_character_inventory`` from Issue #157; ``pov_character_state`` from
+    Issue #160) back to the character frontmatter so the *next* chapter's brief
+    picks them up from the highest-priority ``frontmatter`` source rather than
+    falling through to timeline regex or draft heuristics.
+
+    Only the five snapshot fields (plus ``as_of_chapter``) are touched — all
+    other frontmatter fields are left unchanged.
+
+    Args:
+        book_slug: Book project slug.
+        character_slug: Character / person slug (without extension).
+        snapshot_json: JSON object with any subset of:
+            ``current_inventory``, ``current_clothing``, ``current_injuries``,
+            ``altered_states``, ``environmental_limiters`` (all list[str]);
+            ``as_of_chapter`` (str). Unknown keys are rejected.
+        book_category: ``"fiction"`` (default) or ``"memoir"``. Controls
+            whether the character lives under ``characters/`` or ``people/``.
+
+    Returns:
+        ``{success, character, book, updated_fields}`` on success, or
+        ``{error}`` on validation / IO failure.
+    """
+    import yaml
+
+    from tools.state.parsers import parse_frontmatter
+
+    config = _app.load_config()
+    content_root = Path(config["paths"]["content_root"]).resolve()
+
+    try:
+        snapshot: dict[str, Any] = json.loads(snapshot_json)
+    except json.JSONDecodeError as exc:
+        return json.dumps({"error": f"snapshot_json is not valid JSON: {exc}"})
+    if not isinstance(snapshot, dict):
+        return json.dumps({"error": "snapshot_json must be a JSON object"})
+    if not snapshot:
+        return json.dumps({"error": "snapshot_json must not be empty"})
+
+    unknown = set(snapshot.keys()) - _SNAPSHOT_FIELDS
+    if unknown:
+        return json.dumps(
+            {
+                "error": (
+                    f"Unknown snapshot fields: {sorted(unknown)}. "
+                    f"Allowed: {sorted(_SNAPSHOT_FIELDS)}"
+                )
+            }
+        )
+
+    list_fields = _SNAPSHOT_FIELDS - {"as_of_chapter"}
+    for field in list_fields:
+        if field in snapshot:
+            val = snapshot[field]
+            if not isinstance(val, list) or not all(isinstance(i, str) for i in val):
+                return json.dumps({"error": f"Field '{field}' must be a list of strings"})
+
+    if "as_of_chapter" in snapshot and not isinstance(snapshot["as_of_chapter"], str):
+        return json.dumps({"error": "Field 'as_of_chapter' must be a string"})
+
+    project_dir = resolve_project_path(config, book_slug)
+    if not project_dir.exists():
+        return json.dumps({"error": f"Book '{book_slug}' not found"})
+
+    if book_category == "memoir":
+        char_file = resolve_people_dir(project_dir, "memoir") / f"{character_slug}.md"
+    else:
+        char_file = resolve_character_path(config, book_slug, character_slug)
+
+    try:
+        resolved = char_file.resolve()
+    except (OSError, RuntimeError) as exc:
+        return json.dumps({"error": f"Invalid path: {exc}"})
+    if not resolved.is_relative_to(content_root):
+        return json.dumps({"error": "Resolved character path escapes content_root"})
+
+    if not char_file.exists():
+        return json.dumps({"error": f"Character file not found: {char_file}"})
+
+    text = char_file.read_text(encoding="utf-8")
+    meta, body = parse_frontmatter(text)
+    meta.update(snapshot)
+    new_text = "---\n" + yaml.dump(meta, default_flow_style=False, allow_unicode=True) + "---\n" + body
+    char_file.write_text(new_text, encoding="utf-8")
+
+    _app._cache.invalidate()
+    return json.dumps(
+        {
+            "success": True,
+            "character": character_slug,
+            "book": book_slug,
+            "updated_fields": sorted(snapshot.keys()),
+        }
+    )
 
 
 @mcp.tool()

--- a/servers/storyforge-server/server.py
+++ b/servers/storyforge-server/server.py
@@ -68,6 +68,7 @@ from routers.claudemd import (  # noqa: E402, F401
     init_book_claudemd,
     sync_book_claudemd_from_text,
     update_book_claudemd_facts,
+    update_character_snapshot,
 )
 from routers.creation import (  # noqa: E402, F401
     create_book_structure,

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -23,7 +23,7 @@ The fiction and memoir prerequisite sets are non-overlapping. Branch every load 
 
 Before writing a single word:
 
-1. **Chapter writing brief** — MCP `get_chapter_writing_brief(book_slug, chapter_slug)`. **Why:** One structured payload that bundles 14 separate context sources — `book_category`, story_anchor, recent_chapter_timelines, recent_chapter_endings, characters_present (fiction: role + knowledge + tactical profiles; memoir: relationship + person_category + consent_status + anonymization), `pov_character_inventory` (deterministic extraction of the POV character's last established physical inventory; structured `items` with source pointers; `extraction_method ∈ {frontmatter, timeline_regex, draft_heuristic, none}`; non-empty `warnings` mean **surface the gap to the user, do not invent items** — Issue #157), `consent_status_warnings` (memoir only), rules_to_honor (book CLAUDE.md ## Rules with severity), callbacks_in_register, banned_phrases (book + author + global), recent_simile_count_per_chapter, tone_litmus_questions, tactical_constraints, review_handle, plus the chapter metadata. Honor every populated field while writing. Empty fields and entries in `errors` mean "not available for this chapter" — degrade gracefully (see the **Abstain from invention** rule under `## Rules > Universal`). Store the returned `review_handle` as `{review_handle}`.
+1. **Chapter writing brief** — MCP `get_chapter_writing_brief(book_slug, chapter_slug)`. **Why:** One structured payload that bundles 14 separate context sources — `book_category`, story_anchor, recent_chapter_timelines, recent_chapter_endings, characters_present (fiction: role + knowledge + tactical profiles; memoir: relationship + person_category + consent_status + anonymization), `pov_character_inventory` (deterministic extraction of the POV character's last established physical inventory; structured `items` with source pointers; `extraction_method ∈ {frontmatter, timeline_regex, draft_heuristic, none}`; non-empty `warnings` mean **surface the gap to the user, do not invent items**; kept fresh by Step 7.8 write-back — Issue #157), `consent_status_warnings` (memoir only), rules_to_honor (book CLAUDE.md ## Rules with severity), callbacks_in_register, banned_phrases (book + author + global), recent_simile_count_per_chapter, tone_litmus_questions, tactical_constraints, review_handle, plus the chapter metadata. Honor every populated field while writing. Empty fields and entries in `errors` mean "not available for this chapter" — degrade gracefully (see the **Abstain from invention** rule under `## Rules > Universal`). Store the returned `review_handle` as `{review_handle}`.
 2. **Author profile** — MCP `get_author()`. **Why:** Drives tone, vocabulary, rhythm, voice. Memoirist's voice is the same load. Without it prose defaults to generic AI register. **The profile's `writing_discoveries` field (Issue #151) carries cross-book findings — `recurring_tics` to actively suppress, `style_principles` to lean into, `donts` to avoid. Apply these BEFORE drafting any prose; they are author identity, not optional.**
 3. **Book data** — MCP `get_book_full()`. **Why:** Genres / category context, plot or scope, the frame the chapter must fit.
 
@@ -206,6 +206,31 @@ For clean scenes, silence is fine. When cuts happen, optionally note "Simile-Sca
 **Both modes — universal step:**
 
 7. **Update Chapter Timeline** in this chapter's `README.md` — every time-anchored event with `~HH:MM`. MANDATORY (future chapters depend on it). Memoir uses real clock times.
+
+8. **Update POV character snapshot** (Issues #157 / #160) — Skip when staying at `Draft`. For `Review` / `Final` closes only.
+
+   **How (Option C — extract, propose, confirm, write):**
+
+   a. Run the brief's extractors mentally against the just-completed draft: what is the POV character carrying, wearing, injured, or affected by at the chapter's *end*? Pull from the Chapter Timeline beats you wrote in step 7 above — those are the authoritative source.
+
+   b. Present a concise proposal to the user:
+   ```
+   POV snapshot for {pov_character} after {chapter_slug}:
+   - current_inventory: [compass, silver knife, no-signal phone]
+   - current_clothing:  [tactical boots, mission jacket]
+   - current_injuries:  [bandaged left hand from ~21:30 beat]
+   - altered_states:    [running on 3 hours sleep]
+   - environmental_limiters: []
+   ```
+   Ask: *"Passt das so? Korrekturen?"*
+
+   c. Wait for user confirmation or corrections.
+
+   d. Persist via MCP `update_character_snapshot(book_slug, pov_slug, snapshot_json, book_category)` where `snapshot_json` is a JSON object with the confirmed fields plus `as_of_chapter: "{chapter_slug}"`. Fiction: `pov_slug` from `characters/{slug}.md`. Memoir: from `people/{slug}.md` (`book_category="memoir"`).
+
+   **Why this matters:** `pov_character_inventory` and (once #160 ships) `pov_character_state` use `frontmatter` as their highest-priority source. Without this write-back, each new chapter's brief degrades to timeline-regex or draft-heuristic extraction — fragile sources that miss silent state changes. A 30-second confirmation at chapter close keeps the brief sharp for every subsequent chapter.
+
+   **What to include:** only fields that actually changed or were established in this chapter. Omit fields with no new information — partial updates are fine; `update_character_snapshot` merges, not replaces.
 
 ### Step 8: Self-Review (both modes)
 Before presenting to user (in full-chapter mode) or after all scenes assembled (in scene-by-scene mode), quick-check:

--- a/tests/server/test_update_character_snapshot.py
+++ b/tests/server/test_update_character_snapshot.py
@@ -1,0 +1,319 @@
+"""Tests for the ``update_character_snapshot`` MCP tool (Issues #157 / #160).
+
+The tool persists end-of-chapter POV character state back to the character
+file's frontmatter so the next brief picks it up from the highest-priority
+``frontmatter`` source rather than falling through to timeline heuristics.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+import routers._app as _app
+from routers.claudemd import update_character_snapshot
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def content_root(tmp_path: Path) -> Path:
+    root = tmp_path / "content"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def mock_config(content_root: Path, monkeypatch: pytest.MonkeyPatch) -> dict:
+    cfg = {
+        "paths": {
+            "content_root": str(content_root),
+            "authors_root": str(content_root / "authors"),
+        },
+        "defaults": {"language": "en", "book_type": "novel"},
+    }
+    monkeypatch.setattr(_app, "load_config", lambda: cfg)
+    _app._cache.invalidate()
+    return cfg
+
+
+def _make_char(content_root: Path, book: str, slug: str, extra: str = "") -> Path:
+    char_dir = content_root / "projects" / book / "characters"
+    char_dir.mkdir(parents=True, exist_ok=True)
+    char_file = char_dir / f"{slug}.md"
+    char_file.write_text(
+        f"---\nname: {slug}\nrole: protagonist\n---\n\nProfile body.\n{extra}",
+        encoding="utf-8",
+    )
+    return char_file
+
+
+def _make_person(content_root: Path, book: str, slug: str) -> Path:
+    person_dir = content_root / "projects" / book / "people"
+    person_dir.mkdir(parents=True, exist_ok=True)
+    person_file = person_dir / f"{slug}.md"
+    person_file.write_text(
+        f"---\nname: {slug}\nconsent_status: confirmed\n---\n\nPerson body.\n",
+        encoding="utf-8",
+    )
+    return person_file
+
+
+# ---------------------------------------------------------------------------
+# Happy path — fiction
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateCharacterSnapshotFiction:
+    def test_writes_inventory_list(self, mock_config, content_root: Path):
+        char_file = _make_char(content_root, "my-book", "theo")
+
+        result = json.loads(
+            update_character_snapshot(
+                "my-book",
+                "theo",
+                json.dumps({"current_inventory": ["compass", "silver knife", "no-signal phone"]}),
+            )
+        )
+
+        assert result["success"] is True
+        assert "current_inventory" in result["updated_fields"]
+        meta = yaml.safe_load(char_file.read_text(encoding="utf-8").split("---")[1])
+        assert meta["current_inventory"] == ["compass", "silver knife", "no-signal phone"]
+
+    def test_writes_all_snapshot_fields(self, mock_config, content_root: Path):
+        char_file = _make_char(content_root, "my-book", "theo")
+        snapshot = {
+            "current_inventory": ["compass", "knife"],
+            "current_clothing": ["tactical boots", "mission jacket"],
+            "current_injuries": ["bandaged left hand"],
+            "altered_states": ["running on 3 hours sleep"],
+            "environmental_limiters": [],
+            "as_of_chapter": "26-the-basement",
+        }
+
+        result = json.loads(update_character_snapshot("my-book", "theo", json.dumps(snapshot)))
+
+        assert result["success"] is True
+        meta = yaml.safe_load(char_file.read_text(encoding="utf-8").split("---")[1])
+        assert meta["current_inventory"] == ["compass", "knife"]
+        assert meta["current_clothing"] == ["tactical boots", "mission jacket"]
+        assert meta["current_injuries"] == ["bandaged left hand"]
+        assert meta["altered_states"] == ["running on 3 hours sleep"]
+        assert meta["environmental_limiters"] == []
+        assert meta["as_of_chapter"] == "26-the-basement"
+
+    def test_preserves_existing_non_snapshot_fields(self, mock_config, content_root: Path):
+        char_file = _make_char(content_root, "my-book", "theo")
+
+        update_character_snapshot(
+            "my-book", "theo", json.dumps({"current_inventory": ["compass"]})
+        )
+
+        meta = yaml.safe_load(char_file.read_text(encoding="utf-8").split("---")[1])
+        assert meta["name"] == "theo"
+        assert meta["role"] == "protagonist"
+
+    def test_overwrites_stale_inventory(self, mock_config, content_root: Path):
+        char_dir = content_root / "projects" / "my-book" / "characters"
+        char_dir.mkdir(parents=True, exist_ok=True)
+        char_file = char_dir / "theo.md"
+        char_file.write_text(
+            "---\ncurrent_inventory:\n- old item\n---\nBody.\n", encoding="utf-8"
+        )
+
+        update_character_snapshot(
+            "my-book", "theo", json.dumps({"current_inventory": ["new item"]})
+        )
+
+        meta = yaml.safe_load(char_file.read_text(encoding="utf-8").split("---")[1])
+        assert meta["current_inventory"] == ["new item"]
+
+    def test_partial_snapshot_only_updates_given_fields(self, mock_config, content_root: Path):
+        char_dir = content_root / "projects" / "my-book" / "characters"
+        char_dir.mkdir(parents=True, exist_ok=True)
+        char_file = char_dir / "theo.md"
+        char_file.write_text(
+            "---\ncurrent_inventory:\n- compass\ncurrent_clothing:\n- jacket\n---\nBody.\n",
+            encoding="utf-8",
+        )
+
+        update_character_snapshot(
+            "my-book", "theo", json.dumps({"current_injuries": ["bruised ribs"]})
+        )
+
+        meta = yaml.safe_load(char_file.read_text(encoding="utf-8").split("---")[1])
+        assert meta["current_inventory"] == ["compass"]
+        assert meta["current_clothing"] == ["jacket"]
+        assert meta["current_injuries"] == ["bruised ribs"]
+
+    def test_empty_list_is_valid(self, mock_config, content_root: Path):
+        _make_char(content_root, "my-book", "theo")
+
+        result = json.loads(
+            update_character_snapshot(
+                "my-book", "theo", json.dumps({"current_injuries": []})
+            )
+        )
+
+        assert result["success"] is True
+
+    def test_body_text_is_preserved(self, mock_config, content_root: Path):
+        char_file = _make_char(content_root, "my-book", "theo")
+
+        update_character_snapshot(
+            "my-book", "theo", json.dumps({"current_inventory": ["compass"]})
+        )
+
+        content = char_file.read_text(encoding="utf-8")
+        assert "Profile body." in content
+
+
+# ---------------------------------------------------------------------------
+# Happy path — memoir (people/ directory)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateCharacterSnapshotMemoir:
+    def test_writes_to_people_dir(self, mock_config, content_root: Path):
+        person_file = _make_person(content_root, "my-memoir", "jane")
+
+        result = json.loads(
+            update_character_snapshot(
+                "my-memoir",
+                "jane",
+                json.dumps({"current_inventory": ["notebook", "pen"]}),
+                book_category="memoir",
+            )
+        )
+
+        assert result["success"] is True
+        meta = yaml.safe_load(person_file.read_text(encoding="utf-8").split("---")[1])
+        assert meta["current_inventory"] == ["notebook", "pen"]
+        assert meta["consent_status"] == "confirmed"
+
+    def test_memoir_does_not_touch_characters_dir(self, mock_config, content_root: Path):
+        _make_person(content_root, "my-memoir", "jane")
+        chars_dir = content_root / "projects" / "my-memoir" / "characters"
+
+        update_character_snapshot(
+            "my-memoir",
+            "jane",
+            json.dumps({"current_inventory": ["notebook"]}),
+            book_category="memoir",
+        )
+
+        assert not chars_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# Validation errors
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateCharacterSnapshotValidation:
+    def test_rejects_invalid_json(self, mock_config, content_root: Path):
+        _make_char(content_root, "my-book", "theo")
+        result = json.loads(update_character_snapshot("my-book", "theo", "not json"))
+        assert "error" in result
+        assert "JSON" in result["error"]
+
+    def test_rejects_json_array(self, mock_config, content_root: Path):
+        _make_char(content_root, "my-book", "theo")
+        result = json.loads(update_character_snapshot("my-book", "theo", '["list"]'))
+        assert "error" in result
+
+    def test_rejects_empty_object(self, mock_config, content_root: Path):
+        _make_char(content_root, "my-book", "theo")
+        result = json.loads(update_character_snapshot("my-book", "theo", "{}"))
+        assert "error" in result
+
+    def test_rejects_unknown_fields(self, mock_config, content_root: Path):
+        _make_char(content_root, "my-book", "theo")
+        result = json.loads(
+            update_character_snapshot(
+                "my-book", "theo", json.dumps({"unknown_field": ["x"]})
+            )
+        )
+        assert "error" in result
+        assert "unknown_field" in result["error"]
+
+    def test_rejects_list_field_with_non_list_value(self, mock_config, content_root: Path):
+        _make_char(content_root, "my-book", "theo")
+        result = json.loads(
+            update_character_snapshot(
+                "my-book", "theo", json.dumps({"current_inventory": "compass"})
+            )
+        )
+        assert "error" in result
+        assert "list of strings" in result["error"]
+
+    def test_rejects_list_with_non_string_items(self, mock_config, content_root: Path):
+        _make_char(content_root, "my-book", "theo")
+        result = json.loads(
+            update_character_snapshot(
+                "my-book", "theo", json.dumps({"current_inventory": [1, 2, 3]})
+            )
+        )
+        assert "error" in result
+
+    def test_rejects_as_of_chapter_non_string(self, mock_config, content_root: Path):
+        _make_char(content_root, "my-book", "theo")
+        result = json.loads(
+            update_character_snapshot(
+                "my-book", "theo", json.dumps({"as_of_chapter": 27})
+            )
+        )
+        assert "error" in result
+
+    def test_rejects_missing_book(self, mock_config, content_root: Path):
+        result = json.loads(
+            update_character_snapshot(
+                "nonexistent-book", "theo", json.dumps({"current_inventory": ["x"]})
+            )
+        )
+        assert "error" in result
+        assert "nonexistent-book" in result["error"]
+
+    def test_rejects_missing_character_file(self, mock_config, content_root: Path):
+        book_dir = content_root / "projects" / "my-book"
+        book_dir.mkdir(parents=True)
+        result = json.loads(
+            update_character_snapshot(
+                "my-book", "nobody", json.dumps({"current_inventory": ["x"]})
+            )
+        )
+        assert "error" in result
+        assert "nobody" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Security — path containment
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateCharacterSnapshotSecurity:
+    def test_rejects_traversal_via_character_slug(
+        self, mock_config, content_root: Path, tmp_path: Path
+    ):
+        """A slug with '..' must not escape content_root."""
+        from tools.shared.paths import resolve_project_path
+
+        import pytest as _pytest
+        with _pytest.raises(ValueError):
+            resolve_project_path({"paths": {"content_root": str(content_root)}}, "../escape")
+
+    def test_result_contains_sorted_updated_fields(self, mock_config, content_root: Path):
+        _make_char(content_root, "my-book", "theo")
+        snapshot = {
+            "current_inventory": ["compass"],
+            "as_of_chapter": "26-the-basement",
+        }
+        result = json.loads(update_character_snapshot("my-book", "theo", json.dumps(snapshot)))
+        assert result["updated_fields"] == sorted(snapshot.keys())


### PR DESCRIPTION
## Summary

- New MCP tool `update_character_snapshot` — persists end-of-chapter POV character state back to `characters/{slug}.md` / `people/{slug}.md` frontmatter (fiction + memoir)
- Writes: `current_inventory`, `current_clothing`, `current_injuries`, `altered_states`, `environmental_limiters`, `as_of_chapter` — all as proper YAML lists, not strings
- `chapter-writer` SKILL.md gains **Step 7.8 "Update POV character snapshot"** (Option C: extract → propose → confirm → persist), runs on Review/Final closes only

## Why this exists before #160

Both `pov_character_inventory` (#157) and the upcoming `pov_character_state` (#160) extract data FROM character files. Without write-back, each chapter's brief degrades to timeline-regex or draft-heuristic extraction — fragile sources that miss silent state changes. This PR closes that loop so #160 ships with write-back already in place from day one.

## Test plan

- [x] 20 unit tests covering happy path (fiction + memoir), validation errors, partial updates, stale overwrite, body preservation, security containment — all green
- [x] Full test suite: 1405 passed
- [ ] Manual: write a chapter, confirm snapshot proposal at Step 7.8, verify `characters/{slug}.md` frontmatter updated correctly
- [ ] Manual: next chapter's brief shows `extraction_method: "frontmatter"` instead of `"timeline_regex"`

## Closes

Prerequisite for #157 (inventory) and #160 (pov_character_state) — not a direct close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)