### PR TITLE
fix(canon_brief): word-boundary token match for multi-token POV names

### DIFF
--- a/tests/state/test_canon_brief.py
+++ b/tests/state/test_canon_brief.py
@@ -433,6 +433,95 @@ class TestPovFilter:
         assert "Theo is the protagonist." in pov_facts
         assert "Rain is falling." not in pov_facts
 
+    def test_multi_token_pov_matches_first_name_in_subject_header(self, tmp_path):
+        # Issue #168: "Theo Wilkons" must match bullets under ### Theo: cognition
+        # The old filter did whole-string substring match ("theo wilkons" not in source)
+        root = _book(tmp_path)
+        _chapter(root, "01-setup", number=1)
+        log = (
+            "## Chapter 01 — Setup\n\n"
+            "### Theo: cognition\n"
+            "- **Theo's question canon:** *\"Sera has been missing for three days.\"*\n\n"
+            "### Kael: behavior\n"
+            "- Kael avoids eye contact.\n"
+        )
+        _canon_log(root, log)
+        brief = build_canon_brief(root, "02-conflict", pov_character="Theo Wilkons")
+
+        assert len(brief["pov_relevant_facts"]) > 0, (
+            "pov_relevant_facts must not be empty for multi-token POV name"
+        )
+        pov_sources = {f["source"] for f in brief["pov_relevant_facts"]}
+        assert all("theo" in s.lower() for s in pov_sources)
+
+    def test_multi_token_pov_no_false_positives_on_partial_match(self, tmp_path):
+        # Word-boundary: "theo" must NOT match "theology"
+        root = _book(tmp_path)
+        _chapter(root, "01-setup", number=1)
+        log = (
+            "## Chapter 01 — Setup\n\n"
+            "- Theology fascinates the scholar.\n"
+            "- Theo arrived late.\n"
+        )
+        _canon_log(root, log)
+        brief = build_canon_brief(root, "02-conflict", pov_character="Theo Wilkons")
+
+        pov_facts = {f["fact"] for f in brief["pov_relevant_facts"]}
+        assert "Theology fascinates the scholar." not in pov_facts
+        assert "Theo arrived late." in pov_facts
+
+    def test_single_token_pov_backward_compatible(self, tmp_path):
+        # Single-name characters ("Kael") must still work after the token fix
+        root = _book(tmp_path)
+        _chapter(root, "01-setup", number=1)
+        log = (
+            "## Chapter 01 — Setup\n\n"
+            "### Kael: behavior\n"
+            "- Kael avoids eye contact.\n\n"
+            "### Theo: cognition\n"
+            "- Theo ponders the question.\n"
+        )
+        _canon_log(root, log)
+        brief = build_canon_brief(root, "02-conflict", pov_character="Kael")
+
+        assert len(brief["pov_relevant_facts"]) > 0
+        pov_sources = {f["source"] for f in brief["pov_relevant_facts"]}
+        assert all("kael" in s.lower() for s in pov_sources)
+
+    def test_short_single_name_fallback(self, tmp_path):
+        # Names shorter than 3 chars ("Bo") fall back to substring match, not empty list
+        root = _book(tmp_path)
+        _chapter(root, "01-setup", number=1)
+        log = (
+            "## Chapter 01 — Setup\n\n"
+            "- Bo crossed the bridge.\n"
+            "- Rain kept falling.\n"
+        )
+        _canon_log(root, log)
+        brief = build_canon_brief(root, "02-conflict", pov_character="Bo")
+
+        pov_facts = {f["fact"] for f in brief["pov_relevant_facts"]}
+        assert "Bo crossed the bridge." in pov_facts
+        assert "Rain kept falling." not in pov_facts
+
+    def test_multi_token_pov_or_semantics_surname_match(self, tmp_path):
+        # OR-semantics: a fact mentioning the surname alone still qualifies.
+        # Documents the intentional behavior: canon logs referencing a character
+        # by last name only are included in pov_relevant_facts.
+        root = _book(tmp_path)
+        _chapter(root, "01-setup", number=1)
+        log = (
+            "## Chapter 01 — Setup\n\n"
+            "- Wilkons noticed the discrepancy.\n"
+            "- Rain kept falling.\n"
+        )
+        _canon_log(root, log)
+        brief = build_canon_brief(root, "02-conflict", pov_character="Theo Wilkons")
+
+        pov_facts = {f["fact"] for f in brief["pov_relevant_facts"]}
+        assert "Wilkons noticed the discrepancy." in pov_facts
+        assert "Rain kept falling." not in pov_facts
+
 
 # ---------------------------------------------------------------------------
 # Slug normalisation

