### PR TITLE
feat(chapter-writer): upgrade Step 6d EA-Scan to interactive hard-gate

### DIFF
--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -130,7 +130,7 @@ Apply ALL craft rules (Steps 3-6 from Mode B). Write ONLY this scene.
 
 **Pre-write tactical check:** if the scene involves combat OR group movement (`walk`, `hike`, `drive`, `attack`, `mission`, `enter the building`, `approach`, multi-character formation), the brief's `tactical_constraints` may already be populated. If not — or if the scene's specific outline differs — call MCP `verify_tactical_setup(book_slug, scene_outline_text, characters_present)` and resolve every warn-severity warning before drafting.
 
-**Pre-append:** run the Step 6c Simile Discipline Scan, then the Step 6d Elegant Abstraction Scan. No scene enters `draft.md` before both scans pass.
+**Pre-append:** run the Step 6c Simile Discipline Scan (model fixes autonomously), then the Step 6d Elegant Abstraction Scan (interactive hard-gate — user resolves every hit before appending). No scene enters `draft.md` until both scans are complete and all EA hits resolved or explicitly skipped.
 
 After writing:
 1. **Append directly to `{project}/chapters/{chapter}/draft.md`** — never paste prose into chat. If `draft.md` doesn't exist, create it with `# Chapter N: Title` above the first scene. Separate scenes with a blank line.
@@ -186,9 +186,9 @@ For clean scenes, silence is fine. When cuts happen, optionally note "Simile-Sca
 
 ---
 
-### Step 6d: Elegant Abstraction Scan (MANDATORY, both modes, pre-save)
+### Step 6d: Elegant Abstraction Scan — Interactive Hard-Gate (MANDATORY, both modes, pre-save)
 
-Runs IMMEDIATELY AFTER the Simile Discipline Scan (Step 6c), BEFORE any prose is appended to `draft.md`. Reference: `anti-ai-patterns.md` Section 11 for the full shape catalog and examples.
+Runs IMMEDIATELY AFTER the Simile Discipline Scan (Step 6c). **No prose enters `draft.md` until this scan is fully resolved.** Reference: `anti-ai-patterns.md` Section 11 for the full shape catalog and examples.
 
 These shapes cluster at high-stakes moments (deaths, declarations, confrontations) and are statistically respectable — they appear in published fiction — but they render emotional weight through abstraction instead of specific physical reality. They pass casual review and are the primary reason AI-generated prose feels "off" even when vocabulary and structure seem fine.
 
