### PR TITLE
fix(people): resolve character aliases in scan_for_named_characters

### DIFF
--- a/templates/character.md
+++ b/templates/character.md
@@ -1,5 +1,6 @@
 ---
 name: "{{name}}"
+# aliases: ["Nickname", "Initials"]  # optional: explicit aliases for outline matching
 role: "{{role}}"
 status: "Concept"
 age: ""

--- a/tests/state/test_people_loaders.py
+++ b/tests/state/test_people_loaders.py
@@ -10,8 +10,6 @@ Covers:
 
 from pathlib import Path
 
-import pytest
-
 from tools.state.loaders.people import scan_for_named_characters
 
 

--- a/tests/state/test_people_loaders.py
+++ b/tests/state/test_people_loaders.py
@@ -1,0 +1,61 @@
+"""Tests for scan_for_named_characters alias resolution (Issue #182).
+
+Covers:
+- Auto-extract quoted aliases from name field ("Sera" from 'Seraphina "Sera"')
+- Explicit aliases: frontmatter field
+- Word-boundary matching avoids false positives
+- Combined quoted + explicit aliases
+- Regression: plain unquoted name still resolves (legacy path)
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tools.state.loaders.people import scan_for_named_characters
+
+
+def _make_char(chars_dir: Path, slug: str, frontmatter: str) -> Path:
+    path = chars_dir / f"{slug}.md"
+    path.write_text(f"---\n{frontmatter}\n---\n", encoding="utf-8")
+    return path
+
+
+class TestScanForNamedCharactersAliases:
+    def test_quoted_alias_in_name_is_recognized(self, tmp_path: Path) -> None:
+        chars_dir = tmp_path / "characters"
+        chars_dir.mkdir()
+        _make_char(chars_dir, "seraphina", 'name: Seraphina "Sera"\nrole: supporting')
+        outline = "Sera arrives at the gate before dawn."
+        assert scan_for_named_characters(outline, chars_dir) == ["seraphina"]
+
+    def test_explicit_aliases_field_is_recognized(self, tmp_path: Path) -> None:
+        chars_dir = tmp_path / "characters"
+        chars_dir.mkdir()
+        _make_char(chars_dir, "seraphina", "name: Seraphina\naliases:\n  - Sera\n  - S.")
+        outline = "S. steps forward and takes the lead."
+        assert scan_for_named_characters(outline, chars_dir) == ["seraphina"]
+
+    def test_word_boundary_avoids_false_positive(self, tmp_path: Path) -> None:
+        chars_dir = tmp_path / "characters"
+        chars_dir.mkdir()
+        _make_char(chars_dir, "lin", "name: Lin\nrole: supporting")
+        outline = "The linguistics professor entered the room."
+        assert scan_for_named_characters(outline, chars_dir) == []
+
+    def test_quoted_and_explicit_aliases_combined(self, tmp_path: Path) -> None:
+        chars_dir = tmp_path / "characters"
+        chars_dir.mkdir()
+        _make_char(chars_dir, "vincent", 'name: Vincent "Vince"\naliases:\n  - V.')
+        outline_vince = "Vince poured two glasses."
+        outline_v = "V. nodded without a word."
+        assert scan_for_named_characters(outline_vince, chars_dir) == ["vincent"]
+        assert scan_for_named_characters(outline_v, chars_dir) == ["vincent"]
+
+    def test_legacy_plain_name_still_resolves(self, tmp_path: Path) -> None:
+        # Regression: unquoted name without aliases must still work.
+        chars_dir = tmp_path / "characters"
+        chars_dir.mkdir()
+        _make_char(chars_dir, "mom", "name: Mom\nrole: supporting")
+        outline = "Mom and Dad sat on the porch."
+        assert scan_for_named_characters(outline, chars_dir) == ["mom"]

--- a/tools/state/loaders/people.py
+++ b/tools/state/loaders/people.py
@@ -13,6 +13,7 @@ Also surfaces the consent-status warning list for memoir scenes.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -63,12 +64,29 @@ def person_payload(path: Path) -> dict[str, Any]:
     }
 
 
-def scan_for_named_characters(text: str, characters_dir: Path) -> list[str]:
-    """Find character/person slugs whose ``name:`` appears in ``text``.
+def _extract_aliases(meta: dict[str, Any]) -> list[str]:
+    """Return all name aliases for a character.
 
-    Lightweight heuristic — reads each character file's frontmatter
-    ``name`` and checks for substring presence in the outline text.
-    Avoids pulling in characters that aren't in this chapter.
+    Combines two sources:
+    - Quoted substrings from the name field: 'Seraphina "Sera"' → ["Sera"]
+    - Explicit aliases list from frontmatter: aliases: ["Sera", "S."]
+    """
+    aliases: list[str] = []
+    name = str(meta.get("name", ""))
+    aliases.extend(re.findall(r'"([^"]+)"', name))
+    aliases.extend(re.findall(r"'([^']+)'", name))
+    explicit = meta.get("aliases", [])
+    if isinstance(explicit, list):
+        aliases.extend(str(a) for a in explicit if a)
+    return list(dict.fromkeys(a for a in aliases if a.strip()))
+
+
+def scan_for_named_characters(text: str, characters_dir: Path) -> list[str]:
+    """Find character/person slugs whose name or alias appears in ``text``.
+
+    Checks the full name plus any aliases (quoted substrings from the name
+    field and explicit ``aliases:`` frontmatter) against word boundaries to
+    avoid false positives like "Lin" matching inside "Linguistics".
     """
     if not characters_dir.is_dir():
         return []
@@ -82,8 +100,13 @@ def scan_for_named_characters(text: str, characters_dir: Path) -> list[str]:
             continue
         meta, _body = parse_frontmatter(char_text)
         name = str(meta.get("name", path.stem))
-        if name and name in text:
-            found.append(path.stem)
+        candidates = [name] + _extract_aliases(meta)
+        for cand in candidates:
+            if not cand:
+                continue
+            if re.search(rf"(?<!\w){re.escape(cand)}(?!\w)", text):
+                found.append(path.stem)
+                break
     return found
 
 


### PR DESCRIPTION
## Summary

- `scan_for_named_characters` matched only against the full `name` field — nicknames like `Sera` silently dropped from `characters_present` when the character file carried `name: Seraphina "Sera"`
- Added `_extract_aliases()`: auto-extracts quoted substrings from `name` + reads optional `aliases:` frontmatter list
- Switched from bare `name in text` to `(?<!\w)...(?!\w)` lookaround — handles dotted initials (`S.`) where `\b` fails, and blocks false positives (`Lin` ≠ `Linguistics`)
- `templates/character.md`: added commented-out `aliases:` example

## Changes

| File | What |
|------|------|
| `tools/state/loaders/people.py` | `_extract_aliases()` helper + updated `scan_for_named_characters` |
| `tests/state/test_people_loaders.py` | 5 new tests (new file) |
| `templates/character.md` | Optional `aliases:` field commented-out example |

## Test plan

- [ ] `pytest tests/state/test_people_loaders.py -v` → 5/5 green
- [ ] `pytest tests/` → 1508/1508 green (no regression)
- [ ] Manually: open a Blood & Binary chapter brief for Ch 27 — verify Seraphina/Sera and Theodore/Theo appear in `characters_present`

Closes #182