### PR TITLE
feat: add native_language + preferred_writing_language to author profile

### DIFF
--- a/skills/create-author/SKILL.md
+++ b/skills/create-author/SKILL.md
@@ -33,6 +33,8 @@ Ask the user:
 1. **Pen name** — What should this author be called?
 2. **Primary genres** — Show available genres via MCP `list_genres()`. Select 1-3.
 3. **Writing influences** — Which published authors inspire this persona? (e.g., "Stephen King meets Carmen Maria Machado")
+4. **Native language** — What is the author's mother tongue? (ISO 639-1 code, e.g. `de`, `fr`, `es`, `ja`) — used for explanations in language-aware skills like the proofreader
+5. **Preferred writing language** — Which language does this author primarily write in? Used as fallback when a book has no `book_language` set. (default: `en`)
 
 ### Phase 2: Voice Definition
 Guide the user through voice choices (use AskUserQuestion):
@@ -69,6 +71,8 @@ Ask the user:
 1. **Name / pen name** — What should this author be called? (May use real name)
 2. **Memoir scope tags** — What kind of memoir? (e.g., memoir-of-illness, memoir-of-family, memoir-of-place, memoir-of-addiction, memoir-of-work — these are not genres but thematic anchors)
 3. **Writing influences** — Which memoirists or essayists inspire this voice? (e.g., Mary Karr, Tara Westover, Carmen Maria Machado, Ta-Nehisi Coates, Kiese Laymon, Roxane Gay, Paul Kalanithi)
+4. **Native language** — What is the author's mother tongue? (ISO 639-1 code, e.g. `de`, `fr`, `es`, `ja`) — used for explanations in language-aware skills like the proofreader
+5. **Preferred writing language** — Which language does this author primarily write in? Used as fallback when a book has no `book_language` set. (default: `en`)
 
 ### Phase 2: Voice Definition (Memoir)
 Same universal voice questions as fiction, plus memoir-specific additions:
@@ -116,7 +120,8 @@ Ask open-ended questions tailored to memoir:
 
 1. Use MCP `create_author()` with collected data
 2. Call MCP `update_author(slug, "author_writing_mode", value)` to persist writing mode
-3. For memoir authors, also call `update_author(slug, "subject_position", value)` and `update_author(slug, "off_limits", value)`
+3. Call MCP `update_author(slug, "native_language", value)` and `update_author(slug, "preferred_writing_language", value)`
+4. For memoir authors, also call `update_author(slug, "subject_position", value)` and `update_author(slug, "off_limits", value)`
 4. Load the generated `profile.md` and `vocabulary.md`
 5. Review the banned words list (AI tells) — ask if user wants to add/remove any
 6. For memoir: pre-populate memoir-specific AI tells from `book_categories/memoir/craft/memoir-anti-ai-patterns.md` (reflective platitudes, "looking back I realize", tidy lesson endings)

--- a/templates/author-profile.md
+++ b/templates/author-profile.md
@@ -15,6 +15,8 @@ themes: []
 influences: []
 avoid: ["purple-prose", "info-dumps", "deus-ex-machina"]
 author_writing_mode: "outliner"  # outliner | plantser | discovery
+native_language: "{{native_language}}"                    # ISO 639-1: author's mother tongue — used for explanations in language-aware skills
+preferred_writing_language: "{{preferred_writing_language}}"  # ISO 639-1: fallback if book has no book_language set
 ---
 
 # {{name}}


### PR DESCRIPTION
## Summary

- Adds `native_language` (ISO 639-1) to author profile template — drives explanation language in language-aware skills (proofreader etc.)
- Adds `preferred_writing_language` (ISO 639-1) as author-level fallback; resolution order: `book_language` → `preferred_writing_language` → `"en"`
- Both fields collected in Phase 1 interview (fiction + memoir paths) and persisted via `update_author()` in Phase 4

## Test plan

- [ ] Run `pytest tests/smoke/test_skills.py -q` — skill frontmatter smoke tests pass
- [ ] Create a new author profile via `/storyforge:create-author` — confirm questions 4 + 5 appear and both fields land in `profile.md` frontmatter
- [ ] Verify existing author profiles are unaffected (no migration needed — `update_author` on demand)

Closes #225
Unblocks #224 (chapter-proofreader)

🤖 Generated with [Claude Code](https://claude.com/claude-code)