### PR TITLE
chore: Sprint 1 quick-wins from audit (M-1, M-2, L-1; epic #179)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ Phase 1 (#54–#56, #67) adds the field plus knowledge scaffold. Skill branching
 | "promote rule" / "rule global machen" / "Regel hochstufen" / "promote to author" / "promote to global" | `/storyforge:promote-rule` |
 | "harvest author rules" / "book to author" / "author rules" / "promote findings" / "Findings ins Autorenprofil" / "Buch-Erkenntnisse promoten" | `/storyforge:harvest-author-rules` |
 | "rules audit" / "regeln prüfen" / "rules check" / "rules cleanup" / "audit my rules" | `/storyforge:rules-audit` |
+| "backfill promises" / "promises nachfüllen" / `/storyforge:backfill-promises` | `/storyforge:backfill-promises` |
 | "Recherche" / "Research" | `/storyforge:researcher` |
 | "Sensitivity" / "Problematisch?" | `/storyforge:sensitivity-reader` |
 | "Ethics check" / "Consent check" / "Einwilligungen prüfen" / "Personen prüfen" | `/storyforge:memoir-ethics-checker` (memoir only) |

--- a/reference/craft/action-verbs.md
+++ b/reference/craft/action-verbs.md
@@ -1,3 +1,10 @@
+---
+book_categories: [fiction, memoir]
+craft_topic: prose-style
+status: stable
+last_reviewed: 2026-05-05
+---
+
 # Action Verb List
 
 Used by the snapshot detector in `manuscript_checker.py` to classify sentences

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -9,6 +9,7 @@ description: |
   Do NOT trigger on bare "Idee" / "brainstorm" without book context — defer to a more specific plugin.
 model: claude-opus-4-7
 user-invocable: true
+argument-hint: "[idea-slug]"
 ---
 
 # Brainstorm

--- a/skills/unblock/SKILL.md
+++ b/skills/unblock/SKILL.md
@@ -6,6 +6,7 @@ description: |
   "keine Motivation", "keine Lust", "Schreibblockade", or similar signals of creative resistance.
 model: claude-opus-4-7
 user-invocable: true
+argument-hint: "[book-slug]"
 ---
 
 # Unblock


### PR DESCRIPTION
## Summary

Three small fixes from the 2026-05-05 plugin audit. Part of Sprint 1 of epic #179.

## Changes

### M-1 — routing drift (CLAUDE.md)

`backfill-promises` is a user-invocable skill but was missing from CLAUDE.md's "Skill Routing" table. Added a row alongside the other utility skills.

### M-2 — action-verbs.md frontmatter

The only narrative \`reference/craft/*.md\` doc missing the PR #56 \`book_categories: [...]\` standard. Added frontmatter, tagged \`[fiction, memoir]\` since action verbs are category-agnostic.

### L-1 — argument-hints (cosmetic)

- \`brainstorm\` → \`[idea-slug]\` (lets users resume a parked idea by slug)
- \`unblock\` → \`[book-slug]\` (lets users focus the diagnostic on a specific book)

Both are optional — the skills remain interactive when invoked without arguments.

## Validation

- Full test suite: **1497 passing** (no regression, no python touched).
- \`ruff check .\` clean.
- After merge, the corresponding audit-report findings (M-1, M-2, L-1) are resolvable on re-audit.

## Test plan

- [x] Verify CLAUDE.md routing table renders correctly in a Markdown viewer.
- [ ] Verify \`/storyforge:brainstorm\` and \`/storyforge:unblock\` accept the optional argument and still run interactively without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)