### PR TITLE
fix(#235): trim chapter-writer scan sections + skill-size smoke test

### DIFF
--- a/skills/chapter-writer/SKILL.md
+++ b/skills/chapter-writer/SKILL.md
@@ -176,11 +176,7 @@ Runs BEFORE any prose is appended to `draft.md`. Scene-by-scene mode: per scene 
 
 Reference: `simile-discipline.md` for the full heuristic. The scan enforces its two-question test (literal resemblance + real work) plus book-CLAUDE.md simile bans (already in the brief's `rules_to_honor`).
 
-Scan markers: `like [noun/clause]`, `as [adj] as`, `as if/as though`, `the way [subj] [verb]`, `moved/felt/sounded/looked/seemed like`, `resembled`, `reminded ___ of`, `gave the impression of`, `had the air of`, and the failure pattern `the kind of [noun] that [clause]`.
-
-For each hit: answer literal-resemblance and real-work honestly. Apply author-voice bias from the profile (simile-heavy authors get more leeway than sparse ones). Flag any paragraph with two or more simile markers — either each does distinct work or all but the strongest are cut. Reject dead similes on sight (*pale as a ghost*, *quick as lightning*, etc.). Revise: cut and replace with a beat first, swap the vehicle second, keep only if rework genuinely earned it.
-
-The brief's `recent_simile_count_per_chapter` shows what the last 3 chapters used — if a paragraph would push above ~3-4, cut harder. Book CLAUDE.md ## Rules in the brief's `rules_to_honor` override author-voice leniency.
+Apply author-voice bias from the author profile — simile-heavy voices get more leeway than sparse ones. The brief's `recent_simile_count_per_chapter` shows what the last 3 chapters used — if a paragraph would push above ~3-4, cut harder. Book CLAUDE.md ## Rules in `rules_to_honor` override author-voice leniency. See `simile-discipline.md` for the full marker list, failure modes, and revision moves.
 
 For clean scenes, silence is fine. When cuts happen, optionally note "Simile-Scan: N cut, M revised" alongside the scene metadata line. Do not skip — decorative similes are the recurring failure mode `prose-style.md` and `anti-ai-patterns.md` cannot catch alone.
 
@@ -190,21 +186,7 @@ For clean scenes, silence is fine. When cuts happen, optionally note "Simile-Sca
 
 Runs IMMEDIATELY AFTER the Simile Discipline Scan (Step 6c). **No prose enters `draft.md` until this scan is fully resolved.** Reference: `anti-ai-patterns.md` Section 11 for the full shape catalog and examples.
 
-These shapes cluster at high-stakes moments (deaths, declarations, confrontations) and are statistically respectable — they appear in published fiction — but they render emotional weight through abstraction instead of specific physical reality. They pass casual review and are the primary reason AI-generated prose feels "off" even when vocabulary and structure seem fine.
-
-**Scan markers — check every sentence for these constructions:**
-
-| Shape (Section) | Markers to search |
-|---|---|
-| 11.1 Word-count commentary | `One word.` / `Two words.` / `Three words.` followed by narrator editorial |
-| 11.2 Sentence-as-projectile | `the words landed`, `the line landed`, `settled into the room` |
-| 11.3 Room-as-receiver | `the room received`, `the silence held`, `the hall absorbed` |
-| 11.4 Economic metaphor | `most expensive sentence`, `the word cost him`, `paid in silence` |
-| 11.5 Near-miss body language | `did not quite become`, `almost became a`, `never quite [verb]` — flag if 2+ per scene |
-| 11.6 Body-part agency | `[hand/breath/stomach/shoulders/face/mouth/eyes/chest/throat/jaw/spine/fingers/knee/feet/legs] + [had been/was/were/kept/started/began] + [deciding/choosing/wanting/refusing/failing/knowing]` — full regex in Section 11.6 |
-| 11.6 Trust-split | `trust his/her/my face/voice/hands/body/expression` + `distrust`/`not trust` variants |
-| 11.7 Backward-negation loop | `what [pronoun] had been refusing/unable to [verb]`; `had not known [noun clause] could [verb]`; `could not [verb] without [negative consequence]` — defining an experience through its negation or refusal |
-| 11.8 Expository repeat | Same key phrase or logical constraint in two consecutive sentences |
+**Shape catalog:** `anti-ai-patterns.md` Section 11 has the full catalog, markers, and examples (11.1–11.10). Quick-scan markers: *One/Two/Three words.* narrator commentary (11.1); *the words/line landed* (11.2); *the room received / silence held* (11.3); *most expensive sentence / paid in silence* (11.4); *did not quite become* — flag 2+ per scene (11.5); body-part + deciding/refusing/knowing (11.6); *trust his/her/my face/hands* trust-split variants (11.6); backward-negation refusal clauses (11.7); same logical constraint in two consecutive sentences (11.8).
 
 **Scan protocol:**
 

--- a/tests/skills/test_skill_sizes.py
+++ b/tests/skills/test_skill_sizes.py
@@ -1,0 +1,62 @@
+"""Skill size guard — catches skills that exceed the budget defined in CLAUDE.md.
+
+CLAUDE.md rule: "Skill size: skills over 25 k chars or 400 LOC require a
+split-or-trim plan."
+
+This test warns at 28K (a buffer above the 25K rule) so we catch drift before
+it becomes a bloat problem. Known offenders are marked xfail so CI stays green
+while their trim plan is in progress.
+
+See: Issue #235 (chapter-writer trim plan)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent.parent
+SKILLS_DIR = PLUGIN_ROOT / "skills"
+WARN_BYTES = 28_000
+FRONTMATTER_SEP = "---"
+
+# Skills currently over budget with an active trim plan.
+# Remove the entry once the skill is trimmed under WARN_BYTES.
+KNOWN_OVERSIZED: dict[str, str] = {
+    "chapter-writer": "Issue #235 — trim plan in progress",
+}
+
+
+def _body_bytes(skill_file: Path) -> int:
+    text = skill_file.read_text(encoding="utf-8")
+    parts = text.split("---", 2)
+    body = parts[2] if len(parts) >= 3 else text
+    return len(body.encode("utf-8"))
+
+
+def _all_skills() -> list[tuple[str, Path]]:
+    return sorted(
+        (p.parent.name, p)
+        for p in SKILLS_DIR.rglob("SKILL.md")
+        if p.is_file()
+    )
+
+
+@pytest.mark.parametrize("skill_name,skill_file", _all_skills())
+def test_skill_size_budget(skill_name: str, skill_file: Path) -> None:
+    """Skill body must stay under the 28K warning threshold."""
+    size = _body_bytes(skill_file)
+    if size <= WARN_BYTES:
+        return
+
+    message = (
+        f"Skill '{skill_name}' body is {size:,} bytes "
+        f"({size - WARN_BYTES:+,} over the 28K budget). "
+        f"CLAUDE.md rule: skills over 25K require a split-or-trim plan."
+    )
+    if skill_name in KNOWN_OVERSIZED:
+        reason = KNOWN_OVERSIZED[skill_name]
+        pytest.xfail(f"{message} Known: {reason}")
+    else:
+        pytest.fail(message)


### PR DESCRIPTION
## What

Implements the first phase of the split-or-trim plan for `chapter-writer` (Issue #235).

## Changes

### chapter-writer/SKILL.md (−1,696 bytes, 32.8K → 31.1K)

**Step 6c — Simile Discipline Scan:** Removed the duplicated marker list paragraph. `simile-discipline.md` (already a mandatory prerequisite load) has the full catalog, failure modes, and revision moves. Kept only skill-specific execution notes: author-voice bias, `recent_simile_count_per_chapter` heuristic, `rules_to_honor` override.

**Step 6d — Elegant Abstraction Scan:** Removed intro paragraphs and the 8-row shape markers table. `anti-ai-patterns.md` Section 11 (already a mandatory prerequisite load) has the full EA catalog, banned-shape regex, and per-shape examples (11.1–11.10). Replaced with a compact one-paragraph quick-scan reference. All scan protocol steps (1–6), display block format, fix direction, and interactive rationale are unchanged.

### tests/skills/test_skill_sizes.py (new)

- Parametrized smoke test over all 48 SKILL.md files.
- Warns at 28K body bytes (buffer above the 25K CLAUDE.md rule).
- `chapter-writer` is marked as known `xfail` (trim in progress, #235) — CI stays green.
- Any new skill exceeding 28K hard-fails — catches future drift.
- **Result:** 47 PASSED, 1 XFAILED

## What's still open (next step in #235)

`chapter-writer` is at 31.1K, still 6.1K over the 28K threshold. The remaining trim requires extracting shared procedural sections (Step 7 POV snapshot, Step 2/2b/A1c/A3/A4 workflow, User Feedback Handling) to a `reference/chapter-writing-shared.md` that both `chapter-writer` and `chapter-writer-memoir` load. This is a more invasive change tracked as the next step.

## Test plan

- [x] `pytest tests/skills/test_skill_sizes.py -v` — 47 passed, 1 xfailed
- [x] Read chapter-writer Step 6c — scan markers no longer duplicated inline; reference to `simile-discipline.md` present
- [x] Read chapter-writer Step 6d — shape table gone; compact quick-scan reference points to Section 11; full protocol steps intact

Closes #235 (partial — full trim in next step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)