### PR TITLE
fix(hooks): skip series-character-trackers in validate_character (#192)

### DIFF
--- a/hooks/validate_character.py
+++ b/hooks/validate_character.py
@@ -40,6 +40,13 @@ WATCHED_TOOLS = frozenset({"Write", "Edit", "MultiEdit"})
 # write whose path does not contain at least one of these.
 WATCHED_PATH_FRAGMENTS = ("/characters/", "/people/")
 
+# Path marker for series-character-trackers. Files under
+# ``series/{slug}/characters/`` document evolution across books and follow a
+# different schema (Snapshot / Evolution per Band / Beziehungen / Updates Log)
+# with roles like ``love-interest`` that the book-level validator does not
+# recognize. They must be skipped to avoid false-positive warnings (Issue #192).
+SERIES_PATH_MARKER = "/series/"
+
 # Frontmatter — block on missing.
 REQUIRED_FRONTMATTER = ("name", "role", "status")
 
@@ -100,10 +107,13 @@ def _extract_file_path(payload: dict[str, Any]) -> str | None:
 
 
 def _is_character_or_people_file(path: Path) -> bool:
-    """True for `characters/*.md` or `people/*.md` (excluding INDEX.md)."""
+    """True for `characters/*.md` or `people/*.md` (excluding INDEX.md and
+    series-character-trackers under ``series/{slug}/characters/``)."""
     if path.suffix != ".md":
         return False
     if path.name == "INDEX.md":
+        return False
+    if SERIES_PATH_MARKER in str(path):
         return False
     return any(frag in str(path) for frag in WATCHED_PATH_FRAGMENTS)
 

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -1264,3 +1264,50 @@ class TestValidateCharacter:
         person_file.write_text("# Mom\n\nNo frontmatter.\n", encoding="utf-8")
         blocking, _warnings = validate_character(str(person_file))
         assert any("Missing YAML frontmatter" in i for i in blocking)
+
+    def test_series_tracker_path_is_skipped(self, tmp_path):
+        """Files under ``series/{slug}/characters/`` are series-character-trackers
+        with a different schema (Snapshot / Evolution per Band / Beziehungen /
+        Updates Log) and roles like ``love-interest`` that the book-level
+        validator does not recognize.
+
+        The substring match on ``/characters/`` accidentally caught these files
+        and produced ~4 false-positive warnings per edit (Issue #192). The
+        validator must bail out before role / section checks for any path
+        containing ``/series/``.
+        """
+        series_dir = tmp_path / "series" / "blood-and-binary" / "characters"
+        series_dir.mkdir(parents=True)
+        tracker = series_dir / "kael.md"
+        tracker.write_text(
+            "---\n"
+            'name: "Kael"\n'
+            'slug: "kael"\n'
+            'role: "love-interest"\n'
+            'status: "Profile"\n'
+            "recurs_in: [B1, B2, B3]\n"
+            "---\n\n"
+            "# Kael — Series Evolution\n\n"
+            "## Snapshot\n\nContent.\n",
+            encoding="utf-8",
+        )
+        blocking, warnings = validate_character(str(tracker))
+        assert blocking == []
+        assert warnings == []
+
+    def test_series_tracker_skip_does_not_break_book_level_characters(self, tmp_path):
+        """Regression guard: book-level ``characters/`` files (no ``/series/``
+        in the path) must continue to validate fully."""
+        chars_dir = tmp_path / "blood-and-binary-firelight" / "characters"
+        chars_dir.mkdir(parents=True)
+        char_file = chars_dir / "alex.md"
+        char_file.write_text(
+            '---\nname: "Alex"\nrole: "wizard"\nstatus: "Concept"\n---\n\n'
+            "# Alex\n\nNo recommended sections.\n",
+            encoding="utf-8",
+        )
+        blocking, warnings = validate_character(str(char_file))
+        # Book-level validation still runs: unknown role + missing sections.
+        assert blocking == []
+        assert any("'wizard'" in w for w in warnings)
+        assert any("Want vs. Need" in w for w in warnings)


### PR DESCRIPTION
## Summary

Closes #192.

`hooks/validate_character.py::_is_character_or_people_file()` matched any path containing `/characters/` as a substring. Series-character-trackers under `series/{slug}/characters/` accidentally matched and got the book-level validator applied — even though they follow a different schema (Snapshot / Evolution per Band / Beziehungen / Updates Log) with roles like `love-interest` that the book-level validator does not recognize.

Result before this fix: ~4 false-positive warnings per edit, ~44 noise warnings across an 11-character series-tracker set on every Edit.

## Fix

Option 1 from the issue — add `/series/` as a negative match in the path filter. Five-line change, zero risk. Series-trackers stay user-managed Markdown without enforced book-level schema.

```python
SERIES_PATH_MARKER = "/series/"

def _is_character_or_people_file(path: Path) -> bool:
    if path.suffix != ".md":
        return False
    if path.name == "INDEX.md":
        return False
    if SERIES_PATH_MARKER in str(path):
        return False
    return any(frag in str(path) for frag in WATCHED_PATH_FRAGMENTS)
```

## Test plan

- [x] New test `test_series_tracker_path_is_skipped` — series-tracker with `role: love-interest` and minimal sections produces 0 blocks, 0 warnings
- [x] New regression test `test_series_tracker_skip_does_not_break_book_level_characters` — book-level `characters/{slug}.md` still produces unknown-role + missing-section warnings
- [x] Full `tests/hooks/` suite: 96 passed
- [x] Full repository test suite: 1574 passed
- [x] `ruff check` clean

## Affected files

- `hooks/validate_character.py` — primary fix (5 lines)
- `tests/hooks/test_hooks.py` — 2 new tests (the original test from the issue + a regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)