### PR TITLE
Split hook author-banlist into three distinct categories (#215)

### DIFF
--- a/tests/analysis/test_chapter_validator.py
+++ b/tests/analysis/test_chapter_validator.py
@@ -273,10 +273,12 @@ class TestAuthorBanlistEnforcesWritingDiscoveries:
 
         result = validate_chapter_path(str(draft))
 
+        # Issue #215: Recurring Tic hits are emitted under their own category,
+        # matching the manuscript-checker vocabulary.
         author_findings = [
-            f for f in result.findings if f.category == "author_vocab_violation"
+            f for f in result.findings if f.category == "writing_discovery_violation"
         ]
-        assert author_findings, "expected at least one author_vocab_violation"
+        assert author_findings, "expected at least one writing_discovery_violation"
         assert any(
             "Writing Discoveries" in f.message for f in author_findings
         ), "expected the source-tag for Writing Discoveries in the message"
@@ -371,8 +373,10 @@ class TestAuthorBanlistEnforcesDonts:
 
         result = validate_chapter_path(str(draft))
 
+        # Issue #215: Don't hits are emitted under author_rule_violation,
+        # matching the manuscript-checker vocabulary.
         author_findings = [
-            f for f in result.findings if f.category == "author_vocab_violation"
+            f for f in result.findings if f.category == "author_rule_violation"
         ]
         assert author_findings, "expected at least one Don't violation"
         assert any(
@@ -401,7 +405,7 @@ class TestAuthorBanlistEnforcesDonts:
         result = validate_chapter_path(str(draft))
 
         author_findings = [
-            f for f in result.findings if f.category == "author_vocab_violation"
+            f for f in result.findings if f.category == "author_rule_violation"
         ]
         assert author_findings
         assert all(f.severity == SEVERITY_BLOCK for f in author_findings)
@@ -427,7 +431,163 @@ class TestAuthorBanlistEnforcesDonts:
         # No author findings, no block.
         dont_findings = [
             f for f in result.findings
-            if f.category == "author_vocab_violation"
+            if f.category == "author_rule_violation"
             and ("don't" in f.message.lower() or "donts" in f.message.lower())
         ]
         assert not dont_findings
+
+
+# ---------------------------------------------------------------------------
+# Issue #215: hook category split — each loader source gets its own category
+# ---------------------------------------------------------------------------
+
+
+class TestAuthorBanlistCategorySplit:
+    """The hook scanner must emit three distinct categories — matching the
+    manuscript-checker's vocabulary — so users can grep / filter hook output
+    consistently across both layers.
+    """
+
+    def test_vocabulary_hit_emits_author_vocab_violation(
+        self, tmp_path: Path, patch_storyforge_home: Path
+    ) -> None:
+        book = _write_book_with_author(tmp_path)
+        _write_author_vocabulary(
+            patch_storyforge_home,
+            "ethan-cole",
+            (
+                "## Banned Words\n\n"
+                "### Absolutely Forbidden\n\n"
+                "- delve\n"
+            ),
+        )
+        prose = "He had to delve into the question one more time today. " * 30
+        draft = _write_draft(book, prose)
+        result = validate_chapter_path(str(draft))
+
+        categories = {f.category for f in result.findings}
+        assert "author_vocab_violation" in categories
+        # Pure-vocab path: no Recurring-Tic or Don't categories emitted.
+        assert "writing_discovery_violation" not in categories
+        assert "author_rule_violation" not in categories
+
+    def test_recurring_tic_hit_emits_writing_discovery_violation(
+        self, tmp_path: Path, patch_storyforge_home: Path
+    ) -> None:
+        book = _write_book_with_author(tmp_path)
+        _write_author_profile_with_discoveries(
+            patch_storyforge_home,
+            "ethan-cole",
+            (
+                '### Recurring Tics\n\n'
+                '- **Vague-noun "thing" als Fallback** — concretize.\n'
+            ),
+        )
+        prose = "He was doing a thing again, definitely a thing. " * 30
+        draft = _write_draft(book, prose)
+        result = validate_chapter_path(str(draft))
+
+        categories = [f.category for f in result.findings]
+        assert "writing_discovery_violation" in categories
+        # Pure-tic path: no vocab or Don't categories.
+        assert "author_vocab_violation" not in categories
+        assert "author_rule_violation" not in categories
+
+    def test_dont_hit_emits_author_rule_violation(
+        self, tmp_path: Path, patch_storyforge_home: Path
+    ) -> None:
+        book = _write_book_with_author(tmp_path)
+        _write_author_profile_with_discoveries(
+            patch_storyforge_home,
+            "ethan-cole",
+            (
+                "### Don'ts\n\n"
+                "- **Never use rooms** — *The room received it.*\n"
+            ),
+        )
+        prose = "The room received it without complaint last night. " * 30
+        draft = _write_draft(book, prose)
+        result = validate_chapter_path(str(draft))
+
+        categories = [f.category for f in result.findings]
+        assert "author_rule_violation" in categories
+        assert "author_vocab_violation" not in categories
+        assert "writing_discovery_violation" not in categories
+
+    def test_three_sources_yield_three_distinct_categories(
+        self, tmp_path: Path, patch_storyforge_home: Path
+    ) -> None:
+        """All three sources present + distinct phrases in the draft —
+        the hook emits one finding per source under its dedicated category."""
+        book = _write_book_with_author(tmp_path)
+        _write_author_vocabulary(
+            patch_storyforge_home,
+            "ethan-cole",
+            (
+                "## Banned Words\n\n"
+                "### Absolutely Forbidden\n\n"
+                "- delve\n"
+            ),
+        )
+        _write_author_profile_with_discoveries(
+            patch_storyforge_home,
+            "ethan-cole",
+            (
+                '### Recurring Tics\n\n'
+                '- **Vague-noun "thing" als Fallback** — concretize.\n\n'
+                "### Don'ts\n\n"
+                "- **Never use rooms** — *The room received it.*\n"
+            ),
+        )
+        prose = (
+            "He had to delve into the question. Then a thing happened. "
+            "The room received it without complaint. " * 30
+        )
+        draft = _write_draft(book, prose)
+        result = validate_chapter_path(str(draft))
+
+        categories = {f.category for f in result.findings}
+        assert "author_vocab_violation" in categories
+        assert "writing_discovery_violation" in categories
+        assert "author_rule_violation" in categories
+
+    def test_dedup_preserves_winning_source_category(
+        self, tmp_path: Path, patch_storyforge_home: Path
+    ) -> None:
+        """The dedup precedence (vocabulary > tics > don'ts) is unchanged.
+        When the same phrase appears in multiple sources, only the winning
+        source's category surfaces — and the winner is vocabulary.
+        """
+        book = _write_book_with_author(tmp_path)
+        _write_author_vocabulary(
+            patch_storyforge_home,
+            "ethan-cole",
+            (
+                "## Banned Words\n\n"
+                "### Forbidden Hedging Phrases\n\n"
+                "- thing\n"
+            ),
+        )
+        _write_author_profile_with_discoveries(
+            patch_storyforge_home,
+            "ethan-cole",
+            (
+                '### Recurring Tics\n\n'
+                '- **Vague-noun "thing" als Fallback** — concretize.\n'
+            ),
+        )
+        prose = "He was doing a thing again, deliberate-feeling. " * 30
+        draft = _write_draft(book, prose)
+        result = validate_chapter_path(str(draft))
+
+        thing_findings = [
+            f for f in result.findings
+            if "thing" in f.message.lower()
+            and f.category in {
+                "author_vocab_violation",
+                "writing_discovery_violation",
+                "author_rule_violation",
+            }
+        ]
+        assert len(thing_findings) == 1
+        assert thing_findings[0].category == "author_vocab_violation"

--- a/tools/analysis/chapter_validator.py
+++ b/tools/analysis/chapter_validator.py
@@ -731,6 +731,12 @@ def _scan_author_banlist(text: str, book_root: Path) -> list[Finding]:
     ``/storyforge:harvest-author-rules`` or shipped in PR #209's Section 11
     would be reported as ``severity:block`` in the brief but pass the
     hard-gate at save time.
+
+    Issue #215: each loader source maps to a distinct finding category,
+    matching the manuscript-checker vocabulary. Dedup precedence is
+    unchanged — vocabulary wins, then tics, then Don'ts — so when the
+    same phrase appears in multiple sources, only the highest-precedence
+    source's category surfaces.
     """
     try:
         from tools.banlist_loader import (
@@ -757,20 +763,27 @@ def _scan_author_banlist(text: str, book_root: Path) -> list[Finding]:
     except Exception:
         dont_patterns = []
 
-    seen_labels: set[str] = set()
-    patterns = []
-    for p in (*vocab_patterns, *discovery_patterns, *dont_patterns):
-        key = p.label.lower()
-        if key in seen_labels:
-            continue
-        seen_labels.add(key)
-        patterns.append(p)
+    sources: list[tuple[list, str]] = [
+        (vocab_patterns, "author_vocab_violation"),
+        (discovery_patterns, "writing_discovery_violation"),
+        (dont_patterns, "author_rule_violation"),
+    ]
 
-    if not patterns:
+    seen_labels: set[str] = set()
+    patterns_with_category: list[tuple[object, str]] = []
+    for plist, category in sources:
+        for p in plist:
+            key = p.label.lower()
+            if key in seen_labels:
+                continue
+            seen_labels.add(key)
+            patterns_with_category.append((p, category))
+
+    if not patterns_with_category:
         return []
 
     findings: list[Finding] = []
-    for banned in patterns:
+    for banned, category in patterns_with_category:
         match = banned.pattern.search(text)
         if not match:
             continue
@@ -778,7 +791,7 @@ def _scan_author_banlist(text: str, book_root: Path) -> list[Finding]:
         findings.append(
             Finding(
                 severity=SEVERITY_BLOCK,
-                category="author_vocab_violation",
+                category=category,
                 message=(f"Banned by author voice ({banned.source}): '{banned.label}'"),
                 line=line_num,
             )


### PR DESCRIPTION
## Summary

- `_scan_author_banlist` in `tools/analysis/chapter_validator.py` now emits one of three distinct finding categories — matching the manuscript-checker vocabulary — instead of lumping every hit under `author_vocab_violation`:

  | Loader source | New category |
  |---|---|
  | `load_author_vocab` (vocabulary.md) | `author_vocab_violation` (unchanged) |
  | `load_author_writing_discoveries` (Recurring Tics) | `writing_discovery_violation` |
  | `load_author_dont_rules` (Don'ts) | `author_rule_violation` |

- Implementation: carry each pattern with its source category through the dedup pass. Precedence is unchanged (vocabulary > tics > Don'ts), so when the same phrase appears in multiple sources only the highest-precedence source's category surfaces.

- Block message, severity, and the hook UX are otherwise unchanged.

## Why

The asymmetry between the hook (one coarse category) and the manuscript-checker (three distinct categories) made hook output harder to read and harder to grep. Surfaced while writing the Banlist Architecture wiki page.

## Test plan

- [x] `pytest tests/analysis/test_chapter_validator.py` — 23 passed (5 new `TestAuthorBanlistCategorySplit` tests + 3 updated existing tests for Recurring Tics / Don'ts categories)
- [x] `pytest tests/` — 1821 passed, no regressions
- [x] `ruff check` on changed files — clean
- [x] Dedup precedence verified: vocabulary entry wins over identical Recurring-Tic entry, finding surfaces under `author_vocab_violation`

## Out of scope

- Loader changes — already in good shape.
- manuscript-checker side — already has the three categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)