### PR TITLE
Extract Recurring-Tic patterns from bullet body (#212)

### DIFF
--- a/tests/tools/test_banlist_loader.py
+++ b/tests/tools/test_banlist_loader.py
@@ -172,6 +172,149 @@ class TestLoadAuthorWritingDiscoveries:
 
 
 # ---------------------------------------------------------------------------
+# load_author_writing_discoveries — body extraction (Issue #212)
+# ---------------------------------------------------------------------------
+#
+# Recurring Tic bullets whose bold title is the rule name (no embedded quotes)
+# but whose scannable example phrases live in the body prose were silently
+# un-scannable: the fallback path used the bold-title text as the pattern,
+# which never matches English chapter prose when the title is a German rule
+# name.
+
+
+class TestLoadAuthorWritingDiscoveriesBodyExtraction:
+    def test_extracts_body_quoted_phrases_when_title_has_no_quote(self, tmp_path):
+        """German rule-name title with English example phrases in body —
+        the very case from the issue (Ethan Cole's Abstrakte
+        Körperteil-Anthropomorphisierung tic).
+        """
+        body = (
+            '### Recurring Tics\n\n'
+            '- **Abstrakte Körperteil-Anthropomorphisierung** — '
+            'Körperteil als Subjekt + vages Prädikat: '
+            '"his hands were having a conversation with each other", '
+            '"his breath was not where he had left it", '
+            '"his stomach kept failing to file". Ersetzen mit konkreter '
+            'Empfindung.\n'
+        )
+        _make_profile(tmp_path, "ethan-cole", body)
+
+        patterns = load_author_writing_discoveries("ethan-cole", storyforge_home=tmp_path)
+        labels = [p.label for p in patterns]
+        assert "his hands were having a conversation with each other" in labels
+        assert "his breath was not where he had left it" in labels
+        assert "his stomach kept failing to file" in labels
+        # The German title MUST NOT be promoted to a pattern when body quotes exist.
+        assert "Abstrakte Körperteil-Anthropomorphisierung" not in labels
+
+    def test_extracts_body_backtick_regex_when_title_has_no_quote(self, tmp_path):
+        """Backtick patterns inside a Recurring Tic body load as regex/literal
+        (same heuristic as `_extract_patterns_from_author_dont`)."""
+        body = (
+            '### Recurring Tics\n\n'
+            '- **Body part as subject anti-pattern** — '
+            'Körperteil-Subjekt + vages Prädikat: '
+            '`\\b(his|her) (hand|hands|breath|stomach) (was|were) '
+            '(having|not|kept)\\b`\n'
+        )
+        _make_profile(tmp_path, "ethan-cole", body)
+
+        patterns = load_author_writing_discoveries("ethan-cole", storyforge_home=tmp_path)
+        assert patterns, "expected at least one pattern from body backtick"
+        # The compiled pattern must actually match the canonical example.
+        any_match = any(
+            p.pattern.search("his hands were having a conversation")
+            for p in patterns
+        )
+        assert any_match, "body-regex pattern must match canonical instance"
+
+    def test_title_quotes_take_priority_over_body_quotes(self, tmp_path):
+        """When the bold title already carries a quoted phrase, body quotes
+        are NOT merged in — preserves current behavior for tics that already
+        work."""
+        body = (
+            '### Recurring Tics\n\n'
+            '- **Vague-noun "thing" als Fallback** — concretize on sight. '
+            'Example: "the thing happened" should become specific.\n'
+        )
+        _make_profile(tmp_path, "ethan-cole", body)
+
+        patterns = load_author_writing_discoveries("ethan-cole", storyforge_home=tmp_path)
+        labels = [p.label for p in patterns]
+        assert "thing" in labels
+        # Body quote MUST NOT pollute the pattern set when the title already
+        # carries the canonical scannable phrase.
+        assert "the thing happened" not in labels
+
+    def test_falls_back_to_title_text_when_nothing_extractable(self, tmp_path):
+        """English bold-title tics with no body quotes/backticks must still
+        fall back to the bold-title text as the pattern (regression for the
+        ``**Opened his mouth. Closed it.**`` style)."""
+        body = (
+            '### Recurring Tics\n\n'
+            '- **Opened his mouth. Closed it.** — vary or skip. '
+            '_(emerged from firelight, 2026-05)_\n'
+        )
+        _make_profile(tmp_path, "ethan-cole", body)
+        patterns = load_author_writing_discoveries("ethan-cole", storyforge_home=tmp_path)
+        labels = [p.label for p in patterns]
+        assert "Opened his mouth. Closed it." in labels
+
+    def test_body_pattern_matches_chapter_prose(self, tmp_path):
+        """The compiled pattern from a body quoted phrase must actually
+        match the original line that would appear in a chapter draft."""
+        body = (
+            '### Recurring Tics\n\n'
+            '- **Hand-as-decider** — Hand als grammatisches Subjekt: '
+            '"the hand had been deciding something". Ersetzen mit konkretem '
+            'Subjekt.\n'
+        )
+        _make_profile(tmp_path, "ethan-cole", body)
+        patterns = load_author_writing_discoveries("ethan-cole", storyforge_home=tmp_path)
+        decider = next(
+            (p for p in patterns if "deciding" in p.label.lower()),
+            None,
+        )
+        assert decider is not None, "expected the body-quoted phrase to be loaded"
+        assert decider.pattern.search(
+            "the hand had been deciding something the rest of Caelan had not yet caught up with"
+        ) is not None
+
+    def test_skips_short_body_quotes(self, tmp_path):
+        """Single-character or near-single-char body quotes are noise — must
+        not pollute the pattern set (and must not block the title-text
+        fallback)."""
+        body = (
+            '### Recurring Tics\n\n'
+            '- **Stylistic German Rule Name** — example: "a" is too short.\n'
+        )
+        _make_profile(tmp_path, "ethan-cole", body)
+        patterns = load_author_writing_discoveries("ethan-cole", storyforge_home=tmp_path)
+        labels = [p.label for p in patterns]
+        # The short body quote must be ignored.
+        assert "a" not in labels
+        # And with nothing else extractable, the title text becomes the
+        # fallback pattern (consistent with current behavior).
+        assert "Stylistic German Rule Name" in labels
+
+    def test_multiple_bullets_independent_extraction(self, tmp_path):
+        """Two bullets, one title-quoted, one body-quoted — both must yield
+        their respective patterns without cross-contamination."""
+        body = (
+            '### Recurring Tics\n\n'
+            '- **Vague-noun "thing" als Fallback** — concretize.\n'
+            '- **German Rule Name** — example: "concrete English phrase". '
+            'rest of prose.\n'
+        )
+        _make_profile(tmp_path, "ethan-cole", body)
+        patterns = load_author_writing_discoveries("ethan-cole", storyforge_home=tmp_path)
+        labels = [p.label for p in patterns]
+        assert "thing" in labels
+        assert "concrete English phrase" in labels
+        assert "German Rule Name" not in labels
+
+
+# ---------------------------------------------------------------------------
 # author_slug_from_book
 # ---------------------------------------------------------------------------
 

--- a/tools/banlist_loader.py
+++ b/tools/banlist_loader.py
@@ -214,6 +214,49 @@ _RECURRING_TICS_HEADER_RE = re.compile(
 _BOLD_TITLE_BULLET_RE = re.compile(r"^-\s+(\*\*[^*]+\*\*)", re.MULTILINE)
 _DOUBLE_QUOTE_RE = re.compile(r'[“„”"]([^“„”"]{2,})[”"]')
 
+# Recurring-Tic bullet with separately-captured title + body (#212). Body
+# spans from the title's closing ``**`` to the next bullet, blank line, or
+# end-of-section.
+_RECURRING_TIC_BULLET_RE = re.compile(
+    r"^-\s+(?P<title>\*\*[^*]+\*\*)\s*(?P<body>.*?)(?=^-\s+|^\s*$|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+
+# Backtick-wrapped content inside a bullet body — same shape as the book-rule
+# extractor uses. Regex hint characters trigger compile-as-regex; otherwise
+# the inner text is escaped and matched literally.
+_BACKTICK_CONTENT_RE = re.compile(r"`([^`\n]+)`")
+_REGEX_HINT_CHARS = set("|()[]\\^$?+*{}")
+
+
+def _title_inner_quotes(title: str) -> list[str]:
+    """Return only the double-quoted phrases embedded in a bold title.
+
+    Unlike :func:`_extract_phrases_from_bold_title`, this helper does NOT
+    fall back to the title text when no quotes are present — it returns
+    ``[]``. Callers use the empty result as the signal that body-level
+    extraction should kick in (#212).
+    """
+    if not title:
+        return []
+    bold_match = re.match(r"\*\*(?P<inner>.+)\*\*\s*$", title.strip())
+    if not bold_match:
+        return []
+    inner = bold_match.group("inner").strip()
+    if not inner:
+        return []
+    quoted = [m.group(1).strip() for m in _DOUBLE_QUOTE_RE.finditer(inner)]
+    quoted = [q for q in quoted if len(q) >= 2]
+    seen: set[str] = set()
+    out: list[str] = []
+    for q in quoted:
+        key = q.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(q)
+    return out
+
 
 def _extract_phrases_from_bold_title(title: str) -> list[str]:
     """Extract scannable phrases from a Writing-Discoveries bullet's bold title.
@@ -231,28 +274,75 @@ def _extract_phrases_from_bold_title(title: str) -> list[str]:
     """
     if not title:
         return []
+    quoted = _title_inner_quotes(title)
+    if quoted:
+        return quoted
     cleaned = title.strip()
     bold_match = re.match(r"\*\*(?P<inner>.+)\*\*\s*$", cleaned)
     if not bold_match:
         return []
     inner = bold_match.group("inner").strip()
-    if not inner:
+    return [inner] if len(inner) >= 2 else []
+
+
+def _extract_patterns_from_tic_body(body: str) -> list[tuple[str, re.Pattern[str] | None]]:
+    """Extract scannable patterns from a Recurring-Tic bullet body (#212).
+
+    Walks the body prose AFTER the bold title and returns one entry per
+    pattern. Two sources, in order:
+
+    1. **Backtick patterns** — same heuristic as
+       :func:`tools.analysis.manuscript.rules._extract_patterns_from_rule`.
+       If the content carries regex metacharacters it compiles as a regex;
+       otherwise literal substring.
+    2. **Double-quoted phrases** of at least 3 characters. Both ASCII
+       (``"x"``) and German typographic (``„x"``) quote pairs are accepted.
+
+    Each tuple is ``(label, compiled_pattern_or_None)``:
+
+    - When ``compiled_pattern`` is not ``None``, the caller should use it
+      directly (backtick path — preserves regex intent).
+    - When it is ``None``, the caller compiles via
+      :func:`_build_discovery_pattern` (quoted-phrase path — gets the
+      same inflection-aware compilation as title quotes).
+
+    Returns a deduplicated, order-preserving list. Empty body returns ``[]``.
+    """
+    if not body:
         return []
 
-    quoted = [m.group(1).strip() for m in _DOUBLE_QUOTE_RE.finditer(inner)]
-    quoted = [q for q in quoted if len(q) >= 2]
-    if quoted:
-        # Dedup while preserving order.
-        seen: set[str] = set()
-        out: list[str] = []
-        for q in quoted:
-            key = q.lower()
-            if key in seen:
+    out: list[tuple[str, re.Pattern[str] | None]] = []
+    seen: set[str] = set()
+
+    for m in _BACKTICK_CONTENT_RE.finditer(body):
+        raw = m.group(1)
+        inner = raw.strip()
+        if len(inner) < 2:
+            continue
+        key = inner.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        if any(c in _REGEX_HINT_CHARS for c in inner):
+            try:
+                compiled = re.compile(raw, re.IGNORECASE)
+            except re.error:
                 continue
-            seen.add(key)
-            out.append(q)
-        return out
-    return [inner] if len(inner) >= 2 else []
+            out.append((inner, compiled))
+        else:
+            out.append((inner, re.compile(re.escape(raw), re.IGNORECASE)))
+
+    for m in _DOUBLE_QUOTE_RE.finditer(body):
+        phrase = m.group(1).strip()
+        if len(phrase) < 3:
+            continue
+        key = phrase.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append((phrase, None))
+
+    return out
 
 
 def _author_profile_path(author_slug: str, storyforge_home: Path | None = None) -> Path:
@@ -300,27 +390,61 @@ def load_author_writing_discoveries(
 
     patterns: list[BannedPattern] = []
     seen: set[str] = set()
+    source = "author profile (## Writing Discoveries / Recurring Tics)"
+    reason = "recurring tic promoted from a finished book"
 
-    for bullet_match in _BOLD_TITLE_BULLET_RE.finditer(tics_body):
-        bold_title = bullet_match.group(1)
-        for phrase in _extract_phrases_from_bold_title(bold_title):
-            cleaned = _strip_parenthetical(phrase).strip()
-            if len(cleaned) < 2:
-                continue
-            key = cleaned.lower()
-            if key in seen:
-                continue
-            seen.add(key)
-            pattern = _build_discovery_pattern(cleaned)
-            patterns.append(
-                BannedPattern(
-                    label=cleaned,
-                    pattern=pattern,
-                    severity=SEVERITY_BLOCK,
-                    source="author profile (## Writing Discoveries / Recurring Tics)",
-                    reason="recurring tic promoted from a finished book",
-                )
+    def _emit(label: str, compiled: re.Pattern[str]) -> None:
+        cleaned = _strip_parenthetical(label).strip()
+        if len(cleaned) < 2:
+            return
+        key = cleaned.lower()
+        if key in seen:
+            return
+        seen.add(key)
+        patterns.append(
+            BannedPattern(
+                label=cleaned,
+                pattern=compiled,
+                severity=SEVERITY_BLOCK,
+                source=source,
+                reason=reason,
             )
+        )
+
+    for bullet_match in _RECURRING_TIC_BULLET_RE.finditer(tics_body):
+        bold_title = bullet_match.group("title")
+        body_text = bullet_match.group("body") or ""
+
+        # Priority 1: quoted phrases inside the bold title (primary path —
+        # unchanged from the pre-#212 behavior so existing tics keep working).
+        title_quotes = _title_inner_quotes(bold_title)
+        if title_quotes:
+            for phrase in title_quotes:
+                _emit(phrase, _build_discovery_pattern(_strip_parenthetical(phrase).strip()))
+            continue
+
+        # Priority 2: extract patterns from the bullet body — backticks and
+        # double-quoted phrases. Backticks ship their own compiled regex;
+        # quoted phrases get the same inflection-aware compilation as title
+        # quotes.
+        body_patterns = _extract_patterns_from_tic_body(body_text)
+        if body_patterns:
+            for label, compiled in body_patterns:
+                if compiled is None:
+                    cleaned = _strip_parenthetical(label).strip()
+                    if len(cleaned) < 2:
+                        continue
+                    _emit(label, _build_discovery_pattern(cleaned))
+                else:
+                    _emit(label, compiled)
+            continue
+
+        # Priority 3: fall back to the bold-title text as the pattern. This
+        # is the only path for English-prose bullets like
+        # ``**Opened his mouth. Closed it.**`` that have neither title quotes
+        # nor body patterns.
+        for phrase in _extract_phrases_from_bold_title(bold_title):
+            _emit(phrase, _build_discovery_pattern(_strip_parenthetical(phrase).strip()))
     return patterns
 
 


### PR DESCRIPTION
## Summary

- `load_author_writing_discoveries` now reads scannable patterns from the **bullet body** when the bold title carries no double-quoted phrase. Previously the fallback compiled the title text itself as the pattern — useless when the title is a German rule name (e.g. `**Abstrakte Körperteil-Anthropomorphisierung**`) and the example phrases live in the body prose.
- New extraction sources inside the body: double-quoted phrases (compiled with the same inflection-aware `_build_discovery_pattern`) and backtick patterns (regex or literal, mirroring `_extract_patterns_from_author_dont`).
- Priority order: title quotes → body quotes + body backticks → title-text fallback. Existing tics with title quotes keep working unchanged; English-bold-title tics like `**Opened his mouth. Closed it.**` still fall back to the title.
- `_title_inner_quotes` is a new no-fallback helper the loader uses to detect "has scannable title quotes". `_extract_phrases_from_bold_title` keeps its current contract.

## Why

`~/.storyforge/authors/ethan-cole/profile.md` ships tics like:

```markdown
- **Abstrakte Körperteil-Anthropomorphisierung** — Körperteil als Subjekt + vages Prädikat: "his hands were having a conversation with each other", "his breath was not where he had left it", "his stomach kept failing to file". Ersetzen mit konkreter Empfindung.
```

Before this PR, the loader compiled `Abstrakte Körperteil-Anthropomorphisierung` as the pattern (no match against English prose) and ignored the three quoted English example phrases. The hook had no scannable pattern, so violations slipped through.

After this PR, Ethan Cole's profile yields 10 Recurring-Tic patterns (up from 4) — the previously-invisible English body phrases now scan.

## Test plan

- [x] `pytest tests/tools/test_banlist_loader.py` — 40 passed (7 new body-extraction tests + 33 existing)
- [x] `pytest tests/` — 1788 passed, no regressions
- [x] `ruff check tools/banlist_loader.py tests/tools/test_banlist_loader.py` — clean
- [x] Real-world smoke: Ethan Cole's German-titled body-quoted tics now load as scannable patterns (`his hands were having a conversation with each other`, etc.)
- [x] Regression: bullets with title quotes still extract only the title-quoted phrases (no body pollution)
- [x] Regression: English-bold-title bullets with no body quotes still fall back to the title text (`**Opened his mouth. Closed it.**` works as before)

## Out of scope

- Linting at the write side (`write_author_discovery` for Recurring Tics) — covered separately in #218 (`bold_title_unscannable` warning code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)