### PR TITLE
feat: chapter-humanizer skill + Elegant Abstraction Scan hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ Phase 1 (#54–#56, #67) adds the field plus knowledge scaffold. Skill branching
 | "Kapitel schreiben" / "Write chapter" (memoir) | `/storyforge:chapter-writer-memoir` |
 | "Kapitel reviewen" / "Review chapter" (fiction) | `/storyforge:chapter-reviewer` |
 | "Kapitel reviewen" / "Review chapter" (memoir) | `/storyforge:chapter-reviewer-memoir` |
+| "Humanize chapter" / "AI-Tells entfernen" / "chapter humanizer" / "AI-Sätze raus" | `/storyforge:chapter-humanizer` |
 | "Kapitel proofreaden" / "Proofread chapter" / "Korrekturlesen" / "Spelling check" / "Grammar check" | `/storyforge:chapter-proofreader` |
 | "Continuity prüfen" / "Check continuity" / "Zeitlinie prüfen" / "Timeline prüfen" | `/storyforge:continuity-checker` |
 | "Voice check" / "Klingt das nach AI?" | `/storyforge:voice-checker` |
@@ -101,8 +102,9 @@ Phase 1 (#54–#56, #67) adds the field plus knowledge scaffold. Skill branching
 1. Create Author Profile → Study PDFs (optional)
 2. Brainstorm → New Book → Concept
 3. Plot Architecture → Characters → World
-4. Chapter Writing → Chapter Review → Voice Check
+4. Chapter Writing → Chapter Review → Chapter Humanizer → Chapter Proofread
 5. Revision → Export → Translation (optional)
+6. Voice Checker (optional, standalone score check)
 ```
 
 ### Standard Workflow (Outliner)
@@ -132,10 +134,11 @@ Phase 1 (#54–#56, #67) adds the field plus knowledge scaffold. Skill branching
 8. `/storyforge:chapter-writer` — Write chapters in author's voice (loads timeline + travel matrix + tonal document + chapter timeline)
 9. `/storyforge:continuity-checker` — (Optional, after several chapters) Validate timeline and location consistency
 9. `/storyforge:chapter-reviewer` — Review each chapter for craft, voice, structure, and AI-tells
-9a. `/storyforge:chapter-proofreader` — Language correctness per chapter: spelling, grammar, punctuation — runs AFTER craft fixes from chapter-reviewer are applied; explanations in author's native_language
-9b. `/storyforge:manuscript-checker` — (At drafting → revision transition) Scan the whole manuscript for book-rule violations, clichés, dialogue punctuation, filter words, adverb density, and cross-chapter repetition
-9c. `/storyforge:beta-feedback` — (After eBook/ARC stage) Process curated beta-reader feedback, triage, revision plan
-10. `/storyforge:voice-checker` — Verify authenticity
+9a. `/storyforge:chapter-humanizer` — Targeted AI-construction scan; identifies Section 11 elegant-abstraction shapes and flagged vocabulary; proposes human alternatives interactively; runs AFTER chapter-reviewer craft fixes
+9b. `/storyforge:chapter-proofreader` — Language correctness per chapter: spelling, grammar, punctuation — runs AFTER humanizer pass; explanations in author's native_language
+9c. `/storyforge:manuscript-checker` — (At drafting → revision transition) Scan the whole manuscript for book-rule violations, clichés, dialogue punctuation, filter words, adverb density, and cross-chapter repetition
+9d. `/storyforge:beta-feedback` — (After eBook/ARC stage) Process curated beta-reader feedback, triage, revision plan
+10. `/storyforge:voice-checker` — (Optional) Holistic AI-authenticity score (0–100) across 7 dimensions; use when you want a scorecard rather than targeted fixes; not a required step in the standard workflow
 11. `/storyforge:cover-artist` — Generate cover prompts
 12. `/storyforge:export-engineer` — EPUB/PDF/MOBI via Pandoc
 13. `/storyforge:promo-writer` — Social media campaign (FB, Instagram, TikTok, X, Bluesky, Newsletter)

--- a/reference/craft/anti-ai-patterns.md
+++ b/reference/craft/anti-ai-patterns.md
@@ -527,8 +527,11 @@ Real human writers render emotional weight through bodies, actions, and dialog. 
 - Sentences as projectiles or settling objects
 - Economic vocabulary as code for emotional cost
 - Body language that *almost* becomes something
+- Body parts treated as autonomous agents with cognitive/decision capacity
+- Same verb negated in a temporal-refusal clause
+- Same logical constraint repeated across two consecutive sentences
 
-Each of the five sub-shapes below has been observed repeatedly in chapter drafts. Each is invisible to the standard banned-word lists. Each requires its own countermeasure.
+Each of the eight sub-shapes below has been observed repeatedly in chapter drafts. Each is invisible to the standard banned-word lists. Each requires its own countermeasure.
 
 ### 11.1 Word-Count Meta-Commentary
 
@@ -624,19 +627,61 @@ A body part is rendered as the subject of a cognitive or decision verb — the h
 > The hand had been deciding something the rest of Caelan had not yet caught up with.
 > His hands were having a conversation with each other.
 > His stomach kept failing to file the news.
+> stayed there until he could trust his face again.
 
 *Human Example:*
 > Caelan watched his own hand move before the rest of him caught up.
 > He flexed his fingers, then closed them. He had not decided yet.
 > The news landed in his stomach and stayed.
+> He held still. When he was certain his expression had settled, he moved.
 
-The bad pattern: cognitive/decision verbs (deciding, choosing, knowing, wanting, refusing, considering, having a conversation, failing) after a body-part subject. Real prose lets the **character** decide; the body either does the physical thing (shook, stilled, tightened, pulled) or signals an unresolved state through the character's awareness of it. Body parts are not small autonomous agents.
+The bad pattern: cognitive/decision verbs (deciding, choosing, knowing, wanting, refusing, considering, having a conversation, failing) after a body-part subject — but also **trust/distrust applied to a body part as its object** ("trust his face", "trust his hands", "trust his voice"). In all cases the character is split from their own body, which becomes a separate entity to be managed. Real prose lets the **character** decide; the body either does the physical thing (shook, stilled, tightened, pulled) or signals an unresolved state through the character's awareness of it. Body parts are not small autonomous agents.
 
 **Banned shape:** `\b(his|her|the|its)\s+(hand|hands|breath|stomach|shoulders|face|mouth|eyes|chest|throat|jaw|spine|fingers|knee|knees|feet|legs)\s+(had been|was|were|kept|started|began)\s+(deciding|having|choosing|wanting|refusing|trying|failing|considering|chosen|remembering|forgetting|knowing)\b`.
 
+**Banned shape (trust-split):** `\b(trust|distrust|not trust)\s+(his|her|my|their)\s+(face|voice|hands|body|expression|eyes|mouth|legs)\b` — e.g. "he could trust his face again", "she didn't trust her voice".
+
+### 11.7 Backward-Negation Loop
+
+A single verb (or near-verb) is used twice in the same sentence: once as the action that now happens, once negated in a prior-time clause. The construction buries emotional weight in temporal recursion instead of rendering it directly.
+
+*AI Example:*
+> His throat closed on what it had been refusing to close on since yesterday in the sitting room.
+> She said the thing she had been unable to say since the hospital.
+> He did what he had promised himself he would never do.
+
+*Human Example:*
+> His throat tightened. Yesterday he hadn't been able to cry. He still couldn't, not entirely — but the pressure was there now.
+> She said it. The word she'd been holding since the hospital.
+> He did it anyway.
+
+The bad pattern: `[verb phrase] on/around/about what it had been [negated same verb phrase] since [time marker]`. The construction is syntactically legal but reads as a model working hard to sound literary. The emotion is named twice (once as action, once as prior refusal) where a direct rendering would name it once and let it land. The reader doesn't need to be told what wasn't happening before.
+
+**Banned shape:** `\b(what|that) (it|he|she|they) had been (refusing|unable|failing|trying not) to\b` followed by the same or near-synonym verb from the opening clause.
+
+**Diagnostic question:** Can you cut the temporal-refusal clause and just write the action? If yes, cut it.
+
+### 11.8 Expository Repeat (Narrative Justification)
+
+The same key phrase or logical constraint appears in two consecutive sentences, the second sentence re-stating the first to "prove" a character decision or justify a narrative gap.
+
+*AI Example:*
+> They had silver on her and weren't careful about the rest. They did not look under the shirt of a vampire they had silver on.
+
+*Human Example:*
+> Silver was enough. They didn't bother checking further — why would they?
+
+The bad pattern: sentence A states fact X. Sentence B restates X as the explanation for why something didn't happen. The AI is filling a logical gap by repeating the premise. The repetition signals the model is aware the scene has a plausibility hole and is papering over it with re-statement instead of dramatizing the moment or trusting the reader. In real prose, logical constraints are established once and trusted; the reader tracks them. When a writer repeats a constraint, it usually means the scene's POV hasn't been rendered specifically enough to make the constraint feel real.
+
+**Diagnostic questions:**
+1. Does sentence B contain the same noun-phrase or verb-phrase as sentence A? If yes, flag it.
+2. Is sentence B doing logical work ("because they had X, they didn't do Y") instead of dramatic work? If yes, cut sentence B and either trust the reader or dramatize the gap from POV.
+
+**Fix:** Remove the repeat. If the constraint matters, establish it once, specifically, with a body in the scene — then let the action follow without re-statement.
+
 ### Why These Patterns Cluster
 
-These five shapes co-occur in the same scenes — typically the highest-stakes moments of a chapter (deaths, declarations, family confrontations). They share a single underlying habit: **rendering emotional weight through abstraction instead of through specific physical reality**. The language model has been trained to recognise "literary" prose, and these shapes appear in published fiction often enough to be statistically respectable. But they are also the prose-equivalent of stage smoke: atmosphere without substance.
+These shapes co-occur in the same scenes — typically the highest-stakes moments of a chapter (deaths, declarations, family confrontations). They share a single underlying habit: **rendering emotional weight through abstraction instead of through specific physical reality**. The language model has been trained to recognise "literary" prose, and these shapes appear in published fiction often enough to be statistically respectable. But they are also the prose-equivalent of stage smoke: atmosphere without substance.
 
 The countermeasure is the same in every case: **route the emotional weight through a named body in the room.** Whose eyes did not move. Whose hand stilled. Whose breath came faster. Specificity is the antidote to elegance.
 

--- a/skills/chapter-humanizer/SKILL.md
+++ b/skills/chapter-humanizer/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: chapter-humanizer
+description: |
+  Targeted AI-construction scan on an existing chapter draft. Identifies Section 11 elegant-abstraction
+  shapes and flagged vocabulary hits, proposes human alternatives per occurrence, applies approved
+  changes interactively to draft.md. Run after chapter-reviewer, before chapter-proofreader.
+  Use when: (1) User says "humanize chapter", "AI-Tells entfernen", "chapter humanizer",
+  (2) After chapter-reviewer craft fixes are applied and the prose still feels AI-generated,
+  (3) As a mandatory step in the standard writing workflow between review and proofread.
+model: claude-opus-4-7
+user-invocable: true
+argument-hint: "<book-slug> <chapter-slug>"
+---
+
+# Chapter Humanizer
+
+The chapter-humanizer is a surgical pass — not a rewrite. Its job is to find AI-construction patterns in already-reviewed prose and replace them with alternatives written in the author's voice. It does not touch craft, structure, story logic, or anything the chapter-reviewer already addressed.
+
+**Position in workflow:** `chapter-writer → chapter-reviewer → chapter-humanizer → chapter-proofreader → manuscript-checker`
+
+## Prerequisites — MANDATORY LOADS
+
+Before scanning a single line:
+
+1. **Draft** — Read `{project}/chapters/{chapter}/draft.md` in full. If missing, stop and tell the user: "Kein draft.md für dieses Kapitel gefunden — chapter-writer muss zuerst laufen."
+2. **Anti-AI patterns** — MCP `get_craft_reference("anti-ai-patterns")`. **Why:** Section 11 contains the shape catalog with banned-shape descriptions and examples. Section 1 contains the flagged-vocabulary list. Both are the scan targets.
+3. **Author profile** — MCP `get_author()`. **Why:** Alternatives must be written in the author's documented voice (tone, rhythm, vocabulary). A proposed fix that doesn't match the author's profile is not a fix — it's a different kind of AI output.
+4. **Book CLAUDE.md** — MCP `get_book_claudemd(book_slug)`. **Why:** Book-level rules may contain additional banned shapes or construction constraints specific to this book.
+
+## Scan — Two Passes
+
+### Pass 1: Section 11 Elegant Abstraction Shapes
+
+Scan every sentence for the following constructions. For each hit, record: line number (approximate), the offending text verbatim, the shape name.
+
+| Shape | What to search for |
+|---|---|
+| **11.1 Word-count commentary** | `One word.` / `Two words.` / `Three words.` followed by narrator editorial about the rarity of those words |
+| **11.2 Sentence-as-projectile** | `the words landed`, `the line landed`, `the sentence landed`, `settled into the room`, `sat in the room` |
+| **11.3 Room-as-receiver** | `the room received`, `the silence held`, `the hall absorbed`, `the air carried`, `the quiet kept` |
+| **11.4 Economic metaphor** | `most expensive [word/sentence/motion/gesture]`, `the word cost him`, `paid in silence`, `[action] cost her` (non-literal) |
+| **11.5 Near-miss body language** | `did not quite become`, `almost became a`, `never quite [verb]` — flag count per scene |
+| **11.6 Body-part agency** | `[hand\|breath\|stomach\|shoulders\|face\|mouth\|eyes\|chest\|throat\|jaw\|spine\|fingers\|knee\|feet\|legs] + [had been\|was\|were\|kept\|started\|began] + [deciding\|having\|choosing\|wanting\|refusing\|trying\|failing\|knowing]` — see Section 11.6 for full regex |
+| **11.6 Trust-split** | `trust his/her/my face`, `trust his/her voice`, `trust his/her hands` + `distrust`/`not trust` variants |
+| **11.7 Backward-negation loop** | `what [pronoun] had been refusing/unable/failing to [verb]` where the verb echoes the sentence's opening action |
+| **11.8 Expository repeat** | Same noun-phrase or logical constraint appearing in two consecutive sentences — second sentence restates first to justify a narrative gap |
+
+**11.5 scoring:** One near-miss per scene is acceptable. Two or more in the same scene → flag all instances.
+
+### Pass 2: Flagged Vocabulary (Section 1)
+
+Scan for the 55 flagged words from Section 1 of anti-ai-patterns.md (`delve`, `tapestry`, `nuanced`, `vibrant`, `landscape` (metaphorical), `embark`, `resonate`, `pivotal`, `realm`, `testament`, `intricate`, `myriad`, `unprecedented`, `foster`, `navigate` (metaphorical), etc.).
+
+For each hit: record word, sentence, context. Do not flag words that are clearly literal or in-character dialect.
+
+Also check author profile's `writing_discoveries.donts` and `vocabulary.md` banned list — these are book/author-specific additions.
+
+## Output: Scan Report
+
+After both passes, present the findings as a numbered list. Do NOT apply any changes yet.
+
+```
+## Humanizer Scan — {book-slug} / {chapter-slug}
+
+**Section 11 shapes found: N**
+**Flagged vocabulary hits: M**
+**Near-miss count per scene: [Sc1: X, Sc2: Y, ...]**
+
+---
+
+### Hits
+
+[1] **11.6 Body-part agency** — Sc 2, ~line 47
+> *"His throat had been refusing to close on what he'd been holding since yesterday."*
+Proposed fix: *"His throat tightened. Yesterday he hadn't been able to cry. He still couldn't, not entirely."*
+
+[2] **11.6 Trust-split** — Sc 2, ~line 52
+> *"stayed there until he could trust his face again."*
+Proposed fix: *"He held still. When he was sure his expression had settled, he moved."*
+
+[3] **11.8 Expository repeat** — Sc 3, ~line 89
+> *"They had silver on her and weren't careful about the rest. They did not look under the shirt of a vampire they had silver on."*
+Proposed fix: *"Silver was enough. They didn't check further."*
+
+[4] **Flagged vocabulary** — Sc 1, ~line 12
+> *"...the nuanced tension between them..."*
+Proposed fix: *"...the tension between them, which neither named..."*
+
+---
+
+**Instructions:** Reply with the hit numbers you want to apply as-is, numbers you want a different alternative for (e.g. "3: shorter"), and numbers you want to skip. Example: "apply 1, 2, 4 / rework 3: make it one sentence / skip none"
+```
+
+**Do not present more than 20 hits at once.** If the chapter has more, present the first 20, apply those, then continue with the next batch.
+
+## Interaction Loop
+
+### User Response Formats
+
+The user responds with one of:
+
+- `apply all` — Apply every proposed fix as-is.
+- `apply N, M, ...` — Apply specific hit numbers as-is.
+- `skip N, M, ...` — Leave those hits unchanged.
+- `N: [instruction]` — Rework hit N with the given instruction before applying.
+- `apply N, M / skip P / Q: shorter` — Mixed response.
+
+### Rework
+
+When the user requests a rework (`N: [instruction]`), generate a revised alternative that:
+- Addresses the specific instruction
+- Stays in the author's documented voice
+- Does not introduce new Section 11 shapes or flagged vocabulary
+
+Present the rework for confirmation before applying: *"Rework for [N]: '[revised text]' — ok?"*
+
+### Applying Changes
+
+After the user approves (or applies with reworks confirmed):
+
+1. Read the full `draft.md` again before writing (GH#27 — file may have changed if the session has been long).
+2. Apply ALL approved changes in a single write pass — do not write the file multiple times.
+3. Report: *"Applied N changes. Skipped M. Draft updated."*
+4. If flagged vocabulary was accepted to stay, note it: *"[word] kept at your request."*
+
+### Iteration
+
+After applying, offer: *"Möchtest du noch eine Runde? Oder weiter zu `/storyforge:chapter-proofreader`?"*
+
+If the user wants another pass: re-scan the updated draft (the fixes may have introduced new issues — rare but possible). Cap at 2 iterations per session.
+
+## Rules
+
+- **Surgical only.** Change only the flagged construction. Do not improve surrounding prose, fix style, or add content. The chapter-reviewer already handled craft.
+- **Author voice is mandatory.** Every proposed alternative must match the author's documented tone, rhythm, and vocabulary. An alternative that sounds like a different author is a regression, not a fix.
+- **No wholesale rewrites.** If a passage has so many Section 11 shapes that individual fixes would require reconstructing the scene, stop and tell the user: *"Szene [N] hat [X] overlapping shapes — eine gezielte Überarbeitung der ganzen Szene wäre effizienter als Einzelfixes. Soll ich Vorschläge für die ganze Szene machen?"* Then wait for explicit confirmation before proceeding.
+- **Do not create new AI-tells.** Before proposing any fix, run a quick mental check: does the proposed alternative introduce a new Section 11 shape, flagged vocabulary word, or other known tell?
+- **Read the full file before writing.** GH#27 applies here. Always re-read `draft.md` before the write pass.
+- **voice-checker is optional after humanizing.** If the user wants a holistic score after this pass, suggest `/storyforge:voice-checker`. But the humanizer's targeted pass is more actionable for the patterns it covers.

--- a/skills/chapter-proofreader/SKILL.md
+++ b/skills/chapter-proofreader/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Check a chapter for spelling, grammar, and punctuation errors in the book's writing language.
   Explanations are delivered in the author's native language.
   Use when: (1) User says "Kapitel proofreaden", "proofread chapter", "Korrekturlesen",
-  (2) After chapter-reviewer craft fixes are applied, before manuscript-checker.
+  (2) After chapter-humanizer AI-tell pass, before manuscript-checker.
   Works for both fiction and memoir books.
 model: claude-sonnet-4-6
 user-invocable: true
@@ -14,7 +14,7 @@ argument-hint: "<book-slug> <chapter-slug>"
 # Chapter Proofreader
 
 Checks language correctness — spelling, grammar, punctuation — on prose that is already
-craft-stable (after chapter-reviewer). Does NOT check craft, voice, or cross-chapter patterns.
+craft-stable (after chapter-reviewer + chapter-humanizer). Does NOT check craft, voice, or cross-chapter patterns.
 
 ## Step 1 — Resolve Languages
 

--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -130,7 +130,7 @@ Apply ALL craft rules (Steps 3-6 from Mode B). Write ONLY this scene.
 
 **Pre-write tactical check:** if the scene involves combat OR group movement (`walk`, `hike`, `drive`, `attack`, `mission`, `enter the building`, `approach`, multi-character formation), the brief's `tactical_constraints` may already be populated. If not — or if the scene's specific outline differs — call MCP `verify_tactical_setup(book_slug, scene_outline_text, characters_present)` and resolve every warn-severity warning before drafting.
 
-**Pre-append:** run the Step 6c Simile Discipline Scan. No scene enters `draft.md` before the scan.
+**Pre-append:** run the Step 6c Simile Discipline Scan, then the Step 6d Elegant Abstraction Scan. No scene enters `draft.md` before both scans pass.
 
 After writing:
 1. **Append directly to `{project}/chapters/{chapter}/draft.md`** — never paste prose into chat. If `draft.md` doesn't exist, create it with `# Chapter N: Title` above the first scene. Separate scenes with a blank line.
@@ -186,6 +186,34 @@ For clean scenes, silence is fine. When cuts happen, optionally note "Simile-Sca
 
 ---
 
+### Step 6d: Elegant Abstraction Scan (MANDATORY, both modes, pre-save)
+
+Runs IMMEDIATELY AFTER the Simile Discipline Scan (Step 6c), BEFORE any prose is appended to `draft.md`. Reference: `anti-ai-patterns.md` Section 11 for the full shape catalog and examples.
+
+These shapes cluster at high-stakes moments (deaths, declarations, confrontations) and are statistically respectable — they appear in published fiction — but they render emotional weight through abstraction instead of specific physical reality. They pass casual review and are the primary reason AI-generated prose feels "off" even when vocabulary and structure seem fine.
+
+**Scan markers — check every sentence for these constructions:**
+
+| Shape (Section) | Markers to search |
+|---|---|
+| 11.1 Word-count commentary | `One word.` / `Two words.` / `Three words.` followed by narrator editorial |
+| 11.2 Sentence-as-projectile | `the words landed`, `the line landed`, `settled into the room` |
+| 11.3 Room-as-receiver | `the room received`, `the silence held`, `the hall absorbed` |
+| 11.4 Economic metaphor | `most expensive sentence`, `the word cost him`, `paid in silence` |
+| 11.5 Near-miss body language | `did not quite become`, `almost became a`, `never quite [verb]` — flag if 2+ per scene |
+| 11.6 Body-part agency | `[hand/breath/stomach/shoulders/face/mouth/eyes/chest/throat/jaw/spine/fingers/knee/feet/legs] + [had been/was/were/kept/started/began] + [deciding/choosing/wanting/refusing/failing/knowing]` — full regex in Section 11.6 |
+| 11.6 Trust-split | `trust his/her/my face/voice/hands/body/expression` + `distrust`/`not trust` variants |
+| 11.7 Backward-negation loop | `what [pronoun] had been refusing/unable to [verb]` echoing the opening verb |
+| 11.8 Expository repeat | Same key phrase or logical constraint in two consecutive sentences |
+
+**For each hit:** Ask — can this be replaced by a named body doing a physical thing? If yes, replace it. If the hit is a near-miss (11.5) and it's the first in the scene, it may stay. If it's the second or more, cut.
+
+**Fix direction (same for all shapes):** Route the emotional weight through a named body in the room. Whose eyes did not move. Whose hand stilled. Whose breath came faster. Specificity is the antidote.
+
+When cuts happen, optionally note "EA-Scan: N cut, M revised" alongside the scene metadata line. Do not skip — these shapes are invisible to the vocabulary-scan in Step 6 and are the most common source of AI-register complaints from readers.
+
+---
+
 ### Step 7: Save and Update (both modes)
 1. Draft is at `{project}/chapters/{chapter}/draft.md`. Count words — report to user.
 2. **Extract promises (Issue #150)** — Before flipping status to `Review` or `Final`, walk the completed draft and identify setup-elements (locked drawers, character claims, cryptic warnings, unresolved clues — full taxonomy in `reference/craft/plot-logic.md`). For each: short concrete description (8–14 words), target chapter slug if the chapter outline names it else `unfired`, status `active`. Cap at 8 per chapter. Persist via MCP `register_chapter_promises(book_slug, chapter_slug, promises)`. If the chapter places no promises, pass an empty list — this writes a placeholder so the index knows the chapter was processed. Skip this step when staying at `Draft` (mid-chapter saves don't lock in promises).
@@ -228,6 +256,7 @@ Before presenting to user (in full-chapter mode) or after all scenes assembled (
 - Does the POV character's emotional state change?
 - Would a reader know which character is speaking without dialog tags?
 - **Simile discipline** — Confirm the Step 6c scan ran on every scene/section. No decorative or illogical comparisons survived. No stacked similes. No dead similes. `the kind of X that Y` constructions inspected.
+- **Elegant abstraction** — Confirm the Step 6d scan ran. No body-part agency, no room-as-receiver, no backward-negation loops, no expository repeats. Section 11 shapes are the primary source of AI-register complaints — never skip.
 - **Litmus test** — If `plot/tone.md` exists, answer EVERY question from the Litmus Test section. If more than 1 answer is "no", flag it to the user and suggest specific revisions before proceeding.
 - **Time consistency** — Verify that every time reference in the chapter (explicit or relative) is consistent with the Chapter Timeline you created in Step 7.
 
@@ -250,6 +279,7 @@ If the user is blocked or struggling: redirect to `/storyforge:unblock` instead 
 - Resolve `book_category` in Step 0 before any prerequisite load. The fiction and memoir prerequisite sets are non-overlapping.
 - Author profile is LAW. SHOW don't tell. Every scene needs conflict. Dialog has subtext. Banned words trigger sentence rewrite.
 - **Simile Discipline (Step 6c) is non-negotiable.** Every scene survives the two-question test before it enters `draft.md`. Author-voice bias = quality not quantity. See `simile-discipline.md`.
+- **Elegant Abstraction Scan (Step 6d) is non-negotiable.** Every scene passes the Section 11 shape-check before entering `draft.md`. These shapes look literary but render emotion through abstraction — they are the primary AI-register failure mode at high-stakes moments. See `anti-ai-patterns.md` Section 11.
 - Honor every entry in the brief's `rules_to_honor` (book CLAUDE.md ## Rules) — `severity: block` rules will be hard-blocked by the PostToolUse hook. Honor `tone_litmus_questions` (from `plot/tone.md`) when present.
 - Never write a relative time reference without checking against the brief's `story_anchor` and `recent_chapter_timelines`. If the math doesn't work, adjust the prose — not the timeline.
 - The Chapter Timeline section in `README.md` is MANDATORY at review status. Future chapters depend on it.

--- a/skills/next-step/SKILL.md
+++ b/skills/next-step/SKILL.md
@@ -28,14 +28,16 @@ user-invocable: true
    | World Built | `/storyforge:chapter-writer` ch.1 | Start writing! |
    | Drafting | `/storyforge:chapter-writer` next unwritten chapter | Keep writing |
    | Drafting → Revision (all chapters drafted) | `/storyforge:chapter-reviewer` on first unreviewed chapter | Start per-chapter craft review before the full-book pass |
-   | Revision (chapter-reviewer done, proofreader not yet run) | `/storyforge:chapter-proofreader` on first un-proofread chapter | Language correctness pass: spelling, grammar, punctuation — after craft fixes are stable |
+   | Revision (chapter-reviewer done, humanizer not yet run) | `/storyforge:chapter-humanizer` on first un-humanized chapter | Targeted AI-construction scan: Section 11 elegant-abstraction shapes + flagged vocabulary, interactive fix proposals |
+   | Revision (humanizer done, proofreader not yet run) | `/storyforge:chapter-proofreader` on first un-proofread chapter | Language correctness pass: spelling, grammar, punctuation — after humanizer pass |
    | Revision (all chapters proofread) | `/storyforge:manuscript-checker` | Catch cross-chapter prose issues (rules, clichés, dialogue punctuation, filter words, adverbs, repetition) |
-   | Editing | `/storyforge:voice-checker` | Final authenticity check |
+   | Editing | `/storyforge:voice-checker` (optional) | Holistic AI-authenticity score 0–100 across 7 dimensions — use when you want a scorecard, not a required step |
    | Proofread | `/storyforge:export-engineer` | Generate the book file |
    | Export Ready | `/storyforge:translator` or publish | Translate or distribute |
 
 4. **Check for incomplete work**
-   - Any chapters reviewed but not yet proofread? → Suggest `chapter-proofreader`
+   - Any chapters reviewed but not yet humanized? → Suggest `chapter-humanizer`
+   - Any chapters humanized but not yet proofread? → Suggest `chapter-proofreader`
    - Any chapters in "Draft" that need review? → Suggest `chapter-reviewer`
    - Characters still in "Concept"? → Suggest `character-creator`
    - Missing plot outline? → Suggest `plot-architect`

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -60,7 +60,7 @@ argument-hint: "<book-slug>"
    | Characters Created | `/storyforge:world-builder` |
    | World Built | `/storyforge:chapter-writer [book] 1` |
    | Drafting | `/storyforge:chapter-writer [book] [next]` |
-   | Revision | `/storyforge:chapter-reviewer` |
-   | Editing | `/storyforge:voice-checker` |
+   | Revision | `/storyforge:chapter-reviewer` → `chapter-humanizer` → `chapter-proofreader` |
+   | Editing | `/storyforge:manuscript-checker` + optionally `/storyforge:voice-checker` |
    | Proofread | `/storyforge:export-engineer` |
    | Export Ready | `/storyforge:export-engineer [book] epub` |

--- a/skills/voice-checker/SKILL.md
+++ b/skills/voice-checker/SKILL.md
@@ -3,7 +3,8 @@ name: voice-checker
 description: |
   Check if written text sounds AI-generated. Compare against author profile for authenticity.
   Use when: (1) User says "voice check", "klingt das nach AI?",
-  (2) After drafting, as a final authenticity gate.
+  (2) After humanizer pass, as an optional holistic score check (0–100 across 7 dimensions).
+  Not a required step in the standard workflow — use chapter-humanizer for targeted AI-tell removal.
 model: claude-opus-4-7
 user-invocable: true
 argument-hint: "<book-slug> [chapter-slug]"


### PR DESCRIPTION
## Summary

- New `chapter-humanizer` skill: surgical, interactive AI-construction scan that identifies Section 11 elegant-abstraction shapes and flagged vocabulary, proposes in-voice alternatives per hit, and writes approved changes back to `draft.md`
- New mandatory `Step 6d` in `chapter-writer`: Elegant Abstraction Scan with lookup table for all 8 Section-11 shapes — runs pre-save alongside the existing Simile Discipline Scan
- Extended `anti-ai-patterns.md` Section 11 with 3 new patterns derived from real chapter-draft failures (11.7 Backward-Negation-Loop, 11.8 Expository Repeat, 11.6 trust-split variant)
- Workflow pipeline updated: humanizer inserted between `chapter-reviewer` and `chapter-proofreader`; `voice-checker` demoted to optional standalone diagnostic

## New workflow order

```
chapter-writer → chapter-reviewer → chapter-humanizer → chapter-proofreader → manuscript-checker
```
`voice-checker` remains available as an optional holistic score check (0–100 / 7 dimensions).

## Why

The three patterns that triggered this work were all Section-11 variants that passed `chapter-writer`'s Step 6 unchallenged because Step 6 referenced `anti-ai-patterns.md` generically without a structured scan. The Simile Discipline Scan (Step 6c) works because it has explicit markers and a mandatory pre-save step — Step 6d replicates that pattern for elegant-abstraction shapes.

The `chapter-humanizer` separates the diagnostic from the prescriptive: `chapter-reviewer` flags craft issues, humanizer targets AI-construction patterns specifically, with interactive per-hit approval.

## Test plan

- [ ] Run `/storyforge:next-step` after a chapter-review pass — should suggest `chapter-humanizer`, not `chapter-proofreader`
- [ ] Run `/storyforge:chapter-humanizer` on Ch30 Sc3 draft — should flag the backward-negation-loop and expository-repeat examples
- [ ] Run `/storyforge:chapter-writer` new scene — Step 6d scan table should appear in pre-save output
- [ ] Run `/storyforge:resume [book]` in Revision status — routing should show reviewer → humanizer → proofreader chain
- [ ] Smoke tests: `pytest tests/smoke/ -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)