### PR TITLE
feat(state): add series-tracker book_slug resolver (#194)

### DIFF
--- a/skills/series-planner/SKILL.md
+++ b/skills/series-planner/SKILL.md
@@ -57,9 +57,25 @@ Set up `{series}/world/canon.md`:
 - World rules (magic systems, technology, geography)
 - Timeline of events across books
 
-Set up `{series}/characters/`:
-- Recurring character profiles that track CHANGES across books
-- Relationship evolution
+Set up `{series}/characters/` from `templates/series-character-tracker.md`:
+- One tracker file per recurring character (`recurs_in: [B1, B2, ...]`)
+- `## Snapshot` (essence at series scope), `## Evolution per Band` (B1 Start/Ende, B2 geplant), `## Beziehungen über die Bände`, `## Updates Log`
+- `tracker_type: thin` for characters whose full profile lives in their home book; `full` is rare and only for characters that span books equally without a home book
+
+**`book_slug:` mapping (Issue #194).** When you propose a tracker slug that differs from the slugified character name (and from the existing book-level character slug — e.g. you pick `king-caelan` for a character whose book-level file is `caelan.md`), write the optional `book_slug:` frontmatter field on the tracker. This is what the future harvest, bootstrap, and brief-source tooling (Issue #195) consumes to bridge between scopes:
+
+```yaml
+---
+name: "King Caelan"
+slug: "king-caelan"
+book_slug: "caelan"        # ← explicit book-level equivalent
+role: "supporting"
+recurs_in: ["B1", "B2", "B3"]
+tracker_type: "thin"
+---
+```
+
+When the tracker slug already matches the book-level slug (e.g. `kael` ↔ `kael.md`), omit `book_slug:` — the resolver falls back to the tracker slug. Zero-config for the common case.
 
 ### Step 6: Link Books
 As books are created, link them via MCP `add_book_to_series()`.

--- a/templates/series-character-tracker.md
+++ b/templates/series-character-tracker.md
@@ -1,0 +1,56 @@
+---
+name: "{{name}}"
+slug: "{{tracker-slug}}"
+# Optional: explicit book-level slug if it differs from the tracker slug.
+# Bridges this series-tracker to the book-level character file
+# `projects/{book}/characters/{book_slug}.md` for the harvest, bootstrap,
+# and brief-source tooling (Issue #195). When absent, the tracker slug
+# IS the book-level slug — the zero-config default for the common case
+# (e.g. tracker `kael` ↔ book file `kael.md`).
+# Set this field when the series-planner picked a role/title-prefixed
+# slug (e.g. `king-caelan`) for a character whose book-level file uses
+# the bare name (e.g. `caelan.md`).
+# book_slug: "{{book-level-slug}}"
+role: "{{role}}"
+species: "{{species}}"
+status: "Profile"
+recurs_in: ["B1"]
+# Tracker depth. ``thin`` = essence + per-book Evolution sections only,
+# full character profile lives in the book-level file. ``full`` = the
+# tracker IS the source of truth (rare; only when a character spans
+# books equally without a "home" book).
+tracker_type: "thin"
+---
+
+# {{name}} — Series Evolution Tracker
+
+> Volles Profil pro Buch in [{{book-slug}}/characters/{{book-level-slug}}.md](../../projects/{{book-slug}}/characters/{{book-level-slug}}.md).
+
+## Snapshot
+
+*One-paragraph essence at series scope. What is constant about this character across all books? Capture identity, role, key relationship anchors. Not plot, not arc-per-book — the through-line.*
+
+## Evolution per Band
+
+### B1 Start
+*Where the character begins in Book 1. Initial state, defining wound or driver, current situation. Filled at planning time.*
+
+### B1 Ende
+*Where the character ends in Book 1. Filled by the harvest tool at end-of-book from book-level frontmatter snapshot fields and relationships.*
+
+### B2 (geplant)
+*Planned arc for Book 2. What changes? What carries forward? What new external pressure forces growth? Filled at planning time.*
+
+<!-- Repeat per planned book: B2 Ende (post-harvest), B3 (geplant), etc. -->
+
+## Beziehungen über die Bände
+
+*Cross-book relationship arcs. Capture how each significant pairing evolves across the series, not just within one book. Format:*
+
+- **{{Other Character}}**: {{B1 dynamic}} → {{B2 shift}} → {{B3 resolution}}
+
+## Updates Log
+
+*Append-only chronological log of changes to this tracker. Each entry: date + what changed + source (manual edit / harvest tool / bootstrap tool).*
+
+- {{YYYY-MM-DD}} — Tracker scaffolded by series-planner

--- a/tests/state/test_series_loaders.py
+++ b/tests/state/test_series_loaders.py
@@ -1,0 +1,179 @@
+"""Tests for series-tracker loaders (Issue #194).
+
+Covers the resolver that maps a series-character-tracker file to its
+book-level character slug. Series-trackers can carry slugs that differ
+from their book-level equivalents (e.g. ``king-caelan`` tracker maps to
+``caelan`` book file). The optional ``book_slug:`` frontmatter field
+declares the explicit mapping; when absent, the tracker slug IS the
+book slug (zero-config legacy behavior).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.state.loaders.series import (
+    find_series_trackers,
+    parse_series_tracker,
+    resolve_book_slug_for_series_tracker,
+)
+
+
+def _write_tracker(chars_dir: Path, slug: str, frontmatter: str) -> Path:
+    path = chars_dir / f"{slug}.md"
+    path.write_text(
+        f"---\n{frontmatter}\n---\n\n# {slug}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+class TestResolveBookSlug:
+    def test_uses_explicit_book_slug_when_present(self) -> None:
+        tracker = {"slug": "king-caelan", "book_slug": "caelan"}
+        assert resolve_book_slug_for_series_tracker(tracker) == "caelan"
+
+    def test_falls_back_to_tracker_slug_when_book_slug_absent(self) -> None:
+        tracker = {"slug": "theo-wilkons"}
+        assert resolve_book_slug_for_series_tracker(tracker) == "theo-wilkons"
+
+    def test_falls_back_when_book_slug_is_none(self) -> None:
+        tracker = {"slug": "kael", "book_slug": None}
+        assert resolve_book_slug_for_series_tracker(tracker) == "kael"
+
+    def test_falls_back_when_book_slug_is_empty_string(self) -> None:
+        # Empty string is falsy → treat as absent, fall back to tracker slug.
+        tracker = {"slug": "kael", "book_slug": ""}
+        assert resolve_book_slug_for_series_tracker(tracker) == "kael"
+
+    def test_returns_empty_string_when_both_missing(self) -> None:
+        # Defensive: malformed tracker without slug should not blow up.
+        assert resolve_book_slug_for_series_tracker({}) == ""
+
+
+class TestParseSeriesTracker:
+    def test_parses_full_tracker_with_book_slug(self, tmp_path: Path) -> None:
+        chars_dir = tmp_path / "characters"
+        chars_dir.mkdir()
+        path = _write_tracker(
+            chars_dir,
+            "king-caelan",
+            "name: King Caelan\n"
+            "slug: king-caelan\n"
+            "book_slug: caelan\n"
+            "role: supporting\n"
+            "species: vampire\n"
+            "status: Profile\n"
+            "recurs_in: [B1, B2, B3]\n"
+            "tracker_type: thin",
+        )
+        tracker = parse_series_tracker(path)
+        assert tracker["slug"] == "king-caelan"
+        assert tracker["name"] == "King Caelan"
+        assert tracker["book_slug"] == "caelan"
+        assert tracker["role"] == "supporting"
+        assert tracker["species"] == "vampire"
+        assert tracker["status"] == "Profile"
+        assert tracker["recurs_in"] == ["B1", "B2", "B3"]
+        assert tracker["tracker_type"] == "thin"
+
+    def test_parses_tracker_without_book_slug(self, tmp_path: Path) -> None:
+        chars_dir = tmp_path / "characters"
+        chars_dir.mkdir()
+        path = _write_tracker(
+            chars_dir,
+            "kael",
+            "name: Kael\n"
+            "slug: kael\n"
+            "role: love-interest\n"
+            "species: vampire\n"
+            "status: Profile\n"
+            "recurs_in: [B1, B2, B3]\n"
+            "tracker_type: thin",
+        )
+        tracker = parse_series_tracker(path)
+        assert tracker["slug"] == "kael"
+        assert tracker["book_slug"] is None
+        assert tracker["role"] == "love-interest"
+
+    def test_resolver_chains_with_parser(self, tmp_path: Path) -> None:
+        # End-to-end: parse a real tracker file, hand to resolver.
+        chars_dir = tmp_path / "characters"
+        chars_dir.mkdir()
+        path = _write_tracker(
+            chars_dir,
+            "queen-miriel",
+            "name: Queen Miriel\n"
+            "slug: queen-miriel\n"
+            "book_slug: miriel\n"
+            "role: supporting\n"
+            "status: Profile\n"
+            "recurs_in: [B1, B2]",
+        )
+        tracker = parse_series_tracker(path)
+        assert resolve_book_slug_for_series_tracker(tracker) == "miriel"
+
+    def test_falls_back_to_path_stem_when_slug_missing(self, tmp_path: Path) -> None:
+        # Frontmatter without slug field — tracker's ``slug`` defaults to
+        # the file stem so downstream resolver still has a value to work with.
+        chars_dir = tmp_path / "characters"
+        chars_dir.mkdir()
+        path = _write_tracker(
+            chars_dir,
+            "viktor",
+            "name: Viktor\nrole: supporting\nstatus: Profile",
+        )
+        tracker = parse_series_tracker(path)
+        assert tracker["slug"] == "viktor"
+        assert tracker["book_slug"] is None
+
+    def test_handles_missing_recurs_in_gracefully(self, tmp_path: Path) -> None:
+        chars_dir = tmp_path / "characters"
+        chars_dir.mkdir()
+        path = _write_tracker(
+            chars_dir,
+            "minor-char",
+            "name: Minor Char\nslug: minor-char\nrole: minor\nstatus: Concept",
+        )
+        tracker = parse_series_tracker(path)
+        assert tracker["recurs_in"] == []
+        assert tracker["tracker_type"] == "thin"
+
+
+class TestFindSeriesTrackers:
+    def test_returns_all_md_files_excluding_index(self, tmp_path: Path) -> None:
+        series_dir = tmp_path / "blood-and-binary"
+        chars_dir = series_dir / "characters"
+        chars_dir.mkdir(parents=True)
+        _write_tracker(chars_dir, "kael", "slug: kael")
+        _write_tracker(chars_dir, "theo-wilkons", "slug: theo-wilkons")
+        _write_tracker(chars_dir, "king-caelan", "slug: king-caelan\nbook_slug: caelan")
+        (chars_dir / "INDEX.md").write_text("# Index\n", encoding="utf-8")
+
+        trackers = find_series_trackers(series_dir)
+        names = sorted(p.name for p in trackers)
+        assert names == ["kael.md", "king-caelan.md", "theo-wilkons.md"]
+
+    def test_returns_empty_when_characters_dir_missing(self, tmp_path: Path) -> None:
+        series_dir = tmp_path / "lonely-series"
+        series_dir.mkdir()
+        assert find_series_trackers(series_dir) == []
+
+    def test_returns_empty_when_series_dir_missing(self, tmp_path: Path) -> None:
+        assert find_series_trackers(tmp_path / "does-not-exist") == []
+
+    def test_ignores_non_md_files(self, tmp_path: Path) -> None:
+        series_dir = tmp_path / "series"
+        chars_dir = series_dir / "characters"
+        chars_dir.mkdir(parents=True)
+        _write_tracker(chars_dir, "kael", "slug: kael")
+        (chars_dir / "notes.txt").write_text("scratch", encoding="utf-8")
+        (chars_dir / ".hidden.md").write_text("---\n---\n", encoding="utf-8")
+
+        trackers = find_series_trackers(series_dir)
+        # Hidden dotfiles are returned by glob("*.md") — current behavior;
+        # we only assert the txt file is filtered. INDEX is the explicit
+        # filter case, dotfiles are author's responsibility.
+        names = {p.name for p in trackers}
+        assert "notes.txt" not in names
+        assert "kael.md" in names

--- a/tools/state/loaders/series.py
+++ b/tools/state/loaders/series.py
@@ -1,0 +1,74 @@
+"""Series-tracker loaders (Issue #194).
+
+Bridges the gap between book-level character files
+(``projects/{book}/characters/{slug}.md``) and series-level evolution
+trackers (``series/{series}/characters/{tracker-slug}.md``).
+
+The series-planner skill may pick role/title-prefixed slugs at series
+scope when a character is recurringly addressed by title across the
+trilogy (e.g. ``king-caelan`` for "King Caelan", whose book-level file
+is just ``caelan.md``). The tracker schema therefore supports an
+optional ``book_slug:`` frontmatter field that declares the explicit
+mapping. When absent, the tracker slug IS the book-level slug — no
+breakage for the common case where they match.
+
+The future series-evolution tooling (harvest, bootstrap, brief-source —
+see Issue #195) consumes this resolver.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from tools.state.parsers import parse_frontmatter
+
+
+def parse_series_tracker(path: Path) -> dict[str, Any]:
+    """Parse a series-character-tracker frontmatter into a dict.
+
+    Returns at minimum: ``slug``, ``name``, ``role``, ``species``,
+    ``status``, ``recurs_in``, ``tracker_type``, ``book_slug``.
+    The ``book_slug`` value is ``None`` when the field is absent.
+    ``slug`` falls back to the path stem so downstream callers always
+    have a non-empty value.
+    """
+    text = path.read_text(encoding="utf-8")
+    meta, _body = parse_frontmatter(text)
+
+    return {
+        "slug": str(meta.get("slug") or path.stem),
+        "name": str(meta.get("name", path.stem)),
+        "role": str(meta.get("role", "supporting")),
+        "species": str(meta.get("species", "")),
+        "status": str(meta.get("status", "Profile")),
+        "recurs_in": list(meta.get("recurs_in") or []),
+        "tracker_type": str(meta.get("tracker_type", "thin")),
+        "book_slug": meta.get("book_slug"),
+    }
+
+
+def resolve_book_slug_for_series_tracker(tracker: dict[str, Any]) -> str:
+    """Return the book-level slug for a series tracker.
+
+    Priority: explicit ``book_slug`` field (when truthy) > tracker
+    ``slug`` as-is. Returns an empty string when neither is set so
+    callers can branch without exception handling.
+    """
+    book_slug = tracker.get("book_slug")
+    if book_slug:
+        return str(book_slug)
+    return str(tracker.get("slug") or "")
+
+
+def find_series_trackers(series_dir: Path) -> list[Path]:
+    """Return all series-character-tracker files for a series.
+
+    Looks under ``{series_dir}/characters/`` and returns every ``*.md``
+    sorted by path, excluding ``INDEX.md``. Returns an empty list when
+    the directory does not exist.
+    """
+    chars_dir = series_dir / "characters"
+    if not chars_dir.exists():
+        return []
+    return sorted(p for p in chars_dir.glob("*.md") if p.name != "INDEX.md")


### PR DESCRIPTION
## Summary

Adds the optional `book_slug:` frontmatter field to series-character-trackers and a `resolve_book_slug_for_series_tracker()` helper that bridges between book-level character files (`projects/{book}/characters/{slug}.md`) and series-level evolution trackers (`series/{series}/characters/{tracker-slug}.md`).

The series-planner skill picked role/title-prefixed slugs at series scope for 3 of 13 trackers in `blood-and-binary` (`king-caelan` → `caelan`, `queen-miriel` → `miriel`, `lord-lucien` → `lucien`). The future series-evolution tooling (harvest, bootstrap, brief-source — Epic #195) needs file-to-file resolution to populate trackers from book files and vice versa.

When `book_slug:` is absent, the resolver falls back to the tracker slug — zero-config for the common case where they match. No migration needed.

## Changes

- **New:** `tools/state/loaders/series.py` — `parse_series_tracker()`, `resolve_book_slug_for_series_tracker()`, `find_series_trackers()`
- **New:** `tests/state/test_series_loaders.py` — 14 tests covering resolver priority, parser fallbacks, tracker discovery
- **New:** `templates/series-character-tracker.md` — schema reference with `book_slug:` documented as commented-out default
- **Edit:** `skills/series-planner/SKILL.md` Step 5 — instructs the skill to write `book_slug:` when the tracker slug differs from the book-level slug

## Out of scope

- Migration of existing series-trackers without `book_slug:` (manual addition is fine; the issue accepts this)
- Wiki [Character Anatomy](https://faq.markus-michalski.net/en/plugins/storyforge/character-anatomy) update — bundled with epic close
- Wiring the resolver into harvest / bootstrap / brief-source — those land in their own PRs

## Test plan

- [x] `pytest tests/state/test_series_loaders.py -q` → 14/14 passing
- [x] `pytest tests/ -q` → 1589/1589 passing
- [x] `ruff check .` → clean
- [x] `ruff format --check` on new files → already formatted

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)