### PR TITLE
Lint author profile writes via write_author_discovery (#218)

### DIFF
--- a/servers/storyforge-server/routers/authors.py
+++ b/servers/storyforge-server/routers/authors.py
@@ -11,6 +11,7 @@ import json
 import re
 from datetime import date
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -277,6 +278,7 @@ def write_author_discovery(
     text: str,
     book_slug: str,
     year_month: str = "",
+    validate: bool = True,
 ) -> str:
     """Append a discovery to ``profile.md`` ``## Writing Discoveries`` (Issue #151).
 
@@ -293,10 +295,16 @@ def write_author_discovery(
             Origin tag is appended automatically.
         book_slug: Book the discovery emerged from.
         year_month: ``YYYY-MM`` stamp; defaults to today's year-month.
+        validate: When ``True`` (default), the response also carries
+            ``warnings`` and ``extracted_patterns`` fields populated by
+            :func:`tools.author.discovery_lint.lint_author_discovery`
+            (Issue #218). Set ``False`` to skip lint and emit the legacy
+            response shape.
 
-    Returns ``{written, already_present, path, message}`` on success or
-    ``{error: ...}`` on failure (unknown author, invalid section, missing
-    profile, missing Writing Discoveries section).
+    Returns ``{written, already_present, path, message}`` on success — with
+    ``warnings`` and ``extracted_patterns`` appended when ``validate=True``
+    — or ``{error: ...}`` on failure (unknown author, invalid section,
+    missing profile, missing Writing Discoveries section).
     """
     if not year_month:
         year_month = date.today().strftime("%Y-%m")
@@ -309,6 +317,14 @@ def write_author_discovery(
 
     if not profile_path.is_file():
         return json.dumps({"error": f"Author '{author_slug}' not found at {profile_path}"})
+
+    lint_result: dict[str, Any] | None = None
+    if validate:
+        try:
+            from tools.author.discovery_lint import lint_author_discovery
+            lint_result = lint_author_discovery(section, text)
+        except ValueError as exc:
+            return json.dumps({"error": str(exc)})
 
     try:
         result = write_discovery(
@@ -329,25 +345,27 @@ def write_author_discovery(
     _cache.invalidate()
 
     if isinstance(result, WriteResult):
-        return json.dumps(
-            {
-                "written": True,
-                "already_present": False,
-                "path": str(result.path),
-                "message": result.message,
-            }
-        )
-    if isinstance(result, AlreadyPresent):
-        return json.dumps(
-            {
-                "written": False,
-                "already_present": True,
-                "path": str(result.path),
-                "message": result.message,
-            }
-        )
-    # Unreachable, but keep mypy happy and the JSON contract well-formed.
-    return json.dumps({"error": "unexpected write result"})
+        payload: dict[str, Any] = {
+            "written": True,
+            "already_present": False,
+            "path": str(result.path),
+            "message": result.message,
+        }
+    elif isinstance(result, AlreadyPresent):
+        payload = {
+            "written": False,
+            "already_present": True,
+            "path": str(result.path),
+            "message": result.message,
+        }
+    else:
+        # Unreachable, but keep mypy happy and the JSON contract well-formed.
+        return json.dumps({"error": "unexpected write result"})
+
+    if lint_result is not None:
+        payload["warnings"] = lint_result["warnings"]
+        payload["extracted_patterns"] = lint_result["extracted_patterns"]
+    return json.dumps(payload)
 
 
 @mcp.tool()

--- a/skills/harvest-author-rules/SKILL.md
+++ b/skills/harvest-author-rules/SKILL.md
@@ -152,12 +152,13 @@ phrase without a session restart.
 ### Promote (style_principle / donts → profile.md ## Writing Discoveries)
 
 ```python
-mcp__storyforge-mcp__write_author_discovery(
+result = mcp__storyforge-mcp__write_author_discovery(
     author_slug=author_slug,
     section=candidate.target_section,  # "recurring_tics" | "style_principles" | "donts"
     text=user_edited_text or build_discovery_text(candidate),
     book_slug=book_slug,
     year_month=current_year_month(),   # optional — defaults to today's YYYY-MM
+    validate=True,                      # default — emits warnings + extracted_patterns
 )
 ```
 
@@ -173,6 +174,51 @@ Build the discovery text with a bold title + dash + short rationale, e.g.:
 ```
 **"math" as analytical metaphor** — cut on sight unless POV explicitly demands.
 ```
+
+#### Surface lint warnings after the write (Issue #218)
+
+The MCP response carries `warnings` and `extracted_patterns` whenever
+`validate=True` (the default). Lint never blocks the write — but the
+warnings often reveal a write that the manuscript-checker scanner won't
+enforce the way the user expects. Always surface them to the user before
+moving to the cleanup step:
+
+```
+Wrote discovery to author profile.
+
+Extracted scan patterns ({N}):
+  - "The room received it."
+  - "the silence held it."
+
+Warnings ({M}):
+  - mixed_positive_negative_italics
+      Italic phrases on both sides of a recommendation marker.
+      Italics after the marker silently do NOT extract as banned patterns.
+      → Verify the post-marker italics are recommendations, not bans.
+
+  - bold_title_unscannable
+      Bold title carries no quoted phrase, the body has no quotes/backticks,
+      and the title text contains non-ASCII characters — the title-text
+      fallback compiles a non-English rule name that won't match English prose.
+      → Add a double-quoted example phrase to the title, or put scannable
+        phrases in the body.
+
+The bullet was written as-is. Want to edit and rewrite?
+```
+
+If the user picks **Edit and rewrite**, restart the promote step with the
+revised text and a fresh `write_author_discovery(validate=True)` call.
+Otherwise continue to Cleanup.
+
+Lint code reference:
+
+| Section | Code | What it means |
+|---------|------|---------------|
+| donts | `mixed_positive_negative_italics` | Italics on both sides of a recommendation marker; post-marker italics are silently NOT extracted |
+| donts | `mixed_positive_negative_quotes` | Multiple double-quoted phrases under a ban cue — both extract as bans |
+| donts | `scanner_extracts_nothing` | Ban cue without any backtick / quoted / italic — scanner sees nothing |
+| donts, recurring_tics, style_principles | `bracket_placeholder` | Backtick body has `[word]` — that's a character class, not `\w+` |
+| recurring_tics | `bold_title_unscannable` | German title + no body pattern — title-text fallback won't match English |
 
 ### Cleanup (after promote)
 

--- a/tests/author/test_discovery_lint.py
+++ b/tests/author/test_discovery_lint.py
@@ -1,0 +1,247 @@
+"""Tests for ``tools.author.discovery_lint`` (Issue #218).
+
+The author-discovery linter surfaces shapes the manuscript-checker scanner
+will silently mis-extract from author-profile ``## Writing Discoveries``
+write paths. It mirrors ``tools.claudemd.rules_lint.lint_rule_text`` but
+applies section-aware semantics: italics in author Don'ts are bannable
+(unlike book rules where they are narrative examples), Recurring Tics
+fall back to title text when the bold title has no quote, and Style
+Principles are intentionally not machine-scanned.
+
+The linter must produce a uniform ``{"warnings": [...], "extracted_patterns": [...]}``
+contract so the ``write_author_discovery`` MCP response stays consistent
+with ``append_book_rule``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.author.discovery_lint import (
+    LINT_BOLD_TITLE_UNSCANNABLE,
+    LINT_BRACKET_PLACEHOLDER,
+    LINT_MIXED_POSITIVE_NEGATIVE_ITALICS,
+    LINT_MIXED_POSITIVE_NEGATIVE_QUOTES,
+    LINT_SCANNER_EXTRACTS_NOTHING,
+    lint_author_discovery,
+)
+
+
+def _codes(result: dict) -> list[str]:
+    return [w["code"] for w in result["warnings"]]
+
+
+# ---------------------------------------------------------------------------
+# Don'ts section
+# ---------------------------------------------------------------------------
+
+
+class TestLintDonts:
+    """Author Don'ts encode bannable phrases in italics + backticks + quotes."""
+
+    def test_clean_donts_no_warnings(self):
+        text = '**Never use rooms as receivers** — *The room received it.*'
+        result = lint_author_discovery("donts", text)
+        assert result["warnings"] == []
+        labels = [p["label"] for p in result["extracted_patterns"]]
+        assert "The room received it." in labels
+
+    def test_mixed_italics_with_recommendation_marker_warns(self):
+        """Bullet has ban cue + ≥2 italics + a recommendation marker.
+        After #217 the post-marker italics silently do NOT extract — the
+        user should know so they can verify intent."""
+        text = (
+            "**Never personify rooms** — *The room received it.* / "
+            "*the silence held it.* Render the impact through a named body: "
+            "*Caelan's eyes did not move*, *Viktor's hand stilled*."
+        )
+        result = lint_author_discovery("donts", text)
+        assert LINT_MIXED_POSITIVE_NEGATIVE_ITALICS in _codes(result)
+        # The bad italics still extract.
+        labels = [p["label"] for p in result["extracted_patterns"]]
+        assert "The room received it." in labels
+        # The post-marker italics do NOT extract.
+        assert "Caelan's eyes did not move" not in labels
+
+    def test_mixed_italics_without_marker_no_warning(self):
+        """No marker → all italics are treated as bans, no asymmetry to flag."""
+        text = (
+            "**Never use** — *first banned.* / *second banned.* / *third banned.*"
+        )
+        result = lint_author_discovery("donts", text)
+        assert LINT_MIXED_POSITIVE_NEGATIVE_ITALICS not in _codes(result)
+
+    def test_mixed_quoted_phrases_warns(self):
+        """Multiple double-quoted phrases under a ban cue: every quote
+        extracts as a banned pattern (unless a recommendation marker gates
+        the later ones)."""
+        text = 'Never use the phrase "totally landed" or "really landed" in narration.'
+        result = lint_author_discovery("donts", text)
+        assert LINT_MIXED_POSITIVE_NEGATIVE_QUOTES in _codes(result)
+
+    def test_single_quoted_phrase_no_warning(self):
+        text = 'Never use the phrase "totally landed" in narration.'
+        result = lint_author_discovery("donts", text)
+        assert LINT_MIXED_POSITIVE_NEGATIVE_QUOTES not in _codes(result)
+
+    def test_scanner_extracts_nothing_warns(self):
+        """Ban cue but no backtick, no quoted phrase, no italic — scanner
+        will see no pattern at all."""
+        text = "**Never use weather metaphors** — they are clichéd."
+        result = lint_author_discovery("donts", text)
+        assert LINT_SCANNER_EXTRACTS_NOTHING in _codes(result)
+        assert result["extracted_patterns"] == []
+
+    def test_scanner_extracts_nothing_silent_without_ban_cue(self):
+        text = "**Style note** — italics are emphasis only here."
+        result = lint_author_discovery("donts", text)
+        assert LINT_SCANNER_EXTRACTS_NOTHING not in _codes(result)
+
+    def test_bracket_placeholder_in_backtick_warns(self):
+        text = "**Never use** — `\\bnever [verb] the [noun]\\b`"
+        result = lint_author_discovery("donts", text)
+        assert LINT_BRACKET_PLACEHOLDER in _codes(result)
+
+    def test_clean_backtick_no_warning(self):
+        text = "**Never personify rooms** — `\\bthe (room|silence) (received|held)\\b`"
+        result = lint_author_discovery("donts", text)
+        assert LINT_BRACKET_PLACEHOLDER not in _codes(result)
+        assert result["extracted_patterns"], "backtick regex must surface as pattern"
+
+
+# ---------------------------------------------------------------------------
+# Recurring Tics section
+# ---------------------------------------------------------------------------
+
+
+class TestLintRecurringTics:
+    """Recurring Tics encode the scannable phrase in the bold title quote,
+    optionally fall back to body extraction or title text."""
+
+    def test_quoted_title_no_warning(self):
+        text = '**Vague-noun "thing" als Fallback** — concretize on sight.'
+        result = lint_author_discovery("recurring_tics", text)
+        assert result["warnings"] == []
+        labels = [p["label"] for p in result["extracted_patterns"]]
+        assert "thing" in labels
+
+    def test_body_quoted_phrase_no_warning(self):
+        """German rule-name title + English body phrases is the new
+        canonical post-#212 pattern — must not warn."""
+        text = (
+            '**Abstrakte Körperteil-Anthropomorphisierung** — '
+            'Körperteil als Subjekt + vages Prädikat: '
+            '"his hands were having a conversation with each other".'
+        )
+        result = lint_author_discovery("recurring_tics", text)
+        assert LINT_BOLD_TITLE_UNSCANNABLE not in _codes(result)
+        labels = [p["label"] for p in result["extracted_patterns"]]
+        assert "his hands were having a conversation with each other" in labels
+
+    def test_german_title_no_body_pattern_warns(self):
+        """German rule-name title with NO body quotes/backticks → title-text
+        fallback fires and won't match English chapter prose."""
+        text = (
+            '**Abstrakte Körperteil-Anthropomorphisierung** — '
+            'Körperteil als Subjekt mit vagem Prädikat. Konkretisieren.'
+        )
+        result = lint_author_discovery("recurring_tics", text)
+        assert LINT_BOLD_TITLE_UNSCANNABLE in _codes(result)
+
+    def test_english_title_no_pattern_no_warning(self):
+        """English bold-title bullets that ARE the pattern (e.g.
+        ``**Opened his mouth. Closed it.**``) must NOT warn — the title-text
+        fallback is intentional and works."""
+        text = "**Opened his mouth. Closed it.** — vary or skip."
+        result = lint_author_discovery("recurring_tics", text)
+        assert LINT_BOLD_TITLE_UNSCANNABLE not in _codes(result)
+
+    def test_bracket_placeholder_warns(self):
+        text = "**Body part anti-pattern** — `\\b[bodypart] (was|were)\\b`"
+        result = lint_author_discovery("recurring_tics", text)
+        assert LINT_BRACKET_PLACEHOLDER in _codes(result)
+
+
+# ---------------------------------------------------------------------------
+# Style Principles section
+# ---------------------------------------------------------------------------
+
+
+class TestLintStylePrinciples:
+    """Style Principles are not machine-scanned — the linter must not warn
+    about scanner gaps. Bracket-placeholder typos still get flagged."""
+
+    def test_clean_style_principle_no_warnings(self):
+        text = "**POV-Wissens-Integrität** — kein POV-Charakter macht Fachbehauptungen."
+        result = lint_author_discovery("style_principles", text)
+        assert result["warnings"] == []
+
+    def test_style_principle_with_ban_cue_does_not_warn_about_scanner_gap(self):
+        """Even with a ban cue, style principles aren't scanned — no
+        ``scanner_extracts_nothing`` warning."""
+        text = "**No purple prose** — avoid lush descriptions."
+        result = lint_author_discovery("style_principles", text)
+        assert LINT_SCANNER_EXTRACTS_NOTHING not in _codes(result)
+        assert LINT_MIXED_POSITIVE_NEGATIVE_ITALICS not in _codes(result)
+        assert LINT_MIXED_POSITIVE_NEGATIVE_QUOTES not in _codes(result)
+        assert LINT_BOLD_TITLE_UNSCANNABLE not in _codes(result)
+
+    def test_style_principle_bracket_placeholder_still_warns(self):
+        text = "**Avoid filler** — see `[noun] of [noun]` for placeholder typo."
+        result = lint_author_discovery("style_principles", text)
+        assert LINT_BRACKET_PLACEHOLDER in _codes(result)
+
+
+# ---------------------------------------------------------------------------
+# Contract / shape
+# ---------------------------------------------------------------------------
+
+
+class TestLintContract:
+    def test_returns_warnings_and_patterns_keys(self):
+        result = lint_author_discovery("donts", "**clean** — `\\bfoo\\b`")
+        assert "warnings" in result
+        assert "extracted_patterns" in result
+        assert isinstance(result["warnings"], list)
+        assert isinstance(result["extracted_patterns"], list)
+
+    def test_warning_shape(self):
+        text = "**Never use weather** — clichéd."
+        result = lint_author_discovery("donts", text)
+        assert result["warnings"]
+        w = result["warnings"][0]
+        assert "code" in w
+        assert "message" in w
+        assert "hint" in w
+        assert isinstance(w["code"], str)
+        assert isinstance(w["message"], str)
+        assert isinstance(w["hint"], str)
+
+    def test_extracted_pattern_shape(self):
+        text = "**Never use** — `\\bfoo\\b`"
+        result = lint_author_discovery("donts", text)
+        assert result["extracted_patterns"]
+        p = result["extracted_patterns"][0]
+        assert "label" in p
+        assert "pattern" in p
+        assert "is_regex" in p
+        assert isinstance(p["is_regex"], bool)
+
+    def test_unknown_section_raises(self):
+        with pytest.raises(ValueError):
+            lint_author_discovery("invalid_section", "anything")
+
+    def test_extracted_patterns_match_author_dont_extractor(self):
+        """Patterns reported by the lint MUST be the same as what
+        ``_extract_patterns_from_author_dont`` would extract — same source
+        of truth so the displayed list matches reality."""
+        from tools.analysis.manuscript.rules import _extract_patterns_from_author_dont
+
+        text = (
+            "**Never personify** — *The room received it.* "
+            "Render: *Caelan's eyes did not move.*"
+        )
+        result = lint_author_discovery("donts", text)
+        ground_truth = [label for label, _ in _extract_patterns_from_author_dont(text)]
+        lint_labels = [p["label"] for p in result["extracted_patterns"]]
+        assert sorted(lint_labels) == sorted(ground_truth)

--- a/tests/server/test_author_write_tools.py
+++ b/tests/server/test_author_write_tools.py
@@ -142,6 +142,125 @@ class TestWriteAuthorDiscovery:
 
 
 # ---------------------------------------------------------------------------
+# write_author_discovery validate=True (Issue #218)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteAuthorDiscoveryValidate:
+    """The MCP response must carry ``warnings`` + ``extracted_patterns``
+    fields when ``validate=True`` (the default), and must omit them when
+    ``validate=False``.
+
+    The lint runs BEFORE the write — but a lint warning never blocks the
+    write; the response surfaces both so the skill can show the warnings
+    to the user and the write still goes through.
+    """
+
+    def test_validate_true_attaches_warnings_and_patterns(self, author_setup):
+        result = json.loads(
+            write_author_discovery(
+                author_slug="ethan-cole",
+                section="donts",
+                text='**Never use rooms** — *The room received it.*',
+                book_slug="firelight",
+                year_month="2026-05",
+            )
+        )
+        assert result["written"] is True
+        assert "warnings" in result
+        assert "extracted_patterns" in result
+        labels = [p["label"] for p in result["extracted_patterns"]]
+        assert "The room received it." in labels
+
+    def test_validate_true_surfaces_lint_warning(self, author_setup):
+        """Don't with ban cue + no scannable pattern → scanner_extracts_nothing."""
+        result = json.loads(
+            write_author_discovery(
+                author_slug="ethan-cole",
+                section="donts",
+                text='**Never use weather openings** — clichéd.',
+                book_slug="firelight",
+                year_month="2026-05",
+            )
+        )
+        # Write still succeeded — lint is observability, not a block.
+        assert result["written"] is True
+        codes = [w["code"] for w in result["warnings"]]
+        assert "scanner_extracts_nothing" in codes
+
+    def test_validate_false_omits_warnings_and_patterns(self, author_setup):
+        result = json.loads(
+            write_author_discovery(
+                author_slug="ethan-cole",
+                section="donts",
+                text='**Never use rooms** — *The room received it.*',
+                book_slug="firelight",
+                year_month="2026-05",
+                validate=False,
+            )
+        )
+        assert result["written"] is True
+        assert "warnings" not in result
+        assert "extracted_patterns" not in result
+
+    def test_validate_true_works_for_already_present(self, author_setup):
+        """Idempotent already-present writes must still attach lint data so
+        the skill can surface warnings on retry."""
+        text = '**Never use rooms** — *The room received it.*'
+        write_author_discovery(
+            author_slug="ethan-cole",
+            section="donts",
+            text=text,
+            book_slug="firelight",
+            year_month="2026-05",
+        )
+        result = json.loads(
+            write_author_discovery(
+                author_slug="ethan-cole",
+                section="donts",
+                text=text,
+                book_slug="firelight",
+                year_month="2026-05",
+            )
+        )
+        assert result["already_present"] is True
+        assert "warnings" in result
+        assert "extracted_patterns" in result
+
+    def test_validate_true_recurring_tics_german_title_warns(self, author_setup):
+        result = json.loads(
+            write_author_discovery(
+                author_slug="ethan-cole",
+                section="recurring_tics",
+                text=(
+                    "**Abstrakte Körperteil-Anthropomorphisierung** — "
+                    "Körperteil als Subjekt + vages Prädikat. Konkretisieren."
+                ),
+                book_slug="firelight",
+                year_month="2026-05",
+            )
+        )
+        codes = [w["code"] for w in result["warnings"]]
+        assert "bold_title_unscannable" in codes
+
+    def test_validate_true_style_principles_no_scanner_warnings(self, author_setup):
+        """Style Principles are not machine-scanned — lint must NOT emit
+        scanner_extracts_nothing even when there's a ban cue."""
+        result = json.loads(
+            write_author_discovery(
+                author_slug="ethan-cole",
+                section="style_principles",
+                text='**No purple prose** — avoid lush descriptions.',
+                book_slug="firelight",
+                year_month="2026-05",
+            )
+        )
+        codes = [w["code"] for w in result["warnings"]]
+        assert "scanner_extracts_nothing" not in codes
+        assert result["extracted_patterns"] == []
+
+
+# ---------------------------------------------------------------------------
 # write_author_banned_phrase
 # ---------------------------------------------------------------------------
 

--- a/tools/author/discovery_lint.py
+++ b/tools/author/discovery_lint.py
@@ -1,0 +1,354 @@
+"""Section-aware lint for author-profile ``## Writing Discoveries`` writes
+(Issue #218).
+
+Mirrors :func:`tools.claudemd.rules_lint.lint_rule_text` but applies the
+inverted semantics of author Don'ts (italics with a ban cue ARE the
+canonical encoding of bannable phrases) and the title-fallback semantics
+of Recurring Tics (bold title may carry the scannable phrase or fall back
+to body extraction / title text).
+
+Section-specific behavior:
+
+- ``donts`` — four lint codes mirror the book-rule lint:
+  ``mixed_positive_negative_italics`` (new — italics on both sides of a
+  recommendation marker), ``mixed_positive_negative_quotes`` (reused),
+  ``scanner_extracts_nothing`` (reused), ``bracket_placeholder`` (reused).
+  ``extracted_patterns`` is the output of
+  :func:`tools.analysis.manuscript.rules._extract_patterns_from_author_dont`
+  so the displayed list matches what the scanner will actually use.
+- ``recurring_tics`` — ``bold_title_unscannable`` (new — non-English title
+  with no body pattern) and ``bracket_placeholder``. ``extracted_patterns``
+  mirrors the Recurring-Tic loader's title → body → title-text fallback
+  cascade.
+- ``style_principles`` — only ``bracket_placeholder``. Style Principles
+  are intentionally not machine-scanned; the lint must not warn about
+  scanner gaps. ``extracted_patterns`` is always empty.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from tools.analysis.manuscript.rules import (
+    _BAN_CUE_RE,
+    _ITALIC_CONTENT_RE,
+    _RECOMMENDATION_MARKER_RE,
+    _extract_patterns_from_author_dont,
+)
+from tools.banlist_loader import (
+    _build_discovery_pattern,
+    _extract_patterns_from_tic_body,
+    _extract_phrases_from_bold_title,
+    _strip_parenthetical,
+    _title_inner_quotes,
+)
+
+# ---------------------------------------------------------------------------
+# Lint codes
+# ---------------------------------------------------------------------------
+
+LINT_BRACKET_PLACEHOLDER = "bracket_placeholder"
+LINT_MIXED_POSITIVE_NEGATIVE_ITALICS = "mixed_positive_negative_italics"
+LINT_MIXED_POSITIVE_NEGATIVE_QUOTES = "mixed_positive_negative_quotes"
+LINT_SCANNER_EXTRACTS_NOTHING = "scanner_extracts_nothing"
+LINT_BOLD_TITLE_UNSCANNABLE = "bold_title_unscannable"
+
+VALID_SECTIONS: tuple[str, ...] = ("recurring_tics", "style_principles", "donts")
+
+# ---------------------------------------------------------------------------
+# Internal patterns
+# ---------------------------------------------------------------------------
+
+_BACKTICK_CONTENT_RE = re.compile(r"`([^`\n]+)`")
+_QUOTED_CONTENT_RE = re.compile(r'"([^"\n]{3,})"')
+_WORDLIKE_BRACKET_RE = re.compile(r"\[([a-z]{2,12})\]", re.IGNORECASE)
+
+# Bold-title detection — same shape the loader uses.
+_BOLD_TITLE_RE = re.compile(r"^-?\s*\*\*(?P<inner>[^*]+)\*\*", re.MULTILINE)
+_NON_ASCII_RE = re.compile(r"[^\x00-\x7F]")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def lint_author_discovery(section: str, text: str) -> dict[str, Any]:
+    """Run section-appropriate lint checks on a single discovery entry.
+
+    Args:
+        section: One of ``recurring_tics``, ``style_principles``, ``donts``.
+        text: The full bullet body as the harvest skill would write it,
+            e.g. ``**Never use rooms** — *The room received it.*``.
+
+    Returns:
+        ``{"warnings": [...], "extracted_patterns": [...]}`` matching the
+        contract of :func:`tools.claudemd.rules_lint.lint_rule_text`. Each
+        warning has shape ``{"code": str, "message": str, "hint": str}``;
+        each extracted pattern has shape
+        ``{"label": str, "pattern": str, "is_regex": bool}``.
+
+    Raises:
+        ValueError: ``section`` is not in :data:`VALID_SECTIONS`.
+    """
+    if section not in VALID_SECTIONS:
+        raise ValueError(f"Invalid section: {section!r}. Valid: {VALID_SECTIONS}")
+
+    if section == "donts":
+        return _lint_donts(text)
+    if section == "recurring_tics":
+        return _lint_recurring_tics(text)
+    return _lint_style_principles(text)
+
+
+# ---------------------------------------------------------------------------
+# Don'ts
+# ---------------------------------------------------------------------------
+
+
+def _lint_donts(text: str) -> dict[str, Any]:
+    warnings: list[dict[str, str]] = []
+    has_ban_cue = bool(_BAN_CUE_RE.search(text))
+
+    warnings.extend(_check_bracket_placeholders(text))
+
+    if has_ban_cue:
+        # Multiple italic phrases AND a recommendation marker: after #217 the
+        # post-marker italics silently do NOT extract. Flag the asymmetry so
+        # the user can verify which italics were meant as bans.
+        italics = [m.group(1) for m in _ITALIC_CONTENT_RE.finditer(text)]
+        marker = _RECOMMENDATION_MARKER_RE.search(
+            _ITALIC_CONTENT_RE.sub(lambda m: " " * len(m.group(0)), text)
+        )
+        if len(italics) >= 2 and marker is not None:
+            # Confirm at least one italic on each side of the marker so the
+            # warning is actually meaningful (not just two italics that all
+            # land before the marker).
+            italic_positions = [m.start() for m in _ITALIC_CONTENT_RE.finditer(text)]
+            before = sum(1 for p in italic_positions if p < marker.start())
+            after = len(italic_positions) - before
+            if before >= 1 and after >= 1:
+                warnings.append(
+                    {
+                        "code": LINT_MIXED_POSITIVE_NEGATIVE_ITALICS,
+                        "message": (
+                            "Italic phrases on both sides of a recommendation "
+                            "marker. Italics after the marker silently do "
+                            "NOT extract as banned patterns — only italics "
+                            "before the marker scan."
+                        ),
+                        "hint": (
+                            "Verify the post-marker italics are recommendations, "
+                            "not additional bans. If they ARE bans, move them "
+                            "before the marker or use backticks (`...`) which "
+                            "extract regardless of position."
+                        ),
+                    }
+                )
+
+        quoted = _QUOTED_CONTENT_RE.findall(text)
+        if len(quoted) >= 2:
+            warnings.append(
+                {
+                    "code": LINT_MIXED_POSITIVE_NEGATIVE_QUOTES,
+                    "message": (
+                        "Multiple double-quoted phrases combined with a ban "
+                        "cue: every quoted phrase before any recommendation "
+                        "marker is extracted as a banned pattern."
+                    ),
+                    "hint": (
+                        "If one of these is a positive rewrite example, move "
+                        "it after a recommendation marker (Render / Instead: "
+                        "/ →) or upgrade banned phrases to backticks (`...`)."
+                    ),
+                }
+            )
+
+    extracted = _extracted_patterns_from_donts(text)
+
+    if has_ban_cue and not extracted:
+        warnings.append(
+            {
+                "code": LINT_SCANNER_EXTRACTS_NOTHING,
+                "message": (
+                    "Bullet has a ban cue but no extractable pattern — the "
+                    "scanner will see nothing and the Don't won't enforce."
+                ),
+                "hint": (
+                    "Add the banned phrase in italics (*phrase.*), double-"
+                    "quotes (\"phrase\"), or — for explicit regex — backticks "
+                    "(`\\bphrase\\b`) so the scanner can extract it."
+                ),
+            }
+        )
+
+    return {"warnings": warnings, "extracted_patterns": extracted}
+
+
+def _extracted_patterns_from_donts(text: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for label, compiled in _extract_patterns_from_author_dont(text):
+        is_regex = compiled.pattern != re.escape(label)
+        out.append(
+            {"label": label, "pattern": compiled.pattern, "is_regex": is_regex}
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Recurring Tics
+# ---------------------------------------------------------------------------
+
+
+def _lint_recurring_tics(text: str) -> dict[str, Any]:
+    warnings: list[dict[str, str]] = []
+    warnings.extend(_check_bracket_placeholders(text))
+
+    bold = _BOLD_TITLE_RE.search(text)
+    title_text = bold.group("inner").strip() if bold else ""
+    bold_title = f"**{title_text}**" if title_text else ""
+
+    title_quotes = _title_inner_quotes(bold_title) if bold_title else []
+    # Body = everything after the bold title (and the dash/whitespace).
+    body = text[bold.end():] if bold else text
+    body_patterns = _extract_patterns_from_tic_body(body)
+
+    has_title_quote = bool(title_quotes)
+    has_body_pattern = bool(body_patterns)
+
+    if not has_title_quote and not has_body_pattern and title_text and _NON_ASCII_RE.search(title_text):
+        warnings.append(
+            {
+                "code": LINT_BOLD_TITLE_UNSCANNABLE,
+                "message": (
+                    "Bold title carries no quoted phrase, the bullet body "
+                    "has no quotes or backticks, and the title text contains "
+                    "non-ASCII characters — the title-text fallback will "
+                    "compile a non-English rule name as the scan pattern, "
+                    "which never matches English chapter prose."
+                ),
+                "hint": (
+                    "Add a double-quoted example phrase to the bold title "
+                    '(e.g. **Vague-noun "thing"**) or put the bannable '
+                    "phrases in the bullet body as double-quoted phrases or "
+                    "a backtick regex. Or move the rule to ### Don'ts as a "
+                    "backtick-regex Don't."
+                ),
+            }
+        )
+
+    extracted = _extracted_patterns_from_recurring_tics(
+        bold_title=bold_title,
+        body=body,
+        title_quotes=title_quotes,
+        body_patterns=body_patterns,
+    )
+    return {"warnings": warnings, "extracted_patterns": extracted}
+
+
+def _extracted_patterns_from_recurring_tics(
+    *,
+    bold_title: str,
+    body: str,
+    title_quotes: list[str],
+    body_patterns: list[tuple[str, re.Pattern[str] | None]],
+) -> list[dict[str, Any]]:
+    """Mirror the title → body → title-text-fallback cascade of
+    :func:`tools.banlist_loader.load_author_writing_discoveries` so the
+    lint reports exactly what the loader will extract."""
+    del body  # cascade is decided by the bool flags; body content reused via body_patterns
+    seen: set[str] = set()
+    out: list[dict[str, Any]] = []
+
+    def _emit_compiled(label: str, compiled: re.Pattern[str]) -> None:
+        cleaned = _strip_parenthetical(label).strip()
+        if len(cleaned) < 2:
+            return
+        key = cleaned.lower()
+        if key in seen:
+            return
+        seen.add(key)
+        is_regex = compiled.pattern != re.escape(cleaned)
+        out.append(
+            {"label": cleaned, "pattern": compiled.pattern, "is_regex": is_regex}
+        )
+
+    if title_quotes:
+        for phrase in title_quotes:
+            cleaned = _strip_parenthetical(phrase).strip()
+            _emit_compiled(phrase, _build_discovery_pattern(cleaned))
+        return out
+
+    if body_patterns:
+        for label, compiled in body_patterns:
+            if compiled is None:
+                cleaned = _strip_parenthetical(label).strip()
+                if len(cleaned) < 2:
+                    continue
+                _emit_compiled(label, _build_discovery_pattern(cleaned))
+            else:
+                _emit_compiled(label, compiled)
+        return out
+
+    if bold_title:
+        for phrase in _extract_phrases_from_bold_title(bold_title):
+            cleaned = _strip_parenthetical(phrase).strip()
+            _emit_compiled(phrase, _build_discovery_pattern(cleaned))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Style Principles
+# ---------------------------------------------------------------------------
+
+
+def _lint_style_principles(text: str) -> dict[str, Any]:
+    """Style Principles are intentionally not machine-scanned — only flag
+    bracket-placeholder typos."""
+    return {
+        "warnings": _check_bracket_placeholders(text),
+        "extracted_patterns": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Shared checks
+# ---------------------------------------------------------------------------
+
+
+def _check_bracket_placeholders(text: str) -> list[dict[str, str]]:
+    warnings: list[dict[str, str]] = []
+    for m in _BACKTICK_CONTENT_RE.finditer(text):
+        body = m.group(1)
+        for bracket in _WORDLIKE_BRACKET_RE.finditer(body):
+            placeholder = bracket.group(0)
+            warnings.append(
+                {
+                    "code": LINT_BRACKET_PLACEHOLDER,
+                    "message": (
+                        f"Backtick body contains {placeholder}, which is a "
+                        f"character class — the scanner reads it literally, "
+                        f"not as a placeholder."
+                    ),
+                    "hint": (
+                        "If you meant a placeholder, use \\w+ inside the "
+                        "backticks; if you meant a literal character "
+                        "class, the rule will only match those exact "
+                        "letters."
+                    ),
+                }
+            )
+            break  # one warning per backtick body is enough
+    return warnings
+
+
+__all__ = [
+    "LINT_BOLD_TITLE_UNSCANNABLE",
+    "LINT_BRACKET_PLACEHOLDER",
+    "LINT_MIXED_POSITIVE_NEGATIVE_ITALICS",
+    "LINT_MIXED_POSITIVE_NEGATIVE_QUOTES",
+    "LINT_SCANNER_EXTRACTS_NOTHING",
+    "VALID_SECTIONS",
+    "lint_author_discovery",
+]


### PR DESCRIPTION
## Summary

- New module `tools/author/discovery_lint.py` — section-aware lint for author-profile writes. Mirrors `tools.claudemd.rules_lint.lint_rule_text`'s contract (`{warnings, extracted_patterns}`) but applies the inverted semantics of author Don'ts (italics with a ban cue ARE bannable) and the post-#212 fallback cascade for Recurring Tics.
- `write_author_discovery` accepts `validate: bool = True` (default). When True, the MCP response carries `warnings` and `extracted_patterns`. When False, the legacy response shape is preserved for callers that opt out.
- `/storyforge:harvest-author-rules` SKILL.md updated — surfaces warnings after each write so the user can decide between "edit and rewrite" vs. "continue to cleanup". `/storyforge:promote-rule` was NOT touched: it only calls `write_author_banned_phrase`, which takes a plain string with no markdown semantics to lint.

## Lint codes per section

| Section | Code | Trigger |
|---------|------|---------|
| donts | `mixed_positive_negative_italics` (NEW) | Italic phrases on both sides of a #217 recommendation marker — post-marker italics silently do NOT extract |
| donts | `mixed_positive_negative_quotes` (REUSE) | Multiple double-quoted phrases under a ban cue |
| donts | `scanner_extracts_nothing` (REUSE) | Ban cue but no backtick / quoted / italic — scanner sees nothing |
| donts, recurring_tics, style_principles | `bracket_placeholder` (REUSE) | Backtick body has `[word]` — character class, not `\w+` |
| recurring_tics | `bold_title_unscannable` (NEW) | Non-ASCII title + no body pattern — title-text fallback won't match English prose |

Style Principles intentionally do NOT emit scanner-gap warnings — they are prose-level, not phrase bans.

## Test plan

- [x] `pytest tests/author/test_discovery_lint.py` — 22 passed (per-code positive + negative + contract)
- [x] `pytest tests/server/test_author_write_tools.py` — 21 passed (5 new MCP integration tests for validate=True / False)
- [x] `pytest tests/` — 1816 passed, no regressions
- [x] `ruff check` on all changed files — clean
- [x] Real-world smoke on `~/.storyforge/authors/ethan-cole/profile.md` — all 16 existing bullets across donts/recurring_tics/style_principles lint clean under the new rules (linter is preventive — it catches new bad bullets, doesn't flag the already-correct ones)
- [x] Synthetic worst-case bullets in the test suite verify warnings actually fire (e.g. `**Abstrakte Körperteil-Anthropomorphisierung** — Körperteil als Subjekt + vages Prädikat. Konkretisieren.` → `bold_title_unscannable`)

## Source-of-truth contract

The lint's `extracted_patterns` for Don'ts comes from `_extract_patterns_from_author_dont` (same function the scanner uses); for Recurring Tics it mirrors the title → body → title-text cascade from `load_author_writing_discoveries`. So the patterns the user sees in the warning are exactly the patterns the scanner will enforce.

## Out of scope

- Linting non-MCP write paths (direct Markdown edits to `profile.md`). The lint fires only on tool-mediated writes. A follow-up `lint_author_profile(slug)` tool could expose this for batch audits.
- Hard-blocking on warnings — lint is observability only. The write always goes through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)