### PR TITLE
refactor(mcp): sweep 7 likely-dead tools — deprecate 4, document 3 as utilities (audit M-5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,6 +302,25 @@ Skills MUST load relevant craft references before generating creative content. U
 19. **ALWAYS `Read` the full file when processing review comments** (GH#27). When the user signals that review comments (`{review_handle}:` blocks) are ready, call the `Read` tool on the full file first. The file-change `system-reminder` diff is truncated for long files — end-of-file comments get silently dropped. After reading, count the comments you see and report the count; re-read if the count mismatches expectation.
 20. **ALWAYS check `book_category` before creative work on a book** (Path E #54/#67). Read it from `get_book_full(slug).book_category`. All skills now branch automatically on `book_category` (Phase 4 #64 complete — no more manual load bridge needed). For named living people in memoir scenes, surface `consent_status` decisions explicitly — use `/storyforge:memoir-ethics-checker` (#65). For felt-sense gaps in chapter drafts, use `/storyforge:emotional-truth-prompt` (#66).
 
+## User-Callable MCP Tools
+
+The following MCP tools are registered but have no skill wiring. They are available as direct utility or diagnostic commands (audit M-5, Issue #175). Do not rely on them in skill workflows — use the recommended alternatives.
+
+| Tool | Purpose | Note |
+|------|---------|------|
+| `list_craft_references` | List all available craft and genre reference documents | Useful when exploring what references exist; skills name their loads explicitly |
+| `validate_timeline_consistency` | Cross-validate chapter anchors against `plot/timeline.md`; flags temporal drift | Diagnostic — run after several chapters to spot drift; not part of the writing pipeline |
+| `get_review_handle_config` | Return the configured inline-review comment handle | Informational; the handle is already bundled in `get_chapter_writing_brief` (`review_handle` field) |
+
+**Deprecated tools** (still callable, emit `DeprecationWarning`, removal in v2.0):
+
+| Tool | Replacement |
+|------|------------|
+| `get_chapter` | `get_book_full()` — projects `chapters_data` in one call |
+| `get_character` | `get_book_full()` — projects `characters` in one call |
+| `get_series` | `series-planner` reads series files directly |
+| `update_book_claudemd_facts` | PreCompact hook writes Book Facts automatically (Issue #172) |
+
 ## Code Style
 
 - Python: English comments, type hints, PEP 8

--- a/servers/storyforge-server/routers/chapters.py
+++ b/servers/storyforge-server/routers/chapters.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import warnings
 from pathlib import Path
 
 from tools.analysis.tactical_checker import (
@@ -45,17 +46,28 @@ from ._app import _cache, mcp
 
 @mcp.tool()
 def get_chapter(book_slug: str, chapter_slug: str) -> str:
-    """Get chapter metadata and word count."""
+    """Get chapter metadata and word count.
+
+    .. deprecated::
+        Use ``get_book_full()`` instead — it returns chapter data via the
+        ``chapters_data`` field and avoids a second round-trip. Removal in v2.0.
+    """
+    warnings.warn(
+        "get_chapter is deprecated — use get_book_full() which projects chapter data. Removal in v2.0.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    _deprecated_msg = "use get_book_full() instead — it projects chapters_data in one call"
     state = _cache.get()
     book = state.get("books", {}).get(book_slug)
     if not book:
-        return json.dumps({"error": f"Book '{book_slug}' not found"})
+        return json.dumps({"error": f"Book '{book_slug}' not found", "_deprecated": _deprecated_msg})
 
     chapter = book.get("chapters_data", {}).get(chapter_slug)
     if not chapter:
-        return json.dumps({"error": f"Chapter '{chapter_slug}' not found in '{book_slug}'"})
+        return json.dumps({"error": f"Chapter '{chapter_slug}' not found in '{book_slug}'", "_deprecated": _deprecated_msg})
 
-    return json.dumps(chapter)
+    return json.dumps({**chapter, "_deprecated": _deprecated_msg})
 
 
 @mcp.tool()

--- a/servers/storyforge-server/routers/claudemd.py
+++ b/servers/storyforge-server/routers/claudemd.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import os
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -107,26 +108,36 @@ def get_book_claudemd(book_slug: str) -> str:
 def get_character(book_slug: str, character_slug: str) -> str:
     """Read the full character file for a book.
 
+    .. deprecated::
+        Use ``get_book_full()`` instead — it projects characters via the
+        ``characters`` field. Removal in v2.0.
+
     Args:
         book_slug: Book slug (exact match)
         character_slug: Character slug without extension
     """
+    warnings.warn(
+        "get_character is deprecated — use get_book_full() which projects character data. Removal in v2.0.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    _deprecated_msg = "use get_book_full() instead — it projects characters in one call"
     config = _app.load_config()
     project_path = resolve_project_path(config, book_slug)
     if not project_path.exists():
-        return json.dumps({"error": f"Book '{book_slug}' not found"})
+        return json.dumps({"error": f"Book '{book_slug}' not found", "_deprecated": _deprecated_msg})
 
     # Primary layout: characters/{slug}.md
     primary = resolve_character_path(config, book_slug, character_slug)
     if primary.exists():
-        return json.dumps({"content": primary.read_text(encoding="utf-8")})
+        return json.dumps({"content": primary.read_text(encoding="utf-8"), "_deprecated": _deprecated_msg})
 
     # Legacy layout: characters/{slug}/README.md
     legacy = project_path / "characters" / character_slug / "README.md"
     if legacy.exists():
-        return json.dumps({"content": legacy.read_text(encoding="utf-8")})
+        return json.dumps({"content": legacy.read_text(encoding="utf-8"), "_deprecated": _deprecated_msg})
 
-    return json.dumps({"error": f"Character '{character_slug}' not found in book '{book_slug}'"})
+    return json.dumps({"error": f"Character '{character_slug}' not found in book '{book_slug}'", "_deprecated": _deprecated_msg})
 
 
 # Snapshot fields written back to the character file at chapter close.
@@ -435,7 +446,18 @@ def update_book_claudemd_facts(
 
     Empty strings are ignored (field left unchanged). Only stable facts
     live in CLAUDE.md; per-chapter progress belongs in the session cache.
+
+    .. deprecated::
+        The PreCompact hook (Issue #172 / PR #173) now writes Book Facts to
+        CLAUDE.md automatically at session-end. Manual calls are redundant.
+        Removal in v2.0.
     """
+    warnings.warn(
+        "update_book_claudemd_facts is deprecated — the PreCompact hook writes Book Facts automatically. Removal in v2.0.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    _deprecated_msg = "PreCompact hook now covers this path automatically (Issue #172)"
     config = _app.load_config()
     provided = {
         "pov": pov,
@@ -445,12 +467,12 @@ def update_book_claudemd_facts(
     }
     facts = {k: v for k, v in provided.items() if v}
     if not facts:
-        return json.dumps({"error": "No fields provided"})
+        return json.dumps({"error": "No fields provided", "_deprecated": _deprecated_msg})
     try:
         path = _update_book_facts_impl(config, book_slug, facts)
     except FileNotFoundError as exc:
-        return json.dumps({"error": str(exc)})
-    return json.dumps({"path": str(path), "updated": list(facts.keys())})
+        return json.dumps({"error": str(exc), "_deprecated": _deprecated_msg})
+    return json.dumps({"path": str(path), "updated": list(facts.keys()), "_deprecated": _deprecated_msg})
 
 
 @mcp.tool()

--- a/servers/storyforge-server/routers/series.py
+++ b/servers/storyforge-server/routers/series.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 
 import yaml
 
@@ -68,12 +69,23 @@ description: ""
 
 @mcp.tool()
 def get_series(slug: str) -> str:
-    """Get series data."""
+    """Get series data.
+
+    .. deprecated::
+        No skill references this tool — series-planner reads series files
+        directly. Removal in v2.0.
+    """
+    warnings.warn(
+        "get_series is deprecated — no skill uses it; series-planner reads files directly. Removal in v2.0.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    _deprecated_msg = "no skill references this tool; series-planner reads files directly"
     state = _cache.get()
     series = state.get("series", {}).get(slug)
     if not series:
-        return json.dumps({"error": f"Series '{slug}' not found"})
-    return json.dumps(series)
+        return json.dumps({"error": f"Series '{slug}' not found", "_deprecated": _deprecated_msg})
+    return json.dumps({**series, "_deprecated": _deprecated_msg})
 
 
 @mcp.tool()

--- a/tests/server/test_mcp_tool_sweep.py
+++ b/tests/server/test_mcp_tool_sweep.py
@@ -1,0 +1,218 @@
+"""Tests for the MCP tool sweep (Issue #175).
+
+Verifies that:
+- The four deprecated tools emit a DeprecationWarning on every call.
+- Deprecated tools still return usable data (backward-compat, removal in v2.0).
+- Each deprecated tool's JSON response carries a ``_deprecated`` field with a
+  rationale string so the model knows not to rely on it.
+- CLAUDE.md documents list_craft_references, validate_timeline_consistency,
+  and get_review_handle_config as user-callable utilities.
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from pathlib import Path
+
+import pytest
+
+import routers._app as _app
+from routers.chapters import get_chapter
+from routers.claudemd import get_character, update_book_claudemd_facts
+from routers.reference import list_craft_references
+from routers.series import get_series
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent.parent
+CLAUDEMD = PLUGIN_ROOT / "CLAUDE.md"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def config_books(tmp_path: Path) -> dict:
+    content_root = tmp_path / "books"
+    (content_root / "projects").mkdir(parents=True)
+    return {"paths": {"content_root": str(content_root)}}
+
+
+@pytest.fixture
+def config_with_book(config_books: dict, tmp_path: Path) -> dict:
+    book_dir = tmp_path / "books" / "projects" / "test-book"
+    book_dir.mkdir(parents=True)
+    (book_dir / "README.md").write_text(
+        "---\ntitle: Test Book\nstatus: Drafting\n---\n", encoding="utf-8"
+    )
+    return config_books
+
+
+@pytest.fixture
+def config_with_chapter(config_with_book: dict, tmp_path: Path) -> dict:
+    ch_dir = tmp_path / "books" / "projects" / "test-book" / "chapters" / "ch01"
+    ch_dir.mkdir(parents=True)
+    (ch_dir / "README.md").write_text("---\ntitle: Chapter 1\n---\n", encoding="utf-8")
+    return config_with_book
+
+
+@pytest.fixture
+def config_with_character(config_with_book: dict, tmp_path: Path) -> dict:
+    char_dir = tmp_path / "books" / "projects" / "test-book" / "characters"
+    char_dir.mkdir(parents=True)
+    (char_dir / "hero.md").write_text("# Hero\n\nProtagonist.\n", encoding="utf-8")
+    return config_with_book
+
+
+@pytest.fixture
+def config_with_series(tmp_path: Path) -> dict:
+    content_root = tmp_path / "books"
+    series_dir = content_root / "series" / "my-series"
+    series_dir.mkdir(parents=True)
+    return {"paths": {"content_root": str(content_root)}}
+
+
+@pytest.fixture
+def config_with_claudemd(config_with_book: dict, tmp_path: Path) -> dict:
+    book_dir = tmp_path / "books" / "projects" / "test-book"
+    (book_dir / "CLAUDE.md").write_text(
+        "## Book Facts\npov: first\ntense: past\n", encoding="utf-8"
+    )
+    return config_with_book
+
+
+# ---------------------------------------------------------------------------
+# get_chapter — deprecated
+# ---------------------------------------------------------------------------
+
+
+class TestGetChapterDeprecated:
+    def test_emits_deprecation_warning(self, config_with_chapter: dict, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(_app, "load_config", lambda: config_with_chapter)
+        # Rebuild cache so the chapter appears in state
+        from routers.state import rebuild_state
+        rebuild_state()
+        with pytest.warns(DeprecationWarning, match="get_book_full"):
+            get_chapter("test-book", "ch01")
+
+    def test_still_returns_data_or_graceful_error(
+        self, config_with_chapter: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(_app, "load_config", lambda: config_with_chapter)
+        from routers.state import rebuild_state
+        rebuild_state()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            result = json.loads(get_chapter("test-book", "ch01"))
+        assert "_deprecated" in result
+
+    def test_response_carries_deprecated_field(
+        self, config_with_chapter: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(_app, "load_config", lambda: config_with_chapter)
+        from routers.state import rebuild_state
+        rebuild_state()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            result = json.loads(get_chapter("test-book", "ch01"))
+        assert isinstance(result["_deprecated"], str)
+        assert len(result["_deprecated"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# get_character — deprecated
+# ---------------------------------------------------------------------------
+
+
+class TestGetCharacterDeprecated:
+    def test_emits_deprecation_warning(
+        self, config_with_character: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(_app, "load_config", lambda: config_with_character)
+        with pytest.warns(DeprecationWarning, match="get_book_full"):
+            get_character("test-book", "hero")
+
+    def test_response_carries_deprecated_field(
+        self, config_with_character: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(_app, "load_config", lambda: config_with_character)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            result = json.loads(get_character("test-book", "hero"))
+        assert "_deprecated" in result
+
+
+# ---------------------------------------------------------------------------
+# get_series — deprecated
+# ---------------------------------------------------------------------------
+
+
+class TestGetSeriesDeprecated:
+    def test_emits_deprecation_warning(
+        self, config_with_series: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(_app, "load_config", lambda: config_with_series)
+        from routers.state import rebuild_state
+        rebuild_state()
+        with pytest.warns(DeprecationWarning, match="series"):
+            get_series("unknown-series")
+
+    def test_response_carries_deprecated_field(
+        self, config_with_series: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(_app, "load_config", lambda: config_with_series)
+        from routers.state import rebuild_state
+        rebuild_state()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            result = json.loads(get_series("unknown-series"))
+        assert "_deprecated" in result
+
+
+# ---------------------------------------------------------------------------
+# update_book_claudemd_facts — deprecated
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateBookClaudemdFactsDeprecated:
+    def test_emits_deprecation_warning(
+        self, config_with_claudemd: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(_app, "load_config", lambda: config_with_claudemd)
+        with pytest.warns(DeprecationWarning, match="PreCompact"):
+            update_book_claudemd_facts("test-book", pov="third")
+
+    def test_response_carries_deprecated_field(
+        self, config_with_claudemd: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(_app, "load_config", lambda: config_with_claudemd)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            result = json.loads(update_book_claudemd_facts("test-book", pov="third"))
+        assert "_deprecated" in result
+
+
+# ---------------------------------------------------------------------------
+# CLAUDE.md — user-callable utilities documented
+# ---------------------------------------------------------------------------
+
+
+class TestUserCallableUtilitiesDocumented:
+    def test_claudemd_has_user_callable_section(self) -> None:
+        text = CLAUDEMD.read_text(encoding="utf-8")
+        assert "User-Callable MCP Tools" in text or "user-callable" in text.lower(), (
+            "CLAUDE.md must document user-callable MCP tools"
+        )
+
+    def test_list_craft_references_documented(self) -> None:
+        text = CLAUDEMD.read_text(encoding="utf-8")
+        assert "list_craft_references" in text
+
+    def test_validate_timeline_consistency_documented(self) -> None:
+        text = CLAUDEMD.read_text(encoding="utf-8")
+        assert "validate_timeline_consistency" in text
+
+    def test_get_review_handle_config_documented(self) -> None:
+        text = CLAUDEMD.read_text(encoding="utf-8")
+        assert "get_review_handle_config" in text

--- a/tests/server/test_mcp_tool_sweep.py
+++ b/tests/server/test_mcp_tool_sweep.py
@@ -20,7 +20,6 @@ import pytest
 import routers._app as _app
 from routers.chapters import get_chapter
 from routers.claudemd import get_character, update_book_claudemd_facts
-from routers.reference import list_craft_references
 from routers.series import get_series
 
 PLUGIN_ROOT = Path(__file__).resolve().parent.parent.parent


### PR DESCRIPTION
## Summary

Closes the M-5 finding from the 2026-05-05 plugin audit: 7 MCP tools had zero static skill references and consumed tool-list budget without delivering value through the documented skill pipeline.

**Deprecated** (emit `DeprecationWarning` + `_deprecated` field in every response, removal in v2.0):

| Tool | Rationale | Replacement |
|------|-----------|------------|
| `get_chapter` | covered by `get_book_full()` | `get_book_full()` projects `chapters_data` |
| `get_character` | covered by `get_book_full()` | `get_book_full()` projects `characters` |
| `get_series` | no skill uses it; `series-planner` reads files directly | — |
| `update_book_claudemd_facts` | PreCompact hook (Issue #172 / PR #173) writes Book Facts automatically | PreCompact hook |

**Documented as user-callable utilities** in `CLAUDE.md`:

| Tool | Purpose |
|------|---------|
| `list_craft_references` | Explore available references interactively |
| `validate_timeline_consistency` | Diagnostic — cross-validate chapter anchors after multi-chapter drafting |
| `get_review_handle_config` | Informational — handle is already bundled in `get_chapter_writing_brief` |

**Note on `get_review_handle_config`:** The audit recommended wiring into `chapter-writer`, but `review_handle` is already projected by `get_chapter_writing_brief` (verified in `chapters.py:243`). Documenting as utility is the correct outcome — no skill change needed.

## Changes

- `routers/chapters.py` — deprecate `get_chapter`
- `routers/claudemd.py` — deprecate `get_character` + `update_book_claudemd_facts`
- `routers/series.py` — deprecate `get_series`
- `CLAUDE.md` — new "User-Callable MCP Tools" section with both utility and deprecated tables
- `tests/server/test_mcp_tool_sweep.py` — 13 tests: DeprecationWarning emission, `_deprecated` field presence, CLAUDE.md coverage

## Test plan

- [x] `pytest tests/server/test_mcp_tool_sweep.py -v` — all 13 pass
- [x] `pytest -q` — 1554 pass, 4 expected DeprecationWarnings (pre-existing test_get_character tests)
- [x] Verify CLAUDE.md "User-Callable MCP Tools" section looks correct
- [x] Call `get_chapter("some-book", "ch01")` — confirm warning in stderr + `_deprecated` in response

Closes #175. Part of epic #179 (Sprint 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)