@@ -203,14 +203,39 @@ These shapes cluster at high-stakes moments (deaths, declarations, confrontation
 | 11.5 Near-miss body language | `did not quite become`, `almost became a`, `never quite [verb]` — flag if 2+ per scene |
 | 11.6 Body-part agency | `[hand/breath/stomach/shoulders/face/mouth/eyes/chest/throat/jaw/spine/fingers/knee/feet/legs] + [had been/was/were/kept/started/began] + [deciding/choosing/wanting/refusing/failing/knowing]` — full regex in Section 11.6 |
 | 11.6 Trust-split | `trust his/her/my face/voice/hands/body/expression` + `distrust`/`not trust` variants |
-| 11.7 Backward-negation loop | `what [pronoun] had been refusing/unable to [verb]` echoing the opening verb |
+| 11.7 Backward-negation loop | `what [pronoun] had been refusing/unable to [verb]`; `had not known [noun clause] could [verb]`; `could not [verb] without [negative consequence]` — defining an experience through its negation or refusal |
 | 11.8 Expository repeat | Same key phrase or logical constraint in two consecutive sentences |
 
-**For each hit:** Ask — can this be replaced by a named body doing a physical thing? If yes, replace it. If the hit is a near-miss (11.5) and it's the first in the scene, it may stay. If it's the second or more, cut.
+**Scan protocol:**
+
+1. Scan all prose in the current scene for the above markers.
+2. If **zero hits**: emit `EA-Scan: clean ✓` and proceed to append.
+3. If **5 or more hits**: stop and flag it. These shapes cluster — a scene with 5+ hits needs a rewrite, not spot-welding. Tell the user: "This scene has N EA-hits. Patching this many shapes risks losing coherence — recommend rewriting from scratch. Proceed with per-hit fixes or rewrite?" Wait for the user's choice before continuing.
+4. If **1–4 hits**: do NOT append yet. **EA-Scan display blocks are the documented exception to the prose-in-chat rule** — they appear in chat as diagnostic blocks, not as prose. Present each hit to the user, one at a time:
+
+```
+EA-Scan — hit N/M — Shape 11.X [Name]
+--------------------------------------
+Original: "[flagged sentence, verbatim]"
+Fix:      "[proposed replacement — physical, specific, named body]"
+
+apply / skip / try again
+```
+
+   If this is the **second or later 11.5 hit** in the scene, add `[11.5 recurrence — pushback required before skip]` and offer a concrete alternative before accepting a skip.
+
+5. Wait for user response per hit:
+   - `apply` — write the fix into the scene text, proceed to next hit
+   - `skip` — keep original, proceed to next hit (shape remains; user accepts it deliberately)
+   - `try again` or free text — user proposes an alternative or requests a different angle; iterate. After **3 try-again iterations** on the same hit, ask: "Provide the replacement text directly, or type `skip`."
+
+6. After ALL hits are resolved (applied or explicitly skipped), append the corrected scene to `draft.md`. In the chat metadata line (scene number / word count / summary) add: `EA-Scan: N fixed, M skipped`.
 
 **Fix direction (same for all shapes):** Route the emotional weight through a named body in the room. Whose eyes did not move. Whose hand stilled. Whose breath came faster. Specificity is the antidote.
 
-When cuts happen, optionally note "EA-Scan: N cut, M revised" alongside the scene metadata line. Do not skip — these shapes are invisible to the vocabulary-scan in Step 6 and are the most common source of AI-register complaints from readers.
+**Why Step 6d is interactive but Step 6c is not:** Simile failures are clear-cut (dead simile, stacked simile, illogical vehicle); the model can fix them reliably. Section 11 shapes are statistically respectable — they appear in published fiction and often sit at peak emotional moments, so whether a given instance is an AI-tell or a deliberate effect requires authorial judgment. The fix must stay in voice. Hence: interactive.
+
+Do not silently bypass the scan — these shapes are invisible to the vocabulary-scan in Step 6 and are the most common source of AI-register complaints from readers.
 
 ---
 
@@ -256,7 +281,7 @@ Before presenting to user (in full-chapter mode) or after all scenes assembled (
 - Does the POV character's emotional state change?
 - Would a reader know which character is speaking without dialog tags?
 - **Simile discipline** — Confirm the Step 6c scan ran on every scene/section. No decorative or illogical comparisons survived. No stacked similes. No dead similes. `the kind of X that Y` constructions inspected.
-- **Elegant abstraction** — Confirm the Step 6d scan ran. No body-part agency, no room-as-receiver, no backward-negation loops, no expository repeats. Section 11 shapes are the primary source of AI-register complaints — never skip.
+- **Elegant abstraction** — Confirm the Step 6d scan ran on every scene/section. Any surviving Section 11 shapes are user-approved skips — not oversights. If any shape is present that was not surfaced in the EA-Scan, that is a failure.
 - **Litmus test** — If `plot/tone.md` exists, answer EVERY question from the Litmus Test section. If more than 1 answer is "no", flag it to the user and suggest specific revisions before proceeding.
 - **Time consistency** — Verify that every time reference in the chapter (explicit or relative) is consistent with the Chapter Timeline you created in Step 7.
 
@@ -279,7 +304,7 @@ If the user is blocked or struggling: redirect to `/storyforge:unblock` instead 
 - Resolve `book_category` in Step 0 before any prerequisite load. The fiction and memoir prerequisite sets are non-overlapping.
 - Author profile is LAW. SHOW don't tell. Every scene needs conflict. Dialog has subtext. Banned words trigger sentence rewrite.
 - **Simile Discipline (Step 6c) is non-negotiable.** Every scene survives the two-question test before it enters `draft.md`. Author-voice bias = quality not quantity. See `simile-discipline.md`.
-- **Elegant Abstraction Scan (Step 6d) is non-negotiable.** Every scene passes the Section 11 shape-check before entering `draft.md`. These shapes look literary but render emotion through abstraction — they are the primary AI-register failure mode at high-stakes moments. See `anti-ai-patterns.md` Section 11.
+- **Elegant Abstraction Scan (Step 6d) is a non-negotiable interactive hard-gate.** No scene enters `draft.md` until every Section 11 hit is either fixed or explicitly skipped by the user. The model does not fix autonomously — each hit is presented, a replacement proposed, user approves. These shapes look literary but render emotion through abstraction; they are the primary AI-register failure mode at high-stakes moments. See `anti-ai-patterns.md` Section 11.
 - Honor every entry in the brief's `rules_to_honor` (book CLAUDE.md ## Rules) — `severity: block` rules will be hard-blocked by the PostToolUse hook. Honor `tone_litmus_questions` (from `plot/tone.md`) when present.
 - Never write a relative time reference without checking against the brief's `story_anchor` and `recent_chapter_timelines`. If the math doesn't work, adjust the prose — not the timeline.
 - The Chapter Timeline section in `README.md` is MANDATORY at review status. Future chapters depend on it.


### PR DESCRIPTION
## Summary

- **Step 6d (Elegant Abstraction Scan)** upgraded from autonomous-fix to interactive hard-gate
- Each Section 11 shape-hit is now presented verbatim to the author with a proposed fix; the author responds per hit (`apply` / `skip` / `try again`)
- No scene enters `draft.md` until every hit is either fixed or explicitly skipped by the author
- Skipped hits are recorded in the chat metadata line (`EA-Scan: N fixed, M skipped`) — visible, not silent

## Motivation

The autonomous scan had a structural flaw: the model decided which EA-shapes stayed and which changed, without the author ever seeing the decision. High-stakes scenes (deaths, confrontations, declarations) are exactly where Section 11 shapes cluster, and exactly where the author's judgment — not the model's — should govern.

The interactive gate also makes the scan educational: seeing "Original / Fix" side-by-side trains the author to recognize the shapes themselves.

## Additional changes in this PR

- **Escape hatch for heavy scenes (≥5 hits):** Recommend scene rewrite rather than patching 5+ spots
- **try-again iteration cap:** After 3 try-again rounds on the same hit, prompt for direct replacement text or `skip`
- **11.5 recurrence tracking:** Second-or-later `almost became` hits flagged differently in the display; skip requires pushback first
- **Pre-append wording clarified:** Step 6c = autonomous (similes are clear-cut), Step 6d = interactive (EA-shapes require authorial judgment)
- **Step 8 Self-Review updated:** Surviving shapes are user-approved skips, not scan failures
- **11.7 markers tightened:** `had not known [noun clause] could [verb]`; `could not [verb] without [negative consequence]` — concrete markers replacing the vague "defining an experience through what it failed to be"
- **Prose-in-chat carve-out documented:** EA-Scan display blocks are the explicit exception to the "prose to draft.md, not chat" rule

## Skill size note

`skills/chapter-writer/SKILL.md` is at 332 LOC / 32.8 k chars — over the 25 k char threshold but under 400 LOC. Refs: Epic #179 (chapter-writer refactor tracking). No split in this PR; the complexity is justified by the quality gates enforced.

## Type of change

- [x] New feature (non-breaking behavior improvement)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation only

## Test plan

- [ ] Write a chapter scene with clear Section 11 hits (use backward-negation loop, body-part agency, expository repeat)
- [ ] Verify EA-Scan presents each hit interactively in chat, not appended to `draft.md`
- [ ] Verify `apply` fixes the sentence and moves to next hit
- [ ] Verify `skip` keeps original and records in metadata
- [ ] Verify `try again` iterates (and caps at 3)
- [ ] Verify scene with 0 hits gets `EA-Scan: clean ✓` and proceeds without interruption
- [ ] Verify scene with ≥5 hits triggers rewrite recommendation

🤖 Generated with [Claude Code](https://claude.com/claude-code)