### PR TITLE
fix(brief): tighten POV facts char-budget to keep brief under MCP cap

### DIFF
--- a/tests/state/test_canon_brief.py
+++ b/tests/state/test_canon_brief.py
@@ -983,8 +983,11 @@ class TestPovFactsCharBudget:
 
         serialized = _json.dumps(brief, ensure_ascii=False)
         # Pre-#170 with POV set: ~105k chars (per Issue #170 reproduction).
-        # Post-#170 target: well under 60k.
-        assert len(serialized) < 60_000, (
+        # Post-#170 with 30k pov-budget: ~55-60k on dense books — still
+        # crossed the real MCP output cap (~50k) on act-3 chapters.
+        # Follow-up tightened pov-budget to 15k; brief now stays well
+        # under 45k even with the densest synthetic canon log.
+        assert len(serialized) < 45_000, (
             f"brief is {len(serialized)} chars — exceeds size budget. "
-            f"pov_relevant_facts trim is likely missing (#170)."
+            f"pov_relevant_facts trim is likely missing or too generous (#170)."
         )

--- a/tools/state/chapter_writing_brief.py
+++ b/tools/state/chapter_writing_brief.py
@@ -63,13 +63,22 @@ from tools.state.loaders.recent_chapters import (
 from tools.timeline_anchor import get_story_anchor
 
 
-# Issue #170: char-budget for pov_relevant_facts in the inline canon_brief.
-# Books with narrative-style canon logs (~200 chars/bullet) accumulate
-# 75k+ chars of pov-matching facts on Act 3, pushing the brief past the
-# tool-result token limit. 30k leaves comfortable headroom for the rest
-# of the brief (banned_phrases ~7k, rules ~3k, callbacks ~3k, ...) inside
-# a ~100k tool-result limit.
-POV_FACTS_CHAR_BUDGET = 30_000
+# Issue #170 + follow-up: char-budget for pov_relevant_facts in the inline
+# canon_brief. Books with narrative-style canon logs (~200 chars/bullet)
+# accumulate 75k+ chars of pov-matching facts on Act 3.
+#
+# The original 30k value assumed a ~100k tool-result limit, but the real
+# MCP output cap is closer to ~50k chars. With the rest of the brief
+# routinely at ~28-30k (characters_present ~8k, banned_phrases ~8k,
+# rules ~3k, callbacks ~3k, character_state ~2k, plus framing), 30k
+# pushed total briefs to 55-60k and triggered tool-result overflow on
+# act-3 chapters of `blood-and-binary-firelight`.
+#
+# 15k keeps total brief comfortably under 45k. Keeps ~25-30 most-recent
+# facts (recency-sorted), which is the high-risk continuity zone for
+# the chapter being written; older facts are stable and redundantly
+# covered by recent_chapter_endings + characters_present + callbacks.
+POV_FACTS_CHAR_BUDGET = 15_000
 
 _CHAPTER_NUM_RE = re.compile(r"^(?P<num>\d{1,3})")
 


### PR DESCRIPTION
## Summary

- Lower `POV_FACTS_CHAR_BUDGET` from 30k to 15k — original assumed ~100k MCP output limit, but the real cap is ~50k.
- Brief on act-3 chapters of `blood-and-binary-firelight` was hitting 60,853 chars and triggering tool-result overflow; the `chapter_writing_brief` MCP call returned an error and the chapter-writer skill had to fall back to fragile `jq` extraction.
- Tighten the budget-test cap from 60k to 45k so future regressions can't silently re-introduce the overflow.

## Why 15k is enough (vs. losing context)

The trim is **recency-sorted**, so 15k still preserves the 25-30 most-recent canonical facts — exactly the high-risk continuity zone for the chapter being written. Older facts are stable and redundantly covered by:

- `recent_chapter_endings` — what just happened
- `recent_chapter_timelines` — last few chapters' temporal markers
- `pov_character_state` + `pov_character_inventory` — current POV state
- `callbacks_in_register` — open promises and threads
- `characters_present` — current character snapshots

Empirical math from the live brief on `blood-and-binary-firelight` ch29:

| Field | chars |
|---|---|
| pov_relevant_facts (capped at 30k) | 29,846 |
| characters_present | 8,082 |
| banned_phrases | 7,864 |
| rules_to_honor | 3,325 |
| callbacks_in_register | 2,673 |
| pov_character_state | 1,827 |
| canon_brief.changed_facts | 1,700 |
| other framing | ~1,500 |
| **total** | **~57k → tool-result overflow** |

With 15k cap: total ~42k → comfortable headroom under the ~50k MCP cap.

## Test plan

- [x] `tests/state/test_canon_brief.py::TestPovFactsCharBudget` — all 4 budget tests pass with new 15k value
- [x] Full suite: 1707 passed
- [ ] Smoke after merge: re-run `get_chapter_writing_brief` on `blood-and-binary-firelight/29-the-name` — must return without overflow error