--- a/tools/state/loaders/canon_brief.py
+++ b/tools/state/loaders/canon_brief.py
@@ -362,10 +362,27 @@ def _subject_before(body: str, pos: int) -> str:
 def _filter_pov(facts: list[dict[str, Any]], pov_name_lower: str) -> list[dict[str, Any]]:
     if not pov_name_lower:
         return []
+    # Match on each significant token (≥3 chars) with word-boundary semantics.
+    # Whole-string substring match fails for "Theo Wilkons" because source
+    # pointers and bullet text use first-name only ("### Theo: cognition").
+    # OR-semantics: a fact qualifies when ANY token matches — intentional, because
+    # canon logs reference characters by first name only, making AND too strict.
+    tokens = [t for t in pov_name_lower.split() if len(t) >= 3]
+    if not tokens:
+        # Short single-name characters ("Bo", "Li") — fall back to substring match
+        # so they aren't silently excluded.
+        return [
+            f for f in facts
+            if pov_name_lower in f.get("source", "").lower()
+            or pov_name_lower in f.get("fact", "").lower()
+        ]
+    patterns = [re.compile(rf"\b{re.escape(t)}\b", re.IGNORECASE) for t in tokens]
     return [
         f for f in facts
-        if pov_name_lower in f.get("source", "").lower()
-        or pov_name_lower in f.get("fact", "").lower()
+        if any(
+            p.search(f.get("source", "")) or p.search(f.get("fact", ""))
+            for p in patterns
+        )
     ]
 
 


### PR DESCRIPTION
## Summary

Fixes `canon_brief.pov_relevant_facts` being silently empty for POV characters with multi-token names (e.g. `"Theo Wilkons"`).

- **Root cause:** `_filter_pov` matched the full name as a substring (`"theo wilkons"` in source/fact text). Canon logs use first-name-only subject headers (`### Theo: cognition`) and first-name-only bullet text — the full surname never appears contiguously.
- **Fix:** Split the name into significant tokens (≥3 chars), match each with a `\b` word-boundary regex (`re.IGNORECASE`). OR-semantics are intentional — canon logs reference characters by first name, making AND too strict.
- **Edge cases:** Short single-name characters (`"Bo"`, `"Li"`) fall back to the original substring match when all tokens are below the length threshold.

## Test plan

- [ ] `pytest tests/state/test_canon_brief.py::TestPovFilter` — all 9 tests pass
- [ ] `pytest --tb=short -q` — 1490 tests pass, no regressions
- [ ] Manual: `get_chapter_writing_brief("blood-and-binary-firelight", "27-sera")` → `pov_relevant_facts` non-empty

## New tests

| Test | Covers |
|------|--------|
| `test_multi_token_pov_matches_first_name_in_subject_header` | Happy path: `"Theo Wilkons"` matches `### Theo:` bullets |
| `test_multi_token_pov_no_false_positives_on_partial_match` | Word-boundary: `"theo"` does not match `"theology"` |
| `test_single_token_pov_backward_compatible` | Single-name POVs (`"Kael"`) unchanged |
| `test_short_single_name_fallback` | `"Bo"` → substring fallback, not empty list |
| `test_multi_token_pov_or_semantics_surname_match` | OR-semantics: surname-only fact is included |

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)