### PR TITLE
fix(hook): modernize + activate validate_character hook (audit H-1, epic #179)

### DIFF
--- a/.claude-plugin/hooks.json
+++ b/.claude-plugin/hooks.json
@@ -17,6 +17,10 @@
           {
             "type": "command",
             "command": "${HOME}/.storyforge/venv/bin/python3 ${CLAUDE_PLUGIN_ROOT}/hooks/validate_chapter.py"
+          },
+          {
+            "type": "command",
+            "command": "${HOME}/.storyforge/venv/bin/python3 ${CLAUDE_PLUGIN_ROOT}/hooks/validate_character.py"
           }
         ]
       }

--- a/hooks/validate_character.py
+++ b/hooks/validate_character.py
@@ -1,84 +1,256 @@
 #!/usr/bin/env python3
-"""PostToolUse hook: Validate character files after Write/Edit operations.
+"""PostToolUse hook: validate character / people files after Write / Edit / MultiEdit.
 
-Checks that character files have required sections and valid frontmatter.
+Runs on writes to ``characters/*.md`` (fiction) and ``people/*.md`` (memoir).
+Skips ``INDEX.md``. Two-tier severity:
+
+- **block** — missing or invalid YAML frontmatter, missing required frontmatter
+  fields. Hook exits 2 and Claude Code rejects the write.
+- **warn**  — missing recommended sections, unknown role. Hook exits 0 and
+  prints diagnostics to stdout.
+
+The two-tier shape mirrors ``validate_chapter.py``: structural integrity is a
+hard gate, content completeness is a soft signal so authors stay free to
+diverge from the template when the story warrants it.
+
+Required sections come from the post-#41 character template
+(`templates/character.md`) but the matcher accepts BOTH ``## Section`` (level 2)
+and ``### Section`` (level 3) headers — the template puts ``The Ghost`` under
+``## Backstory`` as level 3, while older character files often use it as
+level 2. Both are valid.
 """
 
-import os
+from __future__ import annotations
+
+import json
 import re
 import sys
 from pathlib import Path
+from typing import Any
 
 import yaml
 
-REQUIRED_FRONTMATTER = ["name", "role", "status"]
-REQUIRED_SECTIONS = ["Want vs. Need", "Fatal Flaw", "The Ghost", "Motivation Chain"]
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+WATCHED_TOOLS = frozenset({"Write", "Edit", "MultiEdit"})
+
+# Path fragments that mark a character / people file. The hook ignores any
+# write whose path does not contain at least one of these.
+WATCHED_PATH_FRAGMENTS = ("/characters/", "/people/")
+
+# Frontmatter — block on missing.
+REQUIRED_FRONTMATTER = ("name", "role", "status")
+
+# Valid roles (fiction). Memoir person files use a different schema and are
+# skipped for the role check (see _is_memoir_person_file).
+VALID_ROLES = frozenset(
+    {"protagonist", "antagonist", "deuteragonist", "supporting", "minor"}
+)
+
+# Recommended sections — warn on missing (only for non-minor characters).
+# Each entry is a tuple of acceptable section titles (any one matches).
+# Aligns with the post-PR #41 character template plus tolerance for legacy
+# files that use level-2 placement of currently-level-3 sections.
+RECOMMENDED_SECTIONS: tuple[tuple[str, ...], ...] = (
+    ("Want vs. Need",),
+    ("Fatal Flaw",),
+    ("The Ghost", "Backstory / The Wound", "Backstory"),  # level 2 or 3
+    ("Motivation Chain", "GMC", "GMC (Goal / Motivation / Conflict)"),
+)
+
+# Memoir-specific frontmatter — when present, role validation is skipped
+# (memoir files use person_category / consent_status instead).
+MEMOIR_FIELD_MARKERS = ("person_category", "consent_status", "real_name")
 
 
-def validate_character(file_path: str) -> list[str]:
-    """Validate a character file and return list of issues."""
+# ---------------------------------------------------------------------------
+# Hook payload + path resolution (mirrors validate_chapter.py)
+# ---------------------------------------------------------------------------
+
+
+def _read_payload() -> dict[str, Any] | None:
+    if sys.stdin.isatty():
+        return None
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _extract_file_path(payload: dict[str, Any]) -> str | None:
+    """Find the file path in the hook payload — schema differs across tools."""
+    tool_input = payload.get("tool_input") or {}
+    if isinstance(tool_input, dict):
+        fp = tool_input.get("file_path")
+        if isinstance(fp, str) and fp:
+            return fp
+    tool_response = payload.get("tool_response") or {}
+    if isinstance(tool_response, dict):
+        for key in ("filePath", "file_path"):
+            fp = tool_response.get(key)
+            if isinstance(fp, str) and fp:
+                return fp
+    return None
+
+
+def _is_character_or_people_file(path: Path) -> bool:
+    """True for `characters/*.md` or `people/*.md` (excluding INDEX.md)."""
+    if path.suffix != ".md":
+        return False
+    if path.name == "INDEX.md":
+        return False
+    return any(frag in str(path) for frag in WATCHED_PATH_FRAGMENTS)
+
+
+def _is_memoir_person_file(meta: dict[str, Any]) -> bool:
+    """Memoir person files carry consent-related frontmatter; skip role validation."""
+    return any(field in meta for field in MEMOIR_FIELD_MARKERS)
+
+
+# ---------------------------------------------------------------------------
+# Section matching — accepts level 2 OR level 3
+# ---------------------------------------------------------------------------
+
+
+def _section_present(text: str, alternatives: tuple[str, ...]) -> bool:
+    """Check whether any of the section title alternatives appears as a
+    level-2 (``##``) or level-3 (``###``) header in the file body."""
+    for title in alternatives:
+        # Match `## Title` or `### Title` at the start of a line, allowing
+        # trailing whitespace / closing hashes / inline markup.
+        pattern = re.compile(
+            rf"^#{{2,3}}\s+{re.escape(title)}\b", re.MULTILINE | re.IGNORECASE
+        )
+        if pattern.search(text):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def validate_character(file_path: str) -> tuple[list[str], list[str]]:
+    """Return ``(blocking_issues, warning_issues)``."""
     path = Path(file_path)
-    issues: list[str] = []
+    blocking: list[str] = []
+    warnings: list[str] = []
 
     if not path.exists():
-        return []
-
-    # Only validate character files (in characters/ directories)
-    if "/characters/" not in str(path) or not path.suffix == ".md":
-        return []
-
-    # Skip INDEX.md
-    if path.name == "INDEX.md":
-        return []
+        return blocking, warnings
+    if not _is_character_or_people_file(path):
+        return blocking, warnings
 
     text = path.read_text(encoding="utf-8")
 
-    # Check frontmatter
+    # ---- frontmatter (BLOCK on structural issues) -------------------------
     fm_match = re.match(r"^---\s*\n(.*?)\n---\s*\n", text, re.DOTALL)
     if not fm_match:
-        issues.append(f"WARN: {path.name} — Missing YAML frontmatter")
-        return issues
+        blocking.append(f"{path.name} — Missing YAML frontmatter")
+        return blocking, warnings
 
     try:
         meta = yaml.safe_load(fm_match.group(1)) or {}
-    except yaml.YAMLError:
-        issues.append(f"FAIL: {path.name} — Invalid YAML frontmatter")
-        return issues
+    except yaml.YAMLError as exc:
+        blocking.append(f"{path.name} — Invalid YAML frontmatter: {exc}")
+        return blocking, warnings
 
-    # Required frontmatter fields
+    if not isinstance(meta, dict):
+        blocking.append(f"{path.name} — Frontmatter is not a YAML mapping")
+        return blocking, warnings
+
     for field in REQUIRED_FRONTMATTER:
         if field not in meta:
-            issues.append(f"WARN: {path.name} — Missing frontmatter field: {field}")
+            blocking.append(f"{path.name} — Missing frontmatter field: '{field}'")
 
-    # Check role is valid
-    valid_roles = {"protagonist", "antagonist", "supporting", "minor"}
-    role = meta.get("role", "").lower()
-    if role and role not in valid_roles:
-        issues.append(f"WARN: {path.name} — Unknown role '{role}'. Valid: {', '.join(sorted(valid_roles))}")
+    # ---- role check (WARN, fiction only) ----------------------------------
+    if not _is_memoir_person_file(meta):
+        role = str(meta.get("role", "")).lower()
+        if role and role not in VALID_ROLES:
+            warnings.append(
+                f"{path.name} — Unknown role '{role}'. "
+                f"Valid: {', '.join(sorted(VALID_ROLES))}"
+            )
 
-    # For non-minor characters, check required sections
-    if role != "minor":
-        for section in REQUIRED_SECTIONS:
-            if f"## {section}" not in text:
-                issues.append(f"WARN: {path.name} — Missing section: ## {section}")
+    # ---- recommended sections (WARN, non-minor fiction characters only) ---
+    role = str(meta.get("role", "")).lower()
+    if role != "minor" and not _is_memoir_person_file(meta):
+        for alternatives in RECOMMENDED_SECTIONS:
+            if not _section_present(text, alternatives):
+                primary = alternatives[0]
+                if len(alternatives) > 1:
+                    msg = (
+                        f"{path.name} — Missing recommended section "
+                        f"'## {primary}' (or one of: "
+                        f"{', '.join(alternatives[1:])})"
+                    )
+                else:
+                    msg = f"{path.name} — Missing recommended section '## {primary}'"
+                warnings.append(msg)
 
-    return issues
+    return blocking, warnings
 
 
-def main() -> None:
-    """Entry point for PostToolUse hook."""
-    file_path = os.environ.get("CLAUDE_TOOL_ARG_FILE_PATH", "")
+# ---------------------------------------------------------------------------
+# Hook entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    """Hook entry point. Returns 0 (continue / warn) or 2 (block).
+
+    The hook differentiates structural problems (frontmatter) from content
+    completeness (sections). Structural problems exit 2 so Claude Code
+    rejects the write; content warnings exit 0 with diagnostics on stdout.
+    """
+    payload = _read_payload()
+
+    file_path: str = ""
+    if payload is not None:
+        tool_name = payload.get("tool_name")
+        if isinstance(tool_name, str) and tool_name not in WATCHED_TOOLS:
+            return 0
+        file_path = _extract_file_path(payload) or ""
+    else:
+        # Legacy fallback: positional argv (tests, manual invocation).
+        if len(sys.argv) > 1:
+            file_path = sys.argv[1]
+
     if not file_path:
-        file_path = os.environ.get("CLAUDE_FILE_PATH", "")
-    if not file_path:
-        sys.exit(0)
+        return 0
 
-    issues = validate_character(file_path)
+    blocking, warnings = validate_character(file_path)
 
-    if issues:
-        print("\n".join(issues))
-    sys.exit(0)
+    if blocking:
+        print(
+            "StoryForge linter blocked this character-file write:",
+            file=sys.stderr,
+        )
+        for msg in blocking:
+            print(f"  [BLOCK] {msg}", file=sys.stderr)
+        if warnings:
+            print(
+                f"Plus {len(warnings)} non-blocking warning(s):", file=sys.stderr
+            )
+            for msg in warnings:
+                print(f"  [WARN] {msg}", file=sys.stderr)
+        print(
+            "Fix the blocking frontmatter issues and try again.",
+            file=sys.stderr,
+        )
+        return 2
+
+    for msg in warnings:
+        print(f"[WARN] {msg}")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -1116,11 +1116,18 @@ class TestHookSubprocess:
 
 
 class TestValidateCharacter:
+    """Tests for the modernized character validator (post-#179 hygiene track).
+
+    The validator returns ``(blocking, warnings)``. Blocking covers structural
+    integrity (frontmatter); warnings cover content completeness (sections).
+    Both lists are empty for ignored files (non-character paths, INDEX.md).
+    """
+
     def test_ignores_non_character_files(self):
-        assert validate_character("/some/other/file.md") == []
+        assert validate_character("/some/other/file.md") == ([], [])
 
     def test_ignores_index(self):
-        assert validate_character("/project/characters/INDEX.md") == []
+        assert validate_character("/project/characters/INDEX.md") == ([], [])
 
     def test_valid_character(self, tmp_path):
         chars_dir = tmp_path / "project" / "characters"
@@ -1132,35 +1139,128 @@ class TestValidateCharacter:
             "## The Ghost\n\nContent.\n\n## Motivation Chain\n\nContent.\n",
             encoding="utf-8",
         )
-        assert validate_character(str(char_file)) == []
+        blocking, warnings = validate_character(str(char_file))
+        assert blocking == []
+        assert warnings == []
 
-    def test_missing_frontmatter(self, tmp_path):
+    def test_missing_frontmatter_blocks(self, tmp_path):
         chars_dir = tmp_path / "project" / "characters"
         chars_dir.mkdir(parents=True)
         char_file = chars_dir / "alex.md"
         char_file.write_text("# Alex\n\nNo frontmatter here.\n", encoding="utf-8")
-        issues = validate_character(str(char_file))
-        assert any("Missing YAML frontmatter" in i for i in issues)
+        blocking, _warnings = validate_character(str(char_file))
+        assert any("Missing YAML frontmatter" in i for i in blocking)
 
-    def test_missing_required_sections(self, tmp_path):
+    def test_missing_frontmatter_field_blocks(self, tmp_path):
+        chars_dir = tmp_path / "project" / "characters"
+        chars_dir.mkdir(parents=True)
+        char_file = chars_dir / "alex.md"
+        # Missing `status` — required field.
+        char_file.write_text(
+            '---\nname: "Alex"\nrole: "protagonist"\n---\n\n# Alex\n',
+            encoding="utf-8",
+        )
+        blocking, _warnings = validate_character(str(char_file))
+        assert any("'status'" in i for i in blocking)
+
+    def test_missing_recommended_sections_warns(self, tmp_path):
         chars_dir = tmp_path / "project" / "characters"
         chars_dir.mkdir(parents=True)
         char_file = chars_dir / "alex.md"
         char_file.write_text(
-            '---\nname: "Alex"\nrole: "protagonist"\nstatus: "Concept"\n---\n\n# Alex\n\nNo required sections.\n',
+            '---\nname: "Alex"\nrole: "protagonist"\nstatus: "Concept"\n---\n\n'
+            "# Alex\n\nNo recommended sections.\n",
             encoding="utf-8",
         )
-        issues = validate_character(str(char_file))
-        assert any("Want vs. Need" in i for i in issues)
-        assert any("Fatal Flaw" in i for i in issues)
+        blocking, warnings = validate_character(str(char_file))
+        assert blocking == []
+        assert any("Want vs. Need" in w for w in warnings)
+        assert any("Fatal Flaw" in w for w in warnings)
 
-    def test_minor_characters_skip_sections(self, tmp_path):
+    def test_section_match_accepts_level_3_header(self, tmp_path):
+        """The post-#41 template puts ``The Ghost`` as a level-3 sub-section
+        of ``## Backstory``. The validator must accept that placement."""
+        chars_dir = tmp_path / "project" / "characters"
+        chars_dir.mkdir(parents=True)
+        char_file = chars_dir / "alex.md"
+        char_file.write_text(
+            '---\nname: "Alex"\nrole: "protagonist"\nstatus: "Concept"\n---\n\n'
+            "# Alex\n\n## Want vs. Need\n\nContent.\n\n## Fatal Flaw\n\nContent.\n\n"
+            "## Backstory\n\n### The Ghost\n\nContent.\n\n## GMC\n\nContent.\n",
+            encoding="utf-8",
+        )
+        blocking, warnings = validate_character(str(char_file))
+        assert blocking == []
+        assert warnings == []
+
+    def test_section_alternatives_accepts_legacy_titles(self, tmp_path):
+        """Legacy character files use ``## Backstory / The Wound`` and ``## GMC
+        (Goal / Motivation / Conflict)`` instead of the strictly-titled
+        template sections. Both should satisfy the recommendation."""
+        chars_dir = tmp_path / "project" / "characters"
+        chars_dir.mkdir(parents=True)
+        char_file = chars_dir / "theo.md"
+        char_file.write_text(
+            '---\nname: "Theo"\nrole: "protagonist"\nstatus: "Concept"\n---\n\n'
+            "# Theo\n\n## Want vs. Need\n\nContent.\n\n## Fatal Flaw\n\nContent.\n\n"
+            "## Backstory / The Wound\n\nContent.\n\n"
+            "## GMC (Goal / Motivation / Conflict)\n\nContent.\n",
+            encoding="utf-8",
+        )
+        blocking, warnings = validate_character(str(char_file))
+        assert blocking == []
+        assert warnings == []
+
+    def test_minor_characters_skip_section_warnings(self, tmp_path):
         chars_dir = tmp_path / "project" / "characters"
         chars_dir.mkdir(parents=True)
         char_file = chars_dir / "barista.md"
         char_file.write_text(
-            '---\nname: "Barista"\nrole: "minor"\nstatus: "Concept"\n---\n\n# Barista\n\nJust a minor character.\n',
+            '---\nname: "Barista"\nrole: "minor"\nstatus: "Concept"\n---\n\n'
+            "# Barista\n\nJust a minor character.\n",
             encoding="utf-8",
         )
-        issues = validate_character(str(char_file))
-        assert not any("Want vs. Need" in i for i in issues)
+        blocking, warnings = validate_character(str(char_file))
+        assert blocking == []
+        assert not any("Want vs. Need" in w for w in warnings)
+
+    def test_unknown_role_warns(self, tmp_path):
+        chars_dir = tmp_path / "project" / "characters"
+        chars_dir.mkdir(parents=True)
+        char_file = chars_dir / "alex.md"
+        char_file.write_text(
+            '---\nname: "Alex"\nrole: "wizard"\nstatus: "Concept"\n---\n\n'
+            "# Alex\n\n## Want vs. Need\n\n## Fatal Flaw\n\n## The Ghost\n\n## Motivation Chain\n",
+            encoding="utf-8",
+        )
+        blocking, warnings = validate_character(str(char_file))
+        assert blocking == []
+        assert any("'wizard'" in w for w in warnings)
+
+    def test_memoir_person_file_validates(self, tmp_path):
+        """Memoir person files live under ``people/`` and use a different
+        schema (``person_category`` / ``consent_status`` etc.). Frontmatter
+        validates; section recommendations are skipped."""
+        people_dir = tmp_path / "memoir-project" / "people"
+        people_dir.mkdir(parents=True)
+        person_file = people_dir / "mom.md"
+        person_file.write_text(
+            "---\n"
+            'name: "Mom"\nrole: "supporting"\nstatus: "Concept"\n'
+            'person_category: "family"\nconsent_status: "given"\n'
+            "---\n\n# Mom\n\n## Memory anchors\n",
+            encoding="utf-8",
+        )
+        blocking, warnings = validate_character(str(person_file))
+        assert blocking == []
+        # No section warnings — memoir schema is different.
+        assert not any("Want vs. Need" in w for w in warnings)
+
+    def test_memoir_person_file_blocks_on_missing_frontmatter(self, tmp_path):
+        """Memoir branch still enforces structural integrity."""
+        people_dir = tmp_path / "memoir-project" / "people"
+        people_dir.mkdir(parents=True)
+        person_file = people_dir / "mom.md"
+        person_file.write_text("# Mom\n\nNo frontmatter.\n", encoding="utf-8")
+        blocking, _warnings = validate_character(str(person_file))
+        assert any("Missing YAML frontmatter" in i for i in blocking)


### PR DESCRIPTION
## Summary

Closes audit finding H-1 from `docs/storyforge-audit-report.md` (epic #179). The `validate_character.py` hook existed since 2026-04-03 as fully-implemented code but was never registered in `hooks.json` — silent dead code. This PR modernizes the implementation to match current schemas and registers it in the PostToolUse pipeline.

## What this PR does

- Modernizes the hook to mirror `validate_chapter.py` (PostToolUse JSON payload, WATCHED_TOOLS, path-fragment filter for both `/characters/` and `/people/`).
- **Two-tier severity:** missing or invalid YAML frontmatter blocks (exit 2); missing recommended sections warn only (exit 0).
- **Level-2 OR level-3 section matching** — handles both the post-#41 template (where `### The Ghost` lives under `## Backstory`) and legacy files (`## The Ghost` directly).
- **Legacy-section aliases** — accepts `## Backstory / The Wound`, `## GMC`, `## GMC (Goal / Motivation / Conflict)` as recommendation-satisfying.
- **Memoir support** — `people/*.md` files with `person_category` / `consent_status` / `real_name` frontmatter skip the fiction-specific role check and section recommendations.
- Registered in `.claude-plugin/hooks.json` PostToolUse pipeline alongside `validate_chapter.py`.

## Tests

12 tests in `tests/hooks/test_hooks.py::TestValidateCharacter` (was 5 — replaced with full coverage). Full suite: **1503 passing**, `ruff check` clean.

## Expected impact on existing books

Live smoke against `blood-and-binary-firelight/characters/theo-wilkons.md` immediately surfaced a real finding: the file is missing the `status` frontmatter field. The hook blocks the next Edit on that file until `status` is added.

**This is designed behavior** — the hook's purpose is to surface this class of structural drift. Authors with existing books should expect to add `status: <Concept|Profile|Backstory|Arc Defined|Final>` to any character file that lacks it on the next write.

## Test plan

- [ ] On `blood-and-binary-firelight`: edit a character file missing `status`, confirm hook emits the BLOCK message.
- [ ] Edit a complete character file, confirm hook stays silent.
- [ ] Edit a memoir person file with missing frontmatter, confirm block message.
- [ ] Edit a non-character file (e.g. `chapters/draft.md`), confirm hook does not interfere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)