### PR TITLE
fix(hooks): extend VALID_ROLES with love-interest, mentor, foil, herald, confidant (#193)

### DIFF
--- a/hooks/validate_character.py
+++ b/hooks/validate_character.py
@@ -52,8 +52,25 @@ REQUIRED_FRONTMATTER = ("name", "role", "status")
 
 # Valid roles (fiction). Memoir person files use a different schema and are
 # skipped for the role check (see _is_memoir_person_file).
+#
+# The set covers core protagonist/antagonist tiers plus standard fiction-craft
+# archetypal roles (love-interest, mentor, foil, herald, confidant) authors
+# and skills reach for naturally — Hero's Journey beats, romance arcs, mystery
+# confidants. ``minor`` is the catch-all that also gates section-recommendation
+# warnings (minor characters skip the recommended-sections check). Issue #193.
 VALID_ROLES = frozenset(
-    {"protagonist", "antagonist", "deuteragonist", "supporting", "minor"}
+    {
+        "protagonist",
+        "deuteragonist",
+        "antagonist",
+        "love-interest",
+        "mentor",
+        "foil",
+        "herald",
+        "confidant",
+        "supporting",
+        "minor",
+    }
 )
 
 # Recommended sections — warn on missing (only for non-minor characters).

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -1237,6 +1237,33 @@ class TestValidateCharacter:
         assert blocking == []
         assert any("'wizard'" in w for w in warnings)
 
+    def test_extended_fiction_roles_pass_role_check(self, tmp_path):
+        """Roles added in Issue #193 — love-interest, mentor, foil, herald,
+        confidant — are standard fiction-craft roles and must pass the role
+        check. Authors and skills (e.g. series-planner) reach for them
+        naturally; surfaced when /storyforge:series-planner blood-and-binary
+        produced ``role: love-interest`` for Kael in a paranormal-romance
+        trilogy and the hook flagged it as unknown.
+
+        Each fixture includes all four recommended sections so the role check
+        is the sole discriminator: a passing role means zero warnings."""
+        new_roles = ("love-interest", "mentor", "foil", "herald", "confidant")
+        chars_dir = tmp_path / "project" / "characters"
+        chars_dir.mkdir(parents=True)
+        for role in new_roles:
+            char_file = chars_dir / f"{role}.md"
+            char_file.write_text(
+                f'---\nname: "Test"\nrole: "{role}"\nstatus: "Concept"\n---\n\n'
+                "# Test\n\n## Want vs. Need\n\n## Fatal Flaw\n\n"
+                "## The Ghost\n\n## Motivation Chain\n",
+                encoding="utf-8",
+            )
+            blocking, warnings = validate_character(str(char_file))
+            assert blocking == [], f"role {role!r} unexpectedly blocked"
+            assert not any("Unknown role" in w for w in warnings), (
+                f"role {role!r} flagged as unknown — must be a valid role"
+            )
+
     def test_memoir_person_file_validates(self, tmp_path):
         """Memoir person files live under ``people/`` and use a different
         schema (``person_category`` / ``consent_status`` etc.). Frontmatter


### PR DESCRIPTION
## Summary

Closes #193.

`hooks/validate_character.py::VALID_ROLES` was a 5-role set (protagonist, antagonist, deuteragonist, supporting, minor) and missed standard fiction-craft archetypes. `/storyforge:series-planner blood-and-binary` set `role: love-interest` for Kael — the contextually correct call for a paranormal-romance trilogy — and the hook flagged it as unknown.

## Fix

Option A from the issue — extend the set with five roles:

| Role | When used |
|---|---|
| `love-interest` | Romance / paranormal-romance / dark-fantasy with romance arcs |
| `mentor` | Hero's Journey, mystery, fantasy |
| `foil` | Literary fiction, thrillers — contrast-by-character |
| `herald` | Hero's Journey 12-station call-to-adventure |
| `confidant` | Mystery, thrillers, family drama |

Kept the contract that obvious typos (`role: protagonisr`) still warn. `minor` still gates the recommended-section special-case (minor characters skip section recommendations).

## Test plan

- [x] New test `test_extended_fiction_roles_pass_role_check` — all five roles produce 0 blocking + 0 warnings (sole discriminator: role check, fixture includes all four recommended sections)
- [x] Existing `test_unknown_role_warns` still passes with `wizard` as the unknown role
- [x] Full `tests/hooks/` suite: 97 passed
- [x] Full repository test suite: 1575 passed
- [x] `ruff check` clean

## Affected files

- `hooks/validate_character.py` — extend `VALID_ROLES` set + comment explaining rationale
- `tests/hooks/test_hooks.py` — 1 new test covering all five roles

## Deferred

- `templates/character.md` — no comment about valid roles exists today; the validator's warning message is self-documenting. If a comment becomes desirable later, it's a 1-line follow-up.
- Wiki [Character Anatomy](https://faq.markus-michalski.net/en/plugins/storyforge/character-anatomy) doc update — separate from code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)