### PR TITLE
Fix author Don't extractor blocking recommended phrases (#217)

### DIFF
--- a/tests/analysis/test_author_rules_scanner.py
+++ b/tests/analysis/test_author_rules_scanner.py
@@ -136,6 +136,124 @@ class TestExtractPatternsFromAuthorDont:
 
 
 # ---------------------------------------------------------------------------
+# _extract_patterns_from_author_dont — recommendation-marker boundary (Issue #217)
+# ---------------------------------------------------------------------------
+
+
+class TestRecommendationMarkerBoundary:
+    """A bullet may carry both bad italic examples (to ban) and good italic
+    examples (the recommended replacement). The extractor must stop italic /
+    quoted extraction at the first 'recommendation marker' (``Render``,
+    ``Instead:``, ``→``, ...) so positive examples never end up as banned
+    patterns. Backticks always extract regardless of position because they
+    encode explicit ban intent.
+    """
+
+    def test_render_marker_blocks_following_italics(self):
+        rule = (
+            "**Never personify rooms** — *The room received it.* / "
+            "*the silence held it.* Render the impact through a named body: "
+            "*Caelan's eyes did not move*, *Viktor's hand stilled*."
+        )
+        labels = [lab for lab, _ in _extract_patterns_from_author_dont(rule)]
+        assert "The room received it." in labels
+        assert "the silence held it." in labels
+        assert "Caelan's eyes did not move" not in labels
+        assert "Viktor's hand stilled" not in labels
+
+    def test_instead_colon_marker_blocks_following_italics(self):
+        rule = (
+            "**Never use** — *bad phrase one.* / *bad phrase two.* "
+            "Instead: *good phrase one.* / *good phrase two.*"
+        )
+        labels = [lab for lab, _ in _extract_patterns_from_author_dont(rule)]
+        assert "bad phrase one." in labels
+        assert "bad phrase two." in labels
+        assert "good phrase one." not in labels
+        assert "good phrase two." not in labels
+
+    def test_arrow_marker_blocks_following_italics(self):
+        rule = "**Never use** — *the old way.* → *the new way.*"
+        labels = [lab for lab, _ in _extract_patterns_from_author_dont(rule)]
+        assert "the old way." in labels
+        assert "the new way." not in labels
+
+    def test_replace_marker_blocks_following_italics(self):
+        rule = "**Avoid** — *clunky phrasing.* Replace with *clean phrasing.*"
+        labels = [lab for lab, _ in _extract_patterns_from_author_dont(rule)]
+        assert "clunky phrasing." in labels
+        assert "clean phrasing." not in labels
+
+    def test_rather_colon_marker_blocks_following_italics(self):
+        rule = "**Never** — *flat note.* Rather: *living note.*"
+        labels = [lab for lab, _ in _extract_patterns_from_author_dont(rule)]
+        assert "flat note." in labels
+        assert "living note." not in labels
+
+    def test_use_instead_marker_blocks_following_italics(self):
+        rule = "**Don't use** — *passive voice example.* Use instead *active phrasing.*"
+        labels = [lab for lab, _ in _extract_patterns_from_author_dont(rule)]
+        assert "passive voice example." in labels
+        assert "active phrasing." not in labels
+
+    def test_marker_is_case_insensitive(self):
+        rule = "**Never use** — *bad one.* INSTEAD: *good one.*"
+        labels = [lab for lab, _ in _extract_patterns_from_author_dont(rule)]
+        assert "bad one." in labels
+        assert "good one." not in labels
+
+    def test_no_marker_extracts_all_italics_status_quo(self):
+        """Bullet without any recommendation marker — behavior unchanged from
+        the pre-#217 status quo: every italic phrase under a ban cue is
+        extracted. Recurring Tics rules and old-style bullets must keep working.
+        """
+        rule = "**Never use** — *first banned.* / *second banned.* / *third banned.*"
+        labels = [lab for lab, _ in _extract_patterns_from_author_dont(rule)]
+        assert "first banned." in labels
+        assert "second banned." in labels
+        assert "third banned." in labels
+
+    def test_backtick_after_marker_still_extracts(self):
+        """Backticks encode explicit ban intent. They must extract regardless
+        of where they sit relative to the recommendation marker — backticks
+        after ``Instead:`` are still ban patterns (the author chose to escalate
+        them to backticks).
+        """
+        rule = (
+            "**Never** — *bad italic.* Instead: *good italic.* "
+            "Also banned: `\\bexplicit regex\\b`"
+        )
+        patterns = _extract_patterns_from_author_dont(rule)
+        labels = [lab for lab, _ in patterns]
+        assert "bad italic." in labels
+        assert "good italic." not in labels
+        assert any("explicit regex" in lab for lab in labels)
+
+    def test_quoted_phrase_after_marker_is_not_extracted(self):
+        """Quoted phrases follow the same gate as italics — they are bannable
+        examples only when they sit inside the ban window.
+        """
+        rule = (
+            'Never use the phrase "bad quoted phrase" in narration. '
+            'Instead: "good quoted phrase" works better.'
+        )
+        labels = [lab for lab, _ in _extract_patterns_from_author_dont(rule)]
+        assert "bad quoted phrase" in labels
+        assert "good quoted phrase" not in labels
+
+    def test_marker_inside_word_does_not_trigger(self):
+        """``Render`` must match as a word, not as a substring inside another
+        word. A bullet body containing e.g. ``rerendered`` must not be
+        misread as a recommendation marker.
+        """
+        rule = "**Never use** — *render method calls.* / *rerendered output.*"
+        labels = [lab for lab, _ in _extract_patterns_from_author_dont(rule)]
+        # No real recommendation marker — both italics extract.
+        assert "render method calls." in labels
+        assert "rerendered output." in labels
+
+
+# ---------------------------------------------------------------------------
 # _read_author_rules
 # ---------------------------------------------------------------------------
 

