### PR TITLE
feat: add chapter-proofreader skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ Phase 1 (#54–#56, #67) adds the field plus knowledge scaffold. Skill branching
 | "Kapitel schreiben" / "Write chapter" (memoir) | `/storyforge:chapter-writer-memoir` |
 | "Kapitel reviewen" / "Review chapter" (fiction) | `/storyforge:chapter-reviewer` |
 | "Kapitel reviewen" / "Review chapter" (memoir) | `/storyforge:chapter-reviewer-memoir` |
+| "Kapitel proofreaden" / "Proofread chapter" / "Korrekturlesen" / "Spelling check" / "Grammar check" | `/storyforge:chapter-proofreader` |
 | "Continuity prüfen" / "Check continuity" / "Zeitlinie prüfen" / "Timeline prüfen" | `/storyforge:continuity-checker` |
 | "Voice check" / "Klingt das nach AI?" | `/storyforge:voice-checker` |
 | "Manuscript check" / "Prose check" / "Repetition check" / "Wiederholungen prüfen" / "Prose tics" / "Buch prüfen" | `/storyforge:manuscript-checker` |
@@ -130,7 +131,8 @@ Phase 1 (#54–#56, #67) adds the field plus knowledge scaffold. Skill branching
 6. `/storyforge:rolling-planner` — Scene-by-scene planning buffer (3-5 scenes ahead)
 8. `/storyforge:chapter-writer` — Write chapters in author's voice (loads timeline + travel matrix + tonal document + chapter timeline)
 9. `/storyforge:continuity-checker` — (Optional, after several chapters) Validate timeline and location consistency
-9. `/storyforge:chapter-reviewer` — Review each chapter
+9. `/storyforge:chapter-reviewer` — Review each chapter for craft, voice, structure, and AI-tells
+9a. `/storyforge:chapter-proofreader` — Language correctness per chapter: spelling, grammar, punctuation — runs AFTER craft fixes from chapter-reviewer are applied; explanations in author's native_language
 9b. `/storyforge:manuscript-checker` — (At drafting → revision transition) Scan the whole manuscript for book-rule violations, clichés, dialogue punctuation, filter words, adverb density, and cross-chapter repetition
 9c. `/storyforge:beta-feedback` — (After eBook/ARC stage) Process curated beta-reader feedback, triage, revision plan
 10. `/storyforge:voice-checker` — Verify authenticity

--- a/skills/chapter-proofreader/SKILL.md
+++ b/skills/chapter-proofreader/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: chapter-proofreader
+description: |
+  Check a chapter for spelling, grammar, and punctuation errors in the book's writing language.
+  Explanations are delivered in the author's native language.
+  Use when: (1) User says "Kapitel proofreaden", "proofread chapter", "Korrekturlesen",
+  (2) After chapter-reviewer craft fixes are applied, before manuscript-checker.
+  Works for both fiction and memoir books.
+model: claude-sonnet-4-6
+user-invocable: true
+argument-hint: "<book-slug> <chapter-slug>"
+---
+
+# Chapter Proofreader
+
+Checks language correctness — spelling, grammar, punctuation — on prose that is already
+craft-stable (after chapter-reviewer). Does NOT check craft, voice, or cross-chapter patterns.
+
+## Step 1 — Resolve Languages
+
+Call MCP `get_author(slug)` to read the author profile.
+
+**Writing language** (what rules to apply):
+```
+book_language (from book frontmatter)
+  → preferred_writing_language (from author profile)
+  → "en" (global fallback)
+```
+
+**Explanation language** (what language to write findings in):
+```
+native_language (from author profile)
+  → "en" (fallback)
+```
+
+If `writing_language == native_language`: skip the explanation — just give the fix. Explanations
+are for non-native writers who need context, not for native speakers who already know the rule.
+
+## Step 2 — Load Book and Chapter
+
+Call MCP `get_book_full(book_slug)` to read:
+- `book_language` — authoritative per-book writing language
+- Author slug (to cross-reference profile from Step 1)
+
+Read the chapter draft directly:
+- `{project}/chapters/{chapter_slug}/draft.md`
+
+## Step 3 — Load Author Profile Context
+
+From the author profile (already loaded in Step 1), extract:
+- `avoid` list — intentional stylistic choices that are NOT errors (e.g. sentence fragments as voice)
+- `sentence_style` — if "short-punchy", intentional fragments are expected, do not flag
+- `vocabulary_level` — informs whether archaic or unusual words are intentional
+
+**Rule:** If a pattern appears in the author's `avoid` list or is consistent with their documented
+style, it is intentional — do not flag it.
+
+## Step 4 — Run Proofreading Pass
+
+### Spelling
+
+- Typos and misspellings
+- Wrong word forms (e.g. "affect" vs "effect", "lay" vs "lie")
+- Homophone confusion (their/there/they're, your/you're, its/it's)
+- Consistency: proper nouns spelled the same way as in earlier chapters (use canon from Step 2)
+
+### Grammar
+
+- Subject-verb agreement ("she don't" → "she doesn't")
+- Tense consistency within a scene — unintentional tense shifts only; intentional mixed tense
+  (e.g. present for reflection, past for events) must be honored
+- Dangling and misplaced modifiers
+- Pronoun-antecedent agreement
+- Double negatives (unless stylistic/dialect)
+- Run-on sentences and comma splices (two independent clauses joined only by a comma)
+- Sentence fragments — flag ONLY if NOT consistent with `sentence_style: short-punchy` or
+  the author's documented voice
+
+### Punctuation
+
+**English (`writing_language: en`):**
+- Em dash (—) vs en dash (–) vs hyphen (-): em dash for interruption/parenthetical, en dash for
+  ranges, hyphen for compound words
+- Oxford comma: flag if inconsistently applied within the chapter (pick one style, keep it)
+- Dialogue punctuation: comma before closing quote when followed by dialogue tag
+  ("Hello," she said — not "Hello." she said); period inside closing quote (US English)
+- Ellipsis: three dots only (…), not two or four, no space before
+- Apostrophe errors: it's/its, possessives, contractions
+
+**German (`writing_language: de`):**
+- Comma rules (Nebensätze, Infinitivgruppen)
+- Quotation marks: „..." not "..."
+- Compound words written together vs apart
+- Capitalization of nouns
+- Comma before "und/oder" in compound sentences (not mandatory, but flag inconsistency)
+
+**Other languages:** Apply the standard punctuation conventions of that language.
+
+### Non-Native Writer Patterns (only when `writing_language != native_language`)
+
+These patterns are common for non-native writers and worth flagging when `writing_language` is
+not the author's mother tongue:
+
+- Article misuse (a/an/the for non-native English writers)
+- Preposition errors ("interested on" → "interested in", "depend of" → "depend on")
+- False friends (words that look similar across languages but mean different things)
+- Calque constructions (literal translations of idioms from the native language that don't work
+  in the writing language)
+- Modal verb misuse ("can" vs "may", "must" vs "have to", "will" vs "would")
+
+## Step 5 — Output Report
+
+**Report target: concise.** Only flag real errors. Do not pad the report with minor stylistic
+observations that belong in chapter-reviewer. If a chapter is clean, say so in one line.
+
+```markdown
+## Proofreading Report: {Chapter Title}
+
+**Writing language:** {en/de/...}
+**Explanations in:** {de/fr/en/...}
+**Non-native patterns checked:** {yes / no — native speaker}
+
+---
+
+### Spelling ({count} issues)
+
+**[~Line/paragraph reference]** "{quoted phrase with error}"
+→ Fix: "{corrected version}"
+→ {Explanation in native_language — only for non-obvious rules}
+
+### Grammar ({count} issues)
+
+**[~Line/paragraph reference]** "{quoted phrase with error}"
+→ Fix: "{corrected version}"
+→ {Explanation in native_language}
+
+### Punctuation ({count} issues)
+
+**[~Line/paragraph reference]** "{quoted phrase with error}"
+→ Fix: "{corrected version}"
+→ {Explanation in native_language}
+
+### Non-Native Patterns ({count} issues / "not checked — native speaker")
+
+**[~Line/paragraph reference]** "{quoted phrase}"
+→ Fix: "{corrected version}"
+→ {Explanation in native_language — explain the rule and why the native pattern causes it}
+
+---
+
+### Summary
+
+| Category | Issues |
+|---|---|
+| Spelling | {n} |
+| Grammar | {n} |
+| Punctuation | {n} |
+| Non-native patterns | {n} |
+| **Total** | **{n}** |
+
+**Verdict:** CLEAN | ISSUES FOUND
+
+**Suggested next step:**
+- CLEAN → `/storyforge:manuscript-checker` (full-book pass)
+- ISSUES FOUND → Fix listed items, then `/storyforge:manuscript-checker`
+```
+
+## Rules
+
+- Flag errors, not style. If unsure whether something is intentional, check the author profile
+  before flagging.
+- Quote the actual text when flagging — never describe it vaguely.
+- Explanations go in the author's `native_language`. If writing_language == native_language,
+  skip explanations entirely — just give the fix.
+- Do not flag craft issues (pacing, show-don't-tell, AI-tells) — those belong in chapter-reviewer.
+- Do not flag cross-chapter repetitions — those belong in manuscript-checker.
+- A clean chapter gets one line: "No issues found. Verdict: CLEAN."

--- a/skills/next-step/SKILL.md
+++ b/skills/next-step/SKILL.md
@@ -27,13 +27,15 @@ user-invocable: true
    | Characters Created | `/storyforge:world-builder` | Build the world (if fantasy/sci-fi/supernatural) or skip to Drafting |
    | World Built | `/storyforge:chapter-writer` ch.1 | Start writing! |
    | Drafting | `/storyforge:chapter-writer` next unwritten chapter | Keep writing |
-   | Drafting → Revision (all chapters drafted) | `/storyforge:manuscript-checker` | Catch cross-chapter prose issues (rules, clichés, dialogue punctuation, filter words, adverbs, repetition) before per-chapter revision |
-   | Revision | `/storyforge:chapter-reviewer` on first unreviewed chapter | Review and polish |
+   | Drafting → Revision (all chapters drafted) | `/storyforge:chapter-reviewer` on first unreviewed chapter | Start per-chapter craft review before the full-book pass |
+   | Revision (chapter-reviewer done, proofreader not yet run) | `/storyforge:chapter-proofreader` on first un-proofread chapter | Language correctness pass: spelling, grammar, punctuation — after craft fixes are stable |
+   | Revision (all chapters proofread) | `/storyforge:manuscript-checker` | Catch cross-chapter prose issues (rules, clichés, dialogue punctuation, filter words, adverbs, repetition) |
    | Editing | `/storyforge:voice-checker` | Final authenticity check |
    | Proofread | `/storyforge:export-engineer` | Generate the book file |
    | Export Ready | `/storyforge:translator` or publish | Translate or distribute |
 
 4. **Check for incomplete work**
+   - Any chapters reviewed but not yet proofread? → Suggest `chapter-proofreader`
    - Any chapters in "Draft" that need review? → Suggest `chapter-reviewer`
    - Characters still in "Concept"? → Suggest `character-creator`
    - Missing plot outline? → Suggest `plot-architect`


### PR DESCRIPTION
## Summary

- New `chapter-proofreader` skill: language-correctness pass (spelling, grammar, punctuation) after craft review, before full-book manuscript-checker
- Language detection: `book_language` → `preferred_writing_language` (author) → `"en"` for rules; `native_language` (author) → `"en"` for explanations
- Non-native writer patterns (article misuse, preposition errors, false friends, calques) only when writing language ≠ native language
- Explanations delivered in the author's `native_language` — skipped entirely for native speakers
- Routing table and workflow pipeline in CLAUDE.md updated (new step 9a)
- `next-step` skill updated to reflect the three-step revision sequence

## Workflow position

```
chapter-reviewer  (craft)
      ↓
chapter-proofreader  ← this PR
      ↓
manuscript-checker  (full-book)
```

## Test plan

- [ ] `pytest tests/smoke/test_skills.py -q` — new skill frontmatter valid, no duplicates
- [ ] Run `/storyforge:chapter-proofreader <book> <chapter>` on a chapter — verify report structure matches spec
- [ ] Verify explanations appear in German for Ethan Cole (`native_language: de`)
- [ ] Verify a chapter with no errors returns "Verdict: CLEAN" in one line
- [ ] Run `/storyforge:next-step` mid-revision — confirm chapter-proofreader appears in the recommendation sequence

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)