### PR TITLE
feat(brief): add series_evolution field per character (D-3 of #195)

### DIFF
--- a/tests/state/test_chapter_writing_brief_series_evolution.py
+++ b/tests/state/test_chapter_writing_brief_series_evolution.py
@@ -1,0 +1,287 @@
+"""Tests for the series_evolution enrichment in chapter_writing_brief
+(Issue #205, D-3 of Epic #195).
+
+Covers the integration: when a book is part of a series, every
+``characters_present`` entry gets a ``series_evolution`` payload (or
+``None`` for graceful degrade).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.state.chapter_writing_brief import build_chapter_writing_brief
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+@pytest.fixture
+def content_root(tmp_path: Path) -> Path:
+    return tmp_path / "content"
+
+
+def _make_book(
+    content_root: Path,
+    book_slug: str,
+    *,
+    series: str = "",
+    series_number: int = 0,
+    book_category: str = "fiction",
+) -> Path:
+    book_root = content_root / "projects" / book_slug
+    series_line = f"series: {series}\n" if series else ""
+    series_n_line = f"series_number: {series_number}\n" if series_number else ""
+    _write(
+        book_root / "README.md",
+        f"---\ntitle: {book_slug}\nbook_category: {book_category}\n{series_line}{series_n_line}---\n\nBook body.\n",
+    )
+    return book_root
+
+
+def _make_chapter(
+    book_root: Path,
+    chapter_slug: str,
+    *,
+    pov: str = "",
+    outline: str = "",
+) -> None:
+    pov_line = f"pov: {pov}\n" if pov else ""
+    _write(
+        book_root / "chapters" / chapter_slug / "README.md",
+        f"---\nslug: {chapter_slug}\n{pov_line}---\n\n## Outline\n\n" + outline + "\n",
+    )
+
+
+def _make_character(
+    book_root: Path,
+    slug: str,
+    *,
+    name: str | None = None,
+    role: str = "supporting",
+) -> Path:
+    char = book_root / "characters" / f"{slug}.md"
+    _write(
+        char,
+        f"---\nname: {name or slug}\nslug: {slug}\nrole: {role}\n---\n\n# Profile\n",
+    )
+    return char
+
+
+def _make_tracker(
+    content_root: Path,
+    series: str,
+    slug: str,
+    *,
+    book_slug: str | None = None,
+    recurs_in: list[str] | None = None,
+    body: str = "",
+) -> Path:
+    chars_dir = content_root / "series" / series / "characters"
+    chars_dir.mkdir(parents=True, exist_ok=True)
+    book_slug_line = f"book_slug: {book_slug}\n" if book_slug else ""
+    fm = (
+        "---\n"
+        f"name: {slug.title()}\n"
+        f"slug: {slug}\n"
+        f"{book_slug_line}"
+        "role: supporting\n"
+        "status: Profile\n"
+        f"recurs_in: {recurs_in or ['B1', 'B2']}\n"
+        "tracker_type: thin\n"
+        "---\n\n"
+    )
+    path = chars_dir / f"{slug}.md"
+    path.write_text(fm + body, encoding="utf-8")
+    return path
+
+
+class TestBriefSeriesEvolutionEnrichment:
+    def test_enriches_when_book_in_series(self, content_root: Path):
+        book_root = _make_book(
+            content_root,
+            "blood-and-binary-firelight",
+            series="blood-and-binary",
+            series_number=1,
+        )
+        _make_character(book_root, "kael", name="Kael", role="deuteragonist")
+        _make_chapter(
+            book_root,
+            "01-opening",
+            pov="kael",
+            outline="Kael walks in. Caelan watches.",
+        )
+        _make_tracker(
+            content_root,
+            "blood-and-binary",
+            "kael",
+            recurs_in=["B1", "B2"],
+            body=(
+                "## Evolution per Band\n\n"
+                "### B1 Firelight\n"
+                "- **Start:** Cabin-Einsiedler.\n"
+                "- **Ende:** Mit Theo zusammen.\n\n"
+                "## Beziehungen ueber die Bande\n\n"
+                "- **Theo:** Liebe.\n"
+            ),
+        )
+
+        brief = build_chapter_writing_brief(
+            book_root=book_root,
+            book_slug="blood-and-binary-firelight",
+            chapter_slug="01-opening",
+            plugin_root=Path("/tmp"),
+        )
+        chars = {c["slug"]: c for c in brief["characters_present"]}
+        assert "kael" in chars
+        evo = chars["kael"]["series_evolution"]
+        assert evo is not None
+        assert evo["tracker_slug"] == "kael"
+        assert "Mit Theo zusammen" in evo["current_book_plan"]
+        assert "**Theo:**" in evo["relationships_evolution"]
+        # B1 has no prev — empty string.
+        assert evo["previous_book_end"] == ""
+
+    def test_b2_chapter_gets_prev_book_end(self, content_root: Path):
+        book_root = _make_book(
+            content_root,
+            "blood-and-binary-moonrise",
+            series="blood-and-binary",
+            series_number=2,
+        )
+        _make_character(book_root, "kael", role="deuteragonist")
+        _make_chapter(book_root, "01-opening", pov="kael", outline="Kael grieves.")
+        _make_tracker(
+            content_root,
+            "blood-and-binary",
+            "kael",
+            recurs_in=["B1", "B2"],
+            body=(
+                "## Evolution per Band\n\n"
+                "### B1 Firelight\n"
+                "- **Ende:** Mit Theo zusammen, Sera tot.\n\n"
+                "### B2 Moonrise (geplant)\n"
+                "- Trauernder Bruder.\n"
+                "- Macht-Asymmetrie kippt.\n"
+            ),
+        )
+        brief = build_chapter_writing_brief(
+            book_root=book_root,
+            book_slug="blood-and-binary-moonrise",
+            chapter_slug="01-opening",
+            plugin_root=Path("/tmp"),
+        )
+        evo = brief["characters_present"][0]["series_evolution"]
+        assert evo is not None
+        assert "Mit Theo zusammen" in evo["previous_book_end"]
+        assert "Trauernder Bruder" in evo["current_book_plan"]
+        assert evo["current_book_phase"] == "B2 Moonrise (geplant)"
+
+    def test_resolves_via_book_slug_field(self, content_root: Path):
+        # Book file is caelan.md, tracker is king-caelan.md with book_slug.
+        book_root = _make_book(
+            content_root,
+            "blood-and-binary-firelight",
+            series="blood-and-binary",
+            series_number=1,
+        )
+        _make_character(book_root, "caelan", name="Caelan", role="supporting")
+        _make_chapter(book_root, "01-opening", pov="caelan", outline="Caelan rules.")
+        _make_tracker(
+            content_root,
+            "blood-and-binary",
+            "king-caelan",
+            book_slug="caelan",
+            recurs_in=["B1", "B2"],
+            body=("## Evolution per Band\n\n### B1\n- **Ende:** Caelan trauert.\n"),
+        )
+        brief = build_chapter_writing_brief(
+            book_root=book_root,
+            book_slug="blood-and-binary-firelight",
+            chapter_slug="01-opening",
+            plugin_root=Path("/tmp"),
+        )
+        evo = brief["characters_present"][0]["series_evolution"]
+        assert evo is not None
+        assert evo["tracker_slug"] == "king-caelan"
+        assert "Caelan trauert" in evo["current_book_plan"]
+
+
+class TestBriefSeriesEvolutionGracefulDegrade:
+    def test_none_when_book_not_in_series(self, content_root: Path):
+        book_root = _make_book(content_root, "standalone-novel")
+        _make_character(book_root, "alice")
+        _make_chapter(book_root, "01-start", pov="alice", outline="Alice walks.")
+
+        brief = build_chapter_writing_brief(
+            book_root=book_root,
+            book_slug="standalone-novel",
+            chapter_slug="01-start",
+            plugin_root=Path("/tmp"),
+        )
+        assert brief["characters_present"][0]["series_evolution"] is None
+
+    def test_none_when_no_tracker_for_char(self, content_root: Path):
+        book_root = _make_book(
+            content_root,
+            "blood-and-binary-firelight",
+            series="blood-and-binary",
+            series_number=1,
+        )
+        _make_character(book_root, "kael", role="deuteragonist")
+        _make_chapter(book_root, "01-opening", pov="kael", outline="Kael walks.")
+        # Tracker for someone else, not kael.
+        _make_tracker(
+            content_root,
+            "blood-and-binary",
+            "tristan",
+            recurs_in=["B1", "B2"],
+            body="## Evolution per Band\n\n### B1\n- **Ende:** End.\n",
+        )
+        brief = build_chapter_writing_brief(
+            book_root=book_root,
+            book_slug="blood-and-binary-firelight",
+            chapter_slug="01-opening",
+            plugin_root=Path("/tmp"),
+        )
+        # Kael has no matching tracker — None.
+        assert brief["characters_present"][0]["series_evolution"] is None
+
+    def test_none_when_series_dir_missing(self, content_root: Path):
+        # Book declares series but the series dir doesn't exist.
+        book_root = _make_book(
+            content_root,
+            "ghost-book",
+            series="ghost-series",
+            series_number=1,
+        )
+        _make_character(book_root, "ghost")
+        _make_chapter(book_root, "01-start", pov="ghost", outline="Ghost walks.")
+        brief = build_chapter_writing_brief(
+            book_root=book_root,
+            book_slug="ghost-book",
+            chapter_slug="01-start",
+            plugin_root=Path("/tmp"),
+        )
+        assert brief["characters_present"][0]["series_evolution"] is None
+
+    def test_field_always_present_on_each_char(self, content_root: Path):
+        # Even when no series, every char dict has the key — downstream
+        # consumers can rely on its presence.
+        book_root = _make_book(content_root, "standalone")
+        _make_character(book_root, "alice")
+        _make_character(book_root, "bob")
+        _make_chapter(book_root, "01-start", pov="alice", outline="Alice meets Bob.")
+        brief = build_chapter_writing_brief(
+            book_root=book_root,
+            book_slug="standalone",
+            chapter_slug="01-start",
+            plugin_root=Path("/tmp"),
+        )
+        for char in brief["characters_present"]:
+            assert "series_evolution" in char
+            assert char["series_evolution"] is None

--- a/tests/state/test_series_evolution_brief_loader.py
+++ b/tests/state/test_series_evolution_brief_loader.py
@@ -1,0 +1,212 @@
+"""Tests for series-evolution brief helpers (Issue #205, D-3 of #195).
+
+The chapter-writing brief enrichment needs two helpers:
+
+- ``find_tracker_for_book_character`` — reverse lookup via #194's
+  resolver. Given a book-level character slug, find the matching
+  series-tracker file (tracker slug may differ — e.g. ``king-caelan``
+  tracker maps to ``caelan`` book file).
+- ``build_series_evolution_for_character`` — assembles the
+  ``series_evolution`` payload that the brief surfaces to the
+  chapter-writer per present character.
+
+Graceful degrade: returns ``None`` when no series link exists, no
+matching tracker exists, or section parsing yields nothing useful.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.state.loaders.series import (
+    build_series_evolution_for_character,
+    find_tracker_for_book_character,
+)
+
+
+def _make_tracker(
+    chars_dir: Path,
+    slug: str,
+    *,
+    book_slug: str | None = None,
+    name: str | None = None,
+    role: str = "supporting",
+    recurs_in: list[str] | None = None,
+    body: str = "",
+) -> Path:
+    chars_dir.mkdir(parents=True, exist_ok=True)
+    book_slug_line = f"book_slug: {book_slug}\n" if book_slug else ""
+    fm = (
+        "---\n"
+        f"name: {name or slug}\n"
+        f"slug: {slug}\n"
+        f"{book_slug_line}"
+        f"role: {role}\n"
+        "status: Profile\n"
+        f"recurs_in: {recurs_in or ['B1', 'B2']}\n"
+        "tracker_type: thin\n"
+        "---\n\n"
+    )
+    path = chars_dir / f"{slug}.md"
+    path.write_text(fm + body, encoding="utf-8")
+    return path
+
+
+class TestFindTrackerForBookCharacter:
+    def test_finds_tracker_with_matching_slug(self, tmp_path: Path) -> None:
+        chars_dir = tmp_path / "characters"
+        _make_tracker(chars_dir, "kael")
+        result = find_tracker_for_book_character(tmp_path, "kael")
+        assert result is not None
+        assert result.name == "kael.md"
+
+    def test_finds_tracker_via_book_slug_field(self, tmp_path: Path) -> None:
+        # Tracker slug ≠ book slug — the #194 case.
+        chars_dir = tmp_path / "characters"
+        _make_tracker(chars_dir, "king-caelan", book_slug="caelan")
+        result = find_tracker_for_book_character(tmp_path, "caelan")
+        assert result is not None
+        assert result.name == "king-caelan.md"
+
+    def test_returns_none_when_no_match(self, tmp_path: Path) -> None:
+        chars_dir = tmp_path / "characters"
+        _make_tracker(chars_dir, "kael")
+        assert find_tracker_for_book_character(tmp_path, "ghost") is None
+
+    def test_returns_none_when_chars_dir_missing(self, tmp_path: Path) -> None:
+        assert find_tracker_for_book_character(tmp_path, "kael") is None
+
+    def test_first_match_wins_when_duplicates(self, tmp_path: Path) -> None:
+        # Two trackers both resolving to "caelan" — defensively picks
+        # the first (sorted) match. Authors should not produce this case
+        # but the helper must not throw.
+        chars_dir = tmp_path / "characters"
+        _make_tracker(chars_dir, "king-caelan", book_slug="caelan")
+        _make_tracker(chars_dir, "lord-caelan", book_slug="caelan")
+        result = find_tracker_for_book_character(tmp_path, "caelan")
+        assert result is not None
+        assert result.name == "king-caelan.md"  # sorted alphabetically
+
+
+class TestBuildSeriesEvolutionForCharacter:
+    def test_full_payload_with_prev_and_current(self, tmp_path: Path) -> None:
+        chars_dir = tmp_path / "characters"
+        _make_tracker(
+            chars_dir,
+            "kael",
+            recurs_in=["B1", "B2", "B3"],
+            body=(
+                "## Evolution per Band\n\n"
+                "### B1 Firelight\n"
+                "- **Start:** Cabin-Einsiedler.\n"
+                "- **Ende:** Mit Theo zusammen, Sera tot.\n\n"
+                "### B2 Moonrise (geplant)\n"
+                "- Trauernder Bruder.\n"
+                "- Macht-Asymmetrie kippt.\n\n"
+                "## Beziehungen ueber die Bande\n\n"
+                "- **Theo:** Liebe -> Macht-Asymmetrie -> Gleichgewicht.\n"
+                "- **Caelan:** Vater-Konflikt.\n"
+            ),
+        )
+        payload = build_series_evolution_for_character(tmp_path, "kael", current_band="B2", prev_band="B1")
+        assert payload is not None
+        assert payload["tracker_slug"] == "kael"
+        assert payload["current_book_phase"] == "B2 Moonrise (geplant)"
+        assert "Mit Theo zusammen" in payload["previous_book_end"]
+        assert "Trauernder Bruder" in payload["current_book_plan"]
+        assert "**Theo:**" in payload["relationships_evolution"]
+
+    def test_first_book_no_prev_band(self, tmp_path: Path) -> None:
+        # B1 chapters have no previous_book_end — empty string.
+        # current_book_plan priority is geplant > ende > start; for a
+        # B1 tracker with both Start and Ende, the Ende (end-target)
+        # is the more useful "where this is heading" payload.
+        chars_dir = tmp_path / "characters"
+        _make_tracker(
+            chars_dir,
+            "kael",
+            recurs_in=["B1", "B2"],
+            body=(
+                "## Evolution per Band\n\n"
+                "### B1 Firelight\n"
+                "- **Start:** Cabin-Einsiedler.\n"
+                "- **Ende:** Mit Theo zusammen.\n"
+            ),
+        )
+        payload = build_series_evolution_for_character(tmp_path, "kael", current_band="B1", prev_band=None)
+        assert payload is not None
+        assert payload["previous_book_end"] == ""
+        # Ende wins when no geplant — "Mit Theo zusammen" is the target
+        # the chapter is heading toward.
+        assert "Mit Theo zusammen" in payload["current_book_plan"]
+
+    def test_first_book_falls_back_to_start_when_only_start(self, tmp_path: Path) -> None:
+        # B1 with only Start (early drafting before any Ende drafted)
+        # falls back to start text as last resort.
+        chars_dir = tmp_path / "characters"
+        _make_tracker(
+            chars_dir,
+            "kael",
+            body=("## Evolution per Band\n\n### B1 Firelight\n- **Start:** Cabin-Einsiedler.\n"),
+        )
+        payload = build_series_evolution_for_character(tmp_path, "kael", current_band="B1", prev_band=None)
+        assert payload is not None
+        assert "Cabin-Einsiedler" in payload["current_book_plan"]
+
+    def test_resolves_via_book_slug_field(self, tmp_path: Path) -> None:
+        chars_dir = tmp_path / "characters"
+        _make_tracker(
+            chars_dir,
+            "king-caelan",
+            book_slug="caelan",
+            recurs_in=["B1", "B2"],
+            body=("## Evolution per Band\n\n### B1\n- **Ende:** Sera trauert.\n\n### B2 (geplant)\n- B2 plan.\n"),
+        )
+        payload = build_series_evolution_for_character(tmp_path, "caelan", current_band="B2", prev_band="B1")
+        assert payload is not None
+        assert payload["tracker_slug"] == "king-caelan"
+        assert "Sera trauert" in payload["previous_book_end"]
+
+    def test_returns_none_when_no_tracker(self, tmp_path: Path) -> None:
+        chars_dir = tmp_path / "characters"
+        _make_tracker(chars_dir, "kael")
+        # Looking up a char that has no tracker.
+        result = build_series_evolution_for_character(tmp_path, "ghost-char", current_band="B2", prev_band="B1")
+        assert result is None
+
+    def test_returns_none_when_chars_dir_missing(self, tmp_path: Path) -> None:
+        result = build_series_evolution_for_character(tmp_path, "kael", current_band="B2", prev_band="B1")
+        assert result is None
+
+    def test_returns_none_when_band_has_no_data(self, tmp_path: Path) -> None:
+        # Tracker exists but has no Evolution per Band content for
+        # the requested band — graceful degrade.
+        chars_dir = tmp_path / "characters"
+        _make_tracker(chars_dir, "kael", body="## Snapshot\n\nEssence text.\n")
+        result = build_series_evolution_for_character(tmp_path, "kael", current_band="B2", prev_band="B1")
+        assert result is None
+
+    def test_relationships_empty_when_section_missing(self, tmp_path: Path) -> None:
+        chars_dir = tmp_path / "characters"
+        _make_tracker(
+            chars_dir,
+            "kael",
+            body=("## Evolution per Band\n\n### B1\n- **Ende:** End.\n"),
+        )
+        payload = build_series_evolution_for_character(tmp_path, "kael", current_band="B1", prev_band=None)
+        assert payload is not None
+        assert payload["relationships_evolution"] == ""
+
+    def test_falls_back_to_ende_when_geplant_empty(self, tmp_path: Path) -> None:
+        # Edge: current band has Ende but no geplant. current_book_plan
+        # falls back to whatever's there — the tracker's narrative text
+        # for this band, in priority order: geplant > ende > start.
+        chars_dir = tmp_path / "characters"
+        _make_tracker(
+            chars_dir,
+            "kael",
+            body=("## Evolution per Band\n\n### B2\n- **Ende:** B2 end state.\n"),
+        )
+        payload = build_series_evolution_for_character(tmp_path, "kael", current_band="B2", prev_band=None)
+        assert payload is not None
+        assert "B2 end state" in payload["current_book_plan"]

--- a/tools/state/chapter_writing_brief.py
+++ b/tools/state/chapter_writing_brief.py
@@ -35,6 +35,7 @@ from tools.state.chapter_timeline_parser import get_recent_chapter_timelines
 from tools.state.loaders.banlist import collect_banned_phrases
 from tools.state.loaders.chapter_meta import (
     load_book_category,
+    load_series_link,
     load_chapter_meta,
     serialize_chapter_meta,
 )
@@ -53,6 +54,7 @@ from tools.state.loaders.people import (
 from tools.state.loaders.canon_brief import build_canon_brief
 from tools.state.loaders.pov_inventory import extract_pov_inventory
 from tools.state.loaders.pov_state import extract_pov_state
+from tools.state.loaders.series import build_series_evolution_for_character
 from tools.state.loaders.recent_chapters import (
     collect_recent_chapters,
     count_similes,
@@ -291,6 +293,57 @@ def _gather_tactical(
     )
 
 
+def _enrich_with_series_evolution(
+    characters: list[dict[str, Any]],
+    book_root: Path,
+    series_slug: str,
+    series_number: int,
+    *,
+    recorder: _Recorder,
+) -> None:
+    """Mutate ``characters`` to add a ``series_evolution`` field per char.
+
+    Issue #205 (D-3 of Epic #195). When the book is part of a series,
+    each present character gets enriched with the matching tracker's
+    prev-band-Ende, current-band-geplant (or fallback), and
+    relationships-evolution narrative. The field is ``None`` when:
+
+    - The book is not in a series (``series_slug`` empty / ``series_number``
+      zero or negative)
+    - No tracker exists for the character
+    - The current band has no Evolution per Band content
+
+    No-op when the series directory does not exist on disk.
+    """
+    # Always set the field so downstream consumers can rely on its
+    # presence — None signals "no series context here".
+    for char in characters:
+        char.setdefault("series_evolution", None)
+
+    if not series_slug or series_number < 1:
+        return
+
+    # book_root is content_root/projects/{book_slug} — series dir is
+    # content_root/series/{series_slug}.
+    series_dir = book_root.parent.parent / "series" / series_slug
+    if not series_dir.is_dir():
+        return
+
+    current_band = f"B{series_number}"
+    prev_band = f"B{series_number - 1}" if series_number > 1 else None
+
+    for char in characters:
+        slug = char.get("slug")
+        if not slug:
+            continue
+        payload = recorder.run(
+            f"series_evolution.{slug}",
+            lambda s=slug: build_series_evolution_for_character(series_dir, s, current_band, prev_band),
+            None,
+        )
+        char["series_evolution"] = payload
+
+
 def build_chapter_writing_brief(
     *,
     book_root: Path,
@@ -328,11 +381,24 @@ def build_chapter_writing_brief(
     )
     is_memoir = book_category == "memoir"
 
+    series_slug, series_number = recorder.run(
+        "book.series_link",
+        lambda: load_series_link(book_root),
+        ("", 0),
+    )
+
     characters = _gather_characters(
         book_root,
         chapter_readme,
         pov_character,
         is_memoir=is_memoir,
+        recorder=recorder,
+    )
+    _enrich_with_series_evolution(
+        characters,
+        book_root,
+        series_slug,
+        series_number,
         recorder=recorder,
     )
 

--- a/tools/state/loaders/chapter_meta.py
+++ b/tools/state/loaders/chapter_meta.py
@@ -124,9 +124,37 @@ def load_book_category(book_root: Path) -> str:
     return str(book_meta.get("book_category", "fiction"))
 
 
+def load_series_link(book_root: Path) -> tuple[str, int]:
+    """Read ``(series_slug, series_number)`` from the book README frontmatter.
+
+    Returns ``("", 0)`` when the book is not part of a series, when the
+    README is missing, or when the field values are unparseable. Used
+    by the chapter-writing brief enricher (Issue #205, D-3 of #195) to
+    resolve the band ids needed for the ``series_evolution`` payload.
+    """
+    book_readme = book_root / "README.md"
+    if not book_readme.is_file():
+        return "", 0
+    try:
+        text = book_readme.read_text(encoding="utf-8")
+    except OSError:
+        return "", 0
+    if not text:
+        return "", 0
+    book_meta, _ = parse_frontmatter(text)
+    series_slug = str(book_meta.get("series", "") or "")
+    raw_number = book_meta.get("series_number", 0) or 0
+    try:
+        series_number = int(raw_number)
+    except (TypeError, ValueError):
+        series_number = 0
+    return series_slug, series_number
+
+
 __all__ = [
     "load_book_category",
     "load_chapter_meta",
+    "load_series_link",
     "parse_overview_table",
     "serialize_chapter_meta",
 ]

--- a/tools/state/loaders/series.py
+++ b/tools/state/loaders/series.py
@@ -179,6 +179,91 @@ def recurring_chars_for_book(series_dir: Path, band: str) -> list[dict[str, Any]
     return out
 
 
+def find_tracker_for_book_character(series_dir: Path, book_slug: str) -> Path | None:
+    """Reverse lookup: find the series-tracker for a book-level character.
+
+    Used by the chapter-writing brief enrichment (Issue #205, D-3 of
+    Epic #195) to surface series-evolution context per present
+    character. Iterates trackers under ``{series_dir}/characters/`` and
+    returns the first whose resolved book-level slug (via #194's
+    resolver) matches ``book_slug``.
+
+    Returns ``None`` when no tracker matches or when the directory does
+    not exist. The first sorted match wins for defensive determinism if
+    duplicates ever creep in (authors should not produce them).
+    """
+    if not book_slug:
+        return None
+    for path in find_series_trackers(series_dir):
+        tracker = parse_series_tracker(path)
+        if resolve_book_slug_for_series_tracker(tracker) == book_slug:
+            return path
+    return None
+
+
+def build_series_evolution_for_character(
+    series_dir: Path,
+    book_slug: str,
+    current_band: str,
+    prev_band: str | None,
+) -> dict[str, Any] | None:
+    """Assemble the ``series_evolution`` brief field for a character.
+
+    Used by ``chapter_writing_brief`` to enrich each present character
+    with series-tracker context. Returns ``None`` for graceful degrade:
+
+    - When no series-tracker exists for ``book_slug``
+    - When ``current_band`` has no Evolution-per-Band data in the
+      tracker (no Start, Ende, or geplant text)
+
+    Returns a dict with:
+    - ``tracker_slug`` — the tracker file stem (may differ from
+      ``book_slug`` per #194)
+    - ``current_book_phase`` — the band heading title
+      (e.g. ``"B2 Moonrise (geplant)"``)
+    - ``previous_book_end`` — ``prev_band`` Ende text, empty string
+      when no prev band
+    - ``current_book_plan`` — current band's geplant > ende > start
+      (priority order); the most-future-facing text available
+    - ``relationships_evolution`` — raw ``## Beziehungen`` section text
+    """
+    tracker_path = find_tracker_for_book_character(series_dir, book_slug)
+    if tracker_path is None:
+        return None
+
+    tracker = parse_series_tracker(tracker_path)
+    sections = parse_evolution_sections(tracker_path)
+
+    current = sections.get(current_band)
+    if current is None:
+        # Tracker has no Evolution per Band content for this band —
+        # graceful degrade.
+        return None
+
+    # Pick the most-future-facing slot for current_book_plan: the
+    # tracker's geplant (planning text) is the canonical "what's
+    # supposed to happen this book" payload. Fall back to ende when
+    # geplant is empty (e.g. drafted books that filled Ende only), and
+    # finally to start (e.g. early B1 drafting before any Ende exists).
+    current_plan = current.get("geplant") or current.get("ende") or current.get("start") or ""
+    if not current_plan:
+        # No narrative at all for the current band — degrade.
+        return None
+
+    prev_end = ""
+    if prev_band:
+        prev = sections.get(prev_band, {})
+        prev_end = prev.get("ende", "")
+
+    return {
+        "tracker_slug": tracker["slug"],
+        "current_book_phase": current.get("title", current_band),
+        "previous_book_end": prev_end,
+        "current_book_plan": current_plan,
+        "relationships_evolution": parse_relationships_section(tracker_path),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Section parsers — Evolution per Band, Beziehungen, Updates Log
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes **#205** — the **final D of Epic #195** (Series-Level Character Evolution Tracking).

When a book is part of a series, every present character in `characters_present` gets an additional `series_evolution` field populated from the matching series-tracker. The chapter-writer now sees what each character did at the end of the previous book and what's planned for the current book — without manual lookup.

## What ships

```json
"series_evolution": {
    "tracker_slug": "kael",
    "current_book_phase": "B2 Moonrise (geplant)",
    "previous_book_end": "Mit Theo zusammen, Sera tot...",
    "current_book_plan": "Trauernder Bruder, Macht-Asymmetrie kippt...",
    "relationships_evolution": "- **Theo:** Liebe → ..."
}
```

Or `null` for graceful degrade — book not in series, no matching tracker, or current band has no Evolution-per-Band content.

## Layered build

- **Layer 1a**: two helpers in `tools/state/loaders/series.py`:
  - `find_tracker_for_book_character(series_dir, book_slug)` — reverse lookup via #194's resolver
  - `build_series_evolution_for_character(...)` — assembles the brief field with priority `geplant > ende > start` for `current_book_plan`
- **Layer 1b**: `load_series_link(book_root)` in `loaders/chapter_meta.py` — returns `(series_slug, series_number)` from book README frontmatter
- **Layer 2**: `_enrich_with_series_evolution` in `chapter_writing_brief.py` — mutates each char payload to add `series_evolution` after `_gather_characters`

## Schema decisions locked

1. **Field always present**: every character dict has the `series_evolution` key (value is `null` when no series context).
2. **Priority `geplant > ende > start`** for `current_book_plan` — the most-future-facing slot wins.
3. **`previous_book_end` is empty string for B1** (no prev band).
4. **Brief-size impact**: ~1k-1.5k chars added on a 5-char present cast — well within the post-#170 char budget.

## Sanity-check on real data

Validated against `blood-and-binary` series:
- `kael`, `theo-wilkons`, `viktor` — full payload returned
- `caelan`, `miriel` — `null` returned (their trackers `king-caelan.md` / `queen-miriel.md` need manual `book_slug:` backfill — out-of-scope per #194)

## Test coverage

- **14** series_evolution loader tests (lookup, payload assembly, fallback priority, graceful degrade, #194 resolver bridge)
- **7** brief integration tests (book-in-series enrichment, B2 prev_book_end, field-always-present, no-series degrade)
- **Total: 1707/1707 passing**, `ruff check .` clean.

## Test plan

- [x] `pytest tests/state/test_series_evolution_brief_loader.py -q` → 14/14
- [x] `pytest tests/state/test_chapter_writing_brief_series_evolution.py -q` → 7/7
- [x] `pytest tests/ -q` → 1707/1707
- [x] `ruff check .` → clean
- [x] `ruff format --check` on touched files → clean
- [x] Manual sanity-check against real `blood-and-binary` trackers (3/5 hit, 2/5 graceful degrade as expected)

Closes #205
**Completes #195** — all four sub-tasks shipped: #194 (resolver) + #200 (D-1 harvest) + #196 (dumb-copy) + #203 (D-2 bootstrap) + #205 (D-3 brief)

🤖 Generated with [Claude Code](https://claude.com/claude-code)