### PR TITLE
fix: coherence audit — broken MCP calls, routing, model names, workflow numbering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Phase 1 (#54–#56, #67) adds the field plus knowledge scaffold. Skill branching
 | "promote rule" / "rule global machen" / "Regel hochstufen" / "promote to author" / "promote to global" | `/storyforge:promote-rule` |
 | "harvest author rules" / "book to author" / "author rules" / "promote findings" / "Findings ins Autorenprofil" / "Buch-Erkenntnisse promoten" | `/storyforge:harvest-author-rules` |
 | "harvest evolution" / "evolve characters" / "harvest character evolution" / "Charakter-Evolution ernten" / "Tracker abgleichen" | `/storyforge:harvest-character-evolution` |
-| "bootstrap from series" / "bootstrap book" / "Charaktere aus Serie initialisieren" / "neues Buch initialisieren" | `/storyforge:bootstrap-book-from-series` |
+| "bootstrap from series" / "bootstrap book" / "Charaktere aus Serie initialisieren" / "Charakter-Snapshots für B2/B3 initialisieren" | `/storyforge:bootstrap-book-from-series` |
 | "rules audit" / "regeln prüfen" / "rules check" / "rules cleanup" / "audit my rules" | `/storyforge:rules-audit` |
 | "backfill promises" / "promises nachfüllen" / `/storyforge:backfill-promises` | `/storyforge:backfill-promises` |
 | "Recherche" / "Research" | `/storyforge:researcher` |
@@ -133,12 +133,12 @@ Phase 1 (#54–#56, #67) adds the field plus knowledge scaffold. Skill branching
 6. `/storyforge:rolling-planner` — Scene-by-scene planning buffer (3-5 scenes ahead)
 8. `/storyforge:chapter-writer` — Write chapters in author's voice (loads timeline + travel matrix + tonal document + chapter timeline)
 9. `/storyforge:continuity-checker` — (Optional, after several chapters) Validate timeline and location consistency
-9. `/storyforge:chapter-reviewer` — Review each chapter for craft, voice, structure, and AI-tells
-9a. `/storyforge:chapter-humanizer` — Targeted AI-construction scan; identifies Section 11 elegant-abstraction shapes and flagged vocabulary; proposes human alternatives interactively; runs AFTER chapter-reviewer craft fixes
-9b. `/storyforge:chapter-proofreader` — Language correctness per chapter: spelling, grammar, punctuation — runs AFTER humanizer pass; explanations in author's native_language
-9c. `/storyforge:manuscript-checker` — (At drafting → revision transition) Scan the whole manuscript for book-rule violations, clichés, dialogue punctuation, filter words, adverb density, and cross-chapter repetition
-9d. `/storyforge:beta-feedback` — (After eBook/ARC stage) Process curated beta-reader feedback, triage, revision plan
-10. `/storyforge:voice-checker` — (Optional) Holistic AI-authenticity score (0–100) across 7 dimensions; use when you want a scorecard rather than targeted fixes; not a required step in the standard workflow
+10. `/storyforge:chapter-reviewer` — Review each chapter for craft, voice, structure, and AI-tells
+10a. `/storyforge:chapter-humanizer` — Targeted AI-construction scan; identifies Section 11 elegant-abstraction shapes and flagged vocabulary; proposes human alternatives interactively; runs AFTER chapter-reviewer craft fixes
+10b. `/storyforge:chapter-proofreader` — Language correctness per chapter: spelling, grammar, punctuation — runs AFTER humanizer pass; explanations in author's native_language
+10c. `/storyforge:manuscript-checker` — (At drafting → revision transition) Scan the whole manuscript for book-rule violations, clichés, dialogue punctuation, filter words, adverb density, and cross-chapter repetition
+10d. `/storyforge:beta-feedback` — (After eBook/ARC stage) Process curated beta-reader feedback, triage, revision plan
+11. `/storyforge:voice-checker` — (Optional) Holistic AI-authenticity score (0–100) across 7 dimensions; use when you want a scorecard rather than targeted fixes; not a required step in the standard workflow
 11. `/storyforge:cover-artist` — Generate cover prompts
 12. `/storyforge:export-engineer` — EPUB/PDF/MOBI via Pandoc
 13. `/storyforge:promo-writer` — Social media campaign (FB, Instagram, TikTok, X, Bluesky, Newsletter)

--- a/skills/character-creator/SKILL.md
+++ b/skills/character-creator/SKILL.md
@@ -153,7 +153,7 @@ Map relationships to other characters:
 - How do relationships change through the story?
 
 ### Step 14: Write Character File
-Update the character file with all developed details via MCP `update_character()` or direct Write.
+Update the character file with all developed details via direct Write.
 Update `{project}/characters/INDEX.md` with the new character.
 
 After all major characters are created, update book status to "Characters Created".

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -3,7 +3,7 @@ name: help
 description: |
   Show available StoryForge skills, workflow overview, and quick-start guide.
   Use when: (1) User says "help", "Hilfe", "was kann das Plugin?"
-model: claude-haiku-4-5-20251001
+model: claude-haiku-4-5
 user-invocable: true
 ---
 

--- a/skills/ideas/SKILL.md
+++ b/skills/ideas/SKILL.md
@@ -4,7 +4,7 @@ description: |
   List, filter, and manage book ideas. Shows ideas by status and genre.
   Use when: (1) User says "meine Ideen", "ideas", "was habe ich gespeichert",
   (2) User wants to pick up a parked idea, (3) User asks what ideas are ready.
-model: claude-haiku-4-5-20251001
+model: claude-haiku-4-5
 user-invocable: true
 argument-hint: "[status] [genre]"
 ---

--- a/skills/promote-rule/SKILL.md
+++ b/skills/promote-rule/SKILL.md
@@ -75,11 +75,21 @@ Use AskUserQuestion:
 
 ## Step 6: Execute Promotion
 
-Call MCP `promote_rule(phrase, reason, from_scope, to_scope, book_slug, author_slug, remove_from_source)`.
+Execute in two sub-steps:
+
+**Write to target scope:**
+- **Book → Author**: MCP `write_author_banned_phrase(author_slug, phrase, reason)` with reason including `_(promoted from book-scope on {today's date})_`.
+- **Author → Global** or **Book → Global**: Direct Write — append the rule entry to `{plugin_root}/reference/craft/anti-ai-patterns.md`.
 
 The `reason` is extracted from the existing rule entry or asked if not present:
 - Book CLAUDE.md: extract text after `` `{phrase}` — ``
 - Author vocabulary: use the section name as reason context
+
+**Remove from source (only when user chose "Yes, promote" in Step 5):**
+- **From book scope**: Read the book's CLAUDE.md via `get_book_claudemd(book_slug)`. Remove the rule entry via direct Edit. Call `get_book_claudemd(book_slug)` once more to confirm.
+- **From author scope**: Read `~/.storyforge/authors/{slug}/vocabulary.md` directly. Remove the phrase entry via direct Edit.
+
+Write to target first — confirm success before removing from source.
 
 ## Step 7: Report Result
 

--- a/skills/report-issue/SKILL.md
+++ b/skills/report-issue/SKILL.md
@@ -53,7 +53,7 @@ For structural rules (walking order, POV boundary) that cannot be expressed as a
 
 If the rule is a literal phrase or regex (not structural):
 
-Use MCP `run_manuscript_scan(book_slug, pattern)` if available. Otherwise:
+Use MCP `scan_manuscript(book_slug, pattern)` if available. Otherwise:
 1. List all chapter draft files: `{project}/chapters/*/draft.md`
 2. Read each draft and count occurrences of the phrase.
 3. Report: "Found N occurrences across M chapters: [chapter list with counts]"
@@ -84,11 +84,11 @@ Use AskUserQuestion:
 
 ## Step 6: Write the Rule
 
-Call the appropriate `rule_writer` function based on scope:
+Call the appropriate tool based on scope:
 
-- **Book scope**: MCP `write_rule_book(book_slug, phrase, reason, severity, source_context)`
-- **Author scope**: MCP `write_rule_author(author_slug, phrase, reason, source_context)`
-- **Global scope**: MCP `write_rule_global(phrase, reason, source_context)`
+- **Book scope**: MCP `append_book_rule(book_slug, phrase, reason, severity, source_context)`
+- **Author scope**: MCP `write_author_banned_phrase(author_slug, phrase, reason)`
+- **Global scope**: Direct Write — append the rule entry to `{plugin_root}/reference/craft/anti-ai-patterns.md`
 
 Where `source_context = "report-issue based on {book_title} Ch {chapter_number} review"`.
 

--- a/skills/study-author/SKILL.md
+++ b/skills/study-author/SKILL.md
@@ -107,12 +107,12 @@ mode: fiction
 ```
 
 ### Phase 4: Update Profile
-Update the author's `profile.md` and `vocabulary.md` based on findings:
-- Add characteristic words to "Preferred Words"
-- Refine tone descriptors based on evidence
-- Update sentence_style based on measured variance
-- Add discovered "Signature Techniques"
-- Update "Deliberate Imperfections" section
+Update the author's profile using MCP tools to ensure cache invalidation:
+
+- **Tone / sentence_style / other frontmatter fields** — MCP `update_author(slug, field, value)` per field
+- **Signature Techniques discovered** — MCP `write_author_discovery(author_slug, section="style_principles", text=<technique>, book_slug=<analyzed-work-slug>)`
+- **Anti-patterns to avoid** — MCP `write_author_banned_phrase(author_slug, phrase, reason=<why-avoid>)` per phrase
+- **Preferred Words / Deliberate Imperfections** — Direct Write to `~/.storyforge/authors/{slug}/vocabulary.md` (no MCP tool for these sections)
 
 ### Phase 5: Report
 Show the user a summary of what was learned and what changed in the profile.
@@ -199,12 +199,12 @@ mode: memoir
 ```
 
 ### Phase 4: Update Profile
-Update the author's `profile.md` and `vocabulary.md` based on findings:
-- Add unguarded personal phrases to "Signature Phrases"
-- Add personal vocabulary to "Preferred Words"
-- Note the natural tense and self-reference style
-- Flag hedging or avoidance patterns as memoir-specific risks to watch
-- Add preoccupation themes — these are the memoir's authentic emotional spine
+Update the author's profile using MCP tools to ensure cache invalidation:
+
+- **Tense / self-reference style / other frontmatter fields** — MCP `update_author(slug, field, value)` per field
+- **Unguarded phrases to preserve** — MCP `write_author_discovery(author_slug, section="style_principles", text=<phrase>, book_slug=<analyzed-work-slug>)`
+- **Hedging / avoidance patterns to flag** — MCP `write_author_banned_phrase(author_slug, phrase, reason="memoir-anti-ai: avoidance pattern")` per phrase
+- **Preferred Words / Signature Phrases / preoccupation themes** — Direct Write to `~/.storyforge/authors/{slug}/vocabulary.md` (no MCP tool for these sections)
 
 ### Phase 5: Report
 Show the user what was found and what changed. Specifically: which phrases are uniquely theirs and should survive editing, and which patterns (hedging, reflective platitudes) the memoir-anti-ai checker will flag.


### PR DESCRIPTION
## Summary

Fixes 7 concrete issues found during the coherence audit of 2026-05-18. All changes are skill documentation fixes — no server code changed.

- **C1** `report-issue` — wrong MCP tool names in Step 4 + Step 6 (`run_manuscript_scan` → `scan_manuscript`, phantom `write_rule_*` → real tools)
- **C2** `promote-rule` — phantom `promote_rule()` MCP call replaced with real orchestration via `write_author_banned_phrase` + direct Edit
- **C3** `character-creator` — `update_character()` doesn't exist; Step 14 now uses direct Write
- **H1** `CLAUDE.md` — "neues Buch initialisieren" removed from bootstrap trigger (misrouted to series bootstrap instead of new-book)
- **H3** `help`, `ideas` — Haiku model standardized to `claude-haiku-4-5` alias
- **L5** `CLAUDE.md` — duplicate step 9 in Plantser workflow fixed (reviewer now 10, voice-checker now 11)
- **M4** `study-author` — Phase 4 now uses `update_author`, `write_author_discovery`, `write_author_banned_phrase` explicitly; direct Write only where no MCP tool exists

## Audit note

M3 finding (harvest-character-evolution missing write_series_evolution_section) was incorrect — the skill uses it correctly in Step 3d. No change needed there.

## Test plan

- [ ] Trigger `/storyforge:report-issue` and verify Step 6 calls `append_book_rule` / `write_author_banned_phrase`
- [ ] Trigger `/storyforge:promote-rule` and verify no reference to phantom `promote_rule()` tool
- [ ] Verify `character-creator` Step 14 uses direct Write (no `update_character()` call)
- [ ] In CLAUDE.md: verify "neues Buch initialisieren" no longer routes to bootstrap
- [ ] Check `help` and `ideas` SKILL.md show `claude-haiku-4-5`
- [ ] Verify Plantser workflow steps: continuity-checker=9, reviewer=10, voice-checker=11

Closes #234 (partial — remaining items tracked in sub-issues #235–#242)

🤖 Generated with [Claude Code](https://claude.com/claude-code)