--- a/tools/analysis/manuscript/rules.py
+++ b/tools/analysis/manuscript/rules.py
@@ -63,6 +63,31 @@ _BAN_CUE_RE = re.compile(
 # italics as narrative examples, not bannable patterns.
 _ITALIC_CONTENT_RE = re.compile(r"(?<![\*\w])\*([^*\n]{3,})\*(?![\*\w])")
 
+# Recommendation markers (#217) — words/symbols that signal "what follows is
+# the recommended replacement, not the banned example". The author-Don't
+# extractor caps the italic/quoted extraction window at the first occurrence
+# of any of these markers so positive examples never end up as banned
+# patterns. Backticks are unaffected — they encode explicit ban intent.
+#
+# Word-boundary markers use ``\b`` to avoid false positives inside other
+# words (``rerendered`` must not trigger the ``Render`` marker). The arrow
+# ``→`` is matched literally; colon-suffixed forms allow optional whitespace
+# before the colon.
+_RECOMMENDATION_MARKER_RE = re.compile(
+    r"(?:"
+    r"\bRender\b"
+    r"|\bReplace\b"
+    r"|\bUse\s+instead\b"
+    r"|\bInstead\s*:"
+    r"|\bAllowed\s*:"
+    r"|\bBetter\s*:"
+    r"|\bRewrite\s+as\b"
+    r"|\bRather\s*:"
+    r"|→"
+    r")",
+    re.IGNORECASE,
+)
+
 # Heading + section markers for the author-profile ``## Writing Discoveries
 # / ### Don'ts`` subsection. Apostrophe variants (ASCII, curly, fancy) are
 # all accepted so the harvest helper's slightly different output never
@@ -300,19 +325,63 @@ def _extract_patterns_from_author_dont(rule: str) -> list[tuple[str, re.Pattern[
     Extraction rules:
 
     1. Backticks: always extracted (literal or regex, same heuristic as
-       :func:`_extract_patterns_from_rule`).
+       :func:`_extract_patterns_from_rule`). Position-independent — they
+       encode explicit ban intent.
     2. Double-quoted phrases: extracted only when the rule carries a ban
-       cue (``Never``, ``Avoid``, ``Don't use``, ...).
-    3. Italic phrases (single ``*foo*``, not bold ``**foo**``): extracted
-       only when the rule carries a ban cue. Bold spans are skipped via
-       ``(?<![\\*\\w])`` / ``(?![\\*\\w])`` look-arounds.
+       cue (``Never``, ``Avoid``, ``Don't use``, ...) AND only from inside
+       the "ban window" — the slice before the first recommendation marker
+       (``Render``, ``Instead:``, ``→``, ...). Phrases after the marker are
+       positive examples, not bans (#217).
+    3. Italic phrases (single ``*foo*``, not bold ``**foo**``): same gate
+       as quoted phrases. Bold spans are skipped via ``(?<![\\*\\w])`` /
+       ``(?![\\*\\w])`` look-arounds.
     """
-    patterns = _extract_patterns_from_rule(rule)
+    patterns: list[tuple[str, re.Pattern[str]]] = []
+    seen: set[str] = set()
+
+    def _add(label: str, compiled: re.Pattern[str]) -> None:
+        key = compiled.pattern.lower()
+        if key in seen:
+            return
+        seen.add(key)
+        patterns.append((label, compiled))
+
+    # Backticks: extracted from the full rule regardless of marker position.
+    for m in _BACKTICK_CONTENT_RE.finditer(rule):
+        raw = m.group(1)
+        inner = raw.strip()
+        if len(inner) < 2:
+            continue
+        if any(c in _REGEX_HINT_CHARS for c in inner):
+            try:
+                _add(inner, re.compile(raw, re.IGNORECASE))
+            except re.error:
+                continue
+        else:
+            _add(inner, re.compile(re.escape(raw), re.IGNORECASE))
+
     if not _BAN_CUE_RE.search(rule):
         return patterns
 
-    seen: set[str] = {p.pattern.lower() for _, p in patterns}
-    for m in _ITALIC_CONTENT_RE.finditer(rule):
+    # Italic and quoted extraction is bounded by the first recommendation
+    # marker (#217). Everything from start-of-rule up to (but not including)
+    # the marker is the ban window; phrases after the marker are positive
+    # examples and must not be extracted as banned patterns.
+    #
+    # Markers inside ``*...*`` italic spans are part of the example, not
+    # a boundary signal — mask italic content with spaces before searching
+    # so positions stay aligned but the marker regex cannot land inside.
+    masked = _ITALIC_CONTENT_RE.sub(lambda m: " " * len(m.group(0)), rule)
+    marker = _RECOMMENDATION_MARKER_RE.search(masked)
+    ban_window = rule[: marker.start()] if marker else rule
+
+    for m in _QUOTED_CONTENT_RE.finditer(ban_window):
+        raw = m.group(1).strip()
+        if len(raw) < 6 or raw.lower() in STOP_WORDS:
+            continue
+        _add(raw, re.compile(re.escape(raw), re.IGNORECASE))
+
+    for m in _ITALIC_CONTENT_RE.finditer(ban_window):
         raw = m.group(1).strip()
         # Italic example sentences in author Don'ts typically end with a period
         # (full sentence). Trailing sentence punctuation is decorative, not part
@@ -321,12 +390,7 @@ def _extract_patterns_from_author_dont(rule: str) -> list[tuple[str, re.Pattern[
         cleaned = raw.rstrip(".,!?;:").strip()
         if len(cleaned) < 3:
             continue
-        compiled = re.compile(re.escape(cleaned), re.IGNORECASE)
-        key = compiled.pattern.lower()
-        if key in seen:
-            continue
-        seen.add(key)
-        patterns.append((raw, compiled))
+        _add(raw, re.compile(re.escape(cleaned), re.IGNORECASE))
     return patterns
 
 


### PR DESCRIPTION
## Summary

- `_extract_patterns_from_author_dont` now caps italic/quoted extraction at the first **recommendation marker** (`Render`, `Replace`, `Use instead`, `Instead:`, `Allowed:`, `Better:`, `Rewrite as`, `→`, `Rather:`). Phrases after the marker are positive examples and stay out of the banned-pattern set.
- Backticks still extract everywhere — they encode explicit ban intent and are unaffected by the new window.
- Italic spans are masked before marker search so a banned phrase like `*render method calls.*` cannot trigger the `Render` marker from inside its own body.

## Why

The current extractor reads every italic/quoted phrase under a ban cue as a banned pattern, including the "Bad — Render — Good" recommendation phrases that follow the bad examples in author Don'ts. The room-as-receiver Don't extracted `Caelan's eyes did not move`, `Viktor's hand stilled`, `no one breathed` — the exact phrases the bullet recommends. Hook and manuscript-checker both inherited the bug.

## Test plan

- [x] `pytest tests/analysis/test_author_rules_scanner.py` — 32 passed (11 new boundary tests + 21 existing)
- [x] `pytest tests/` — 1781 passed, no regressions
- [x] `ruff check tools/analysis/manuscript/rules.py tests/analysis/test_author_rules_scanner.py` — All checks passed
- [x] Real-world smoke (Ethan Cole profile): synthetic "Bad — Render — Good" bullet extracts only the bad italics; `Caelan's eyes did not move`, `Viktor's hand stilled`, `no one breathed` are gated out
- [x] Status-quo bullets without a marker keep extracting every italic — Recurring-Tic-style rules continue to work

## Out of scope

- Linting at the **write** side (`write_author_discovery`) — covered separately in #218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)