### PR TITLE
docs(contributing): establish skill-bloat budget rule (audit Rec 10, #178)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,3 +326,4 @@ The following MCP tools are registered but have no skill wiring. They are availa
 - Python: English comments, type hints, PEP 8
 - Markdown: English for reference docs
 - YAML frontmatter: always present in project/chapter/character files
+- Skill size: skills over 25 k chars or 400 LOC require a split-or-trim plan — see [Skill-bloat budget](CONTRIBUTING.md#skill-bloat-budget) in CONTRIBUTING.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,6 +164,26 @@ The PR template will guide you through the checklist. The CLA bot will comment w
 - **YAML frontmatter**: Required in all SKILL.md, book README.md, chapter README.md, character files.
 - **No emojis** in code comments, skill files, or internal documentation (UTF8MB4 issues in integrations).
 
+## Skill-bloat budget
+
+Any pull request that brings a single `skills/{name}/SKILL.md` over **either**:
+
+- **25 000 characters**, or
+- **400 lines**
+
+must include in the PR description **one of**:
+
+1. A split-or-trim plan in the same PR (target file size + how the diff gets there).
+2. A linked tracking issue with the split-or-trim plan (must be opened in the same week the threshold is crossed).
+
+The thresholds are not hard blocks — CI does not fail. They exist to make size growth a deliberate decision, not a side effect.
+
+**Why two thresholds?** LOC alone is misleading: a 300-LOC file can exceed 37 k chars if Why-blocks dominate (see `chapter-writer` history, Epic #179). Chars alone misses procedural sprawl. Both axes need watching.
+
+**Monitoring helper:** `scripts/check_skill_sizes.py` reports current sizes and flags entries over threshold. Run it before opening a PR that touches skill files.
+
+Reference: PR #137 (plot-architect split), Issue #174 (chapter-writer refactor), Epic #179.
+
 ## What Does NOT Belong in a PR
 
 - Generated book content (belongs in user's private repos)

--- a/scripts/check_skill_sizes.py
+++ b/scripts/check_skill_sizes.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Report skill file sizes and flag entries over the bloat budget thresholds.
+
+Thresholds (from CONTRIBUTING.md § Skill-bloat budget):
+  - 25 000 characters
+  - 400 lines
+
+Info-only: this script never fails CI. It surfaces size pressure so reviewers
+can make deliberate decisions before a skill crosses into attention-degradation
+territory (see chapter-writer history, Epic #179).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+CHAR_THRESHOLD = 25_000
+LINE_THRESHOLD = 400
+
+RESET = "\033[0m"
+RED = "\033[31m"
+YELLOW = "\033[33m"
+GREEN = "\033[32m"
+BOLD = "\033[1m"
+
+
+def check_skills(repo_root: Path) -> list[dict]:
+    skills_dir = repo_root / "skills"
+    results = []
+    for skill_file in sorted(skills_dir.glob("*/SKILL.md")):
+        text = skill_file.read_text(encoding="utf-8")
+        chars = len(text)
+        lines = text.count("\n") + 1
+        over_chars = chars > CHAR_THRESHOLD
+        over_lines = lines > LINE_THRESHOLD
+        results.append(
+            {
+                "name": skill_file.parent.name,
+                "chars": chars,
+                "lines": lines,
+                "over_chars": over_chars,
+                "over_lines": over_lines,
+                "flagged": over_chars or over_lines,
+            }
+        )
+    return results
+
+
+def format_row(r: dict, max_name: int) -> str:
+    char_str = f"{r['chars']:>7,}"
+    line_str = f"{r['lines']:>5}"
+    char_flag = f" {RED}> {CHAR_THRESHOLD:,}{RESET}" if r["over_chars"] else ""
+    line_flag = f" {RED}> {LINE_THRESHOLD}{RESET}" if r["over_lines"] else ""
+    color = RED if r["flagged"] else (YELLOW if r["chars"] > CHAR_THRESHOLD * 0.8 else GREEN)
+    name = f"{color}{r['name']:<{max_name}}{RESET}"
+    return f"  {name}  {char_str} chars{char_flag}  {line_str} lines{line_flag}"
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    results = check_skills(repo_root)
+
+    flagged = [r for r in results if r["flagged"]]
+    near = [r for r in results if not r["flagged"] and r["chars"] > CHAR_THRESHOLD * 0.8]
+
+    max_name = max(len(r["name"]) for r in results) if results else 10
+
+    print(f"\n{BOLD}Skill sizes — storyforge{RESET}\n")
+    print(f"  {'Skill':<{max_name}}  {'Chars':>7}        {'Lines':>5}")
+    print(f"  {'-' * (max_name + 30)}")
+
+    for r in sorted(results, key=lambda x: x["chars"], reverse=True):
+        print(format_row(r, max_name))
+
+    print(f"\n  Thresholds: {CHAR_THRESHOLD:,} chars  |  {LINE_THRESHOLD} lines")
+
+    if flagged:
+        print(f"\n  {RED}{BOLD}Over threshold ({len(flagged)} skill(s)):{RESET}")
+        for r in flagged:
+            reasons = []
+            if r["over_chars"]:
+                reasons.append(f"{r['chars']:,} chars > {CHAR_THRESHOLD:,}")
+            if r["over_lines"]:
+                reasons.append(f"{r['lines']} lines > {LINE_THRESHOLD}")
+            print(f"    {r['name']}: {', '.join(reasons)}")
+        print(f"\n  PR must include a split-or-trim plan. See CONTRIBUTING.md § Skill-bloat budget.")
+
+    if near:
+        print(f"\n  {YELLOW}Approaching threshold (> 80%) ({len(near)} skill(s)):{RESET}")
+        for r in near:
+            pct = int(r["chars"] / CHAR_THRESHOLD * 100)
+            print(f"    {r['name']}: {r['chars']:,} chars ({pct}% of limit)")
+
+    if not flagged and not near:
+        print(f"\n  {GREEN}All skills within budget.{RESET}")
+
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_skill_sizes.py
+++ b/scripts/check_skill_sizes.py
@@ -84,7 +84,7 @@ def main() -> int:
             if r["over_lines"]:
                 reasons.append(f"{r['lines']} lines > {LINE_THRESHOLD}")
             print(f"    {r['name']}: {', '.join(reasons)}")
-        print(f"\n  PR must include a split-or-trim plan. See CONTRIBUTING.md § Skill-bloat budget.")
+        print("\n  PR must include a split-or-trim plan. See CONTRIBUTING.md § Skill-bloat budget.")
 
     if near:
         print(f"\n  {YELLOW}Approaching threshold (> 80%) ({len(near)} skill(s)):{RESET}")


### PR DESCRIPTION
## Summary

- Adds `## Skill-bloat budget` section to `CONTRIBUTING.md`: any PR that pushes a `skills/{name}/SKILL.md` past **25 000 chars** or **400 lines** must include a split-or-trim plan (in-PR or linked issue)
- Adds `scripts/check_skill_sizes.py` — info-only reporter, flags over-threshold entries, highlights skills at > 80% of limit
- Adds cross-reference in `CLAUDE.md § Code Style`

## Motivation

No policy prevented `chapter-writer/SKILL.md` from growing 5 k → 37 k chars in 33 days. Each addition was individually justified, but without a budget rule there was no forcing function. This closes that gap without adding a hard CI gate (which historically causes gaming behavior).

## Current skill sizes (post-Sprint-2 refactor)

All within budget. Three skills in the "approaching 80%" zone:
- `chapter-writer`: 24 742 chars (98% of limit) — #176 split incoming
- `chapter-reviewer`: 21 447 chars (85%)
- `chapter-writer-memoir`: 20 908 chars (83%)

## Test plan

- [x] `scripts/check_skill_sizes.py` runs without errors
- [x] `pytest tests/skills/ -q` — 51 passed
- [x] CONTRIBUTING.md renders correctly in GitHub preview

Closes #178
Part of Epic #179