### PR TITLE
feat(series): add create_character_tracker MCP tool + series-planner improvements (#237)

### DIFF
--- a/servers/storyforge-server/routers/series.py
+++ b/servers/storyforge-server/routers/series.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import re
 import shutil
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -743,3 +744,182 @@ def bootstrap_character_for_new_book(
             "new_char_path": str(dest),
         }
     )
+
+
+_VALID_TRACKER_TYPES = {"thin", "full"}
+
+
+def _build_tracker_content(
+    name: str,
+    slug: str,
+    role: str,
+    recurs_in: list[str],
+    species: str,
+    tracker_type: str,
+    book_slug: str,
+    today: str,
+) -> str:
+    """Generate h3-shape series character tracker file content."""
+    resolved_book_slug = book_slug if book_slug else slug
+
+    # Build frontmatter as a dict — yaml.dump handles quoting/escaping.
+    meta: dict[str, Any] = {
+        "name": name,
+        "slug": slug,
+        "role": role,
+        "status": "Profile",
+        "recurs_in": recurs_in,
+        "tracker_type": tracker_type,
+    }
+    if species:
+        meta["species"] = species
+    if book_slug:
+        meta["book_slug"] = book_slug
+
+    # Sort keys in a canonical order for readability.
+    key_order = ["name", "slug", "book_slug", "role", "species", "status", "recurs_in", "tracker_type"]
+    sorted_meta = {k: meta[k] for k in key_order if k in meta}
+
+    frontmatter = "---\n" + yaml.dump(sorted_meta, default_flow_style=False, allow_unicode=True, sort_keys=False) + "---\n"
+
+    # Build Evolution per Band in h3 shape.
+    # Each band in recurs_in gets Start + Ende headings.
+    # The next band after the last gets a (geplant) heading.
+    band_numbers = sorted(int(b[1:]) for b in recurs_in)
+    next_band_n = band_numbers[-1] + 1
+
+    evolution_lines: list[str] = ["## Evolution per Band\n"]
+    for i, n in enumerate(band_numbers):
+        band = f"B{n}"
+        if i == 0:
+            start_hint = "Initial state, defining wound or driver, current situation. Filled at planning time."
+            ende_hint = "Filled by the harvest tool at end-of-book from book-level frontmatter snapshot fields and relationships."
+        else:
+            prev = f"B{band_numbers[i - 1]}"
+            start_hint = f"Where the character begins in {band}. Filled by the bootstrap tool from {prev} Ende."
+            ende_hint = f"Where the character ends in {band}. Filled by the harvest tool at end-of-book."
+        evolution_lines.append(f"\n### {band} Start\n*{start_hint}*\n")
+        evolution_lines.append(f"\n### {band} Ende\n*{ende_hint}*\n")
+
+    next_band = f"B{next_band_n}"
+    evolution_lines.append(
+        f"\n### {next_band} (geplant)\n"
+        f"*Planned arc for Book {next_band_n}. What changes? What carries forward? "
+        f"What new external pressure forces growth? Filled at planning time.*\n"
+    )
+
+    body = f"""
+# {name} — Series Evolution Tracker
+
+> Full character profile per book: `projects/<book-slug>/characters/{resolved_book_slug}.md`
+
+## Snapshot
+
+*One-paragraph essence at series scope. What is constant about this character across all books? Capture identity, role, key relationship anchors. Not plot, not arc-per-book — the through-line.*
+
+{"".join(evolution_lines)}
+## Beziehungen über die Bände
+
+*Cross-book relationship arcs. Capture how each significant pairing evolves across the series, not just within one book. Format:*
+
+- **{{Other Character}}**: {{B1 dynamic}} → {{B2 shift}} → resolution
+
+## Updates Log
+
+- {today} — Tracker scaffolded by series-planner
+"""
+    return frontmatter + body
+
+
+@mcp.tool()
+def create_character_tracker(
+    series_slug: str,
+    name: str,
+    slug: str,
+    role: str,
+    recurs_in: list[str],
+    species: str = "",
+    tracker_type: str = "thin",
+    book_slug: str = "",
+) -> str:
+    """Create a series character tracker file from the canonical template.
+
+    Scaffolds ``series/{series_slug}/characters/{slug}.md`` with:
+    - YAML frontmatter (name, slug, role, species, status, recurs_in,
+      tracker_type; ``book_slug`` included only when it differs from
+      ``slug``)
+    - h3-shape Evolution per Band sections: ``### BN Start`` and
+      ``### BN Ende`` for every band in ``recurs_in``, plus
+      ``### B{N+1} (geplant)`` for the next planned book
+    - Empty Snapshot and Beziehungen sections
+    - An initial Updates Log entry dated today
+
+    Use this in the series-planner Step 5 (Canon Management) to create
+    one tracker per recurring character rather than copying the template
+    manually.
+
+    Args:
+        series_slug: Series slug (must already exist).
+        name: Full character name (e.g. ``"King Caelan"``).
+        slug: Tracker file slug / stem (e.g. ``"king-caelan"``).
+        role: Character role (e.g. ``"supporting"``, ``"protagonist"``).
+        recurs_in: Band ids the character appears in
+            (e.g. ``["B1", "B2", "B3"]``). Each must match ``B<N>``.
+            Must not be empty.
+        species: Optional species / type (e.g. ``"vampire"``).
+        tracker_type: ``"thin"`` (default) or ``"full"``. Use ``"full"``
+            only for characters that span books equally without a home
+            book.
+        book_slug: Optional. Set when the tracker slug differs from the
+            book-level character file stem (e.g. tracker ``king-caelan``
+            ↔ book file ``caelan.md``). Omit for the common case where
+            they match — the resolver falls back to ``slug``.
+
+    Returns:
+        ``{success, slug, path}`` on success or ``{error}`` on failure.
+    """
+    if not recurs_in:
+        return json.dumps({"error": "recurs_in must not be empty"})
+
+    if len(set(recurs_in)) != len(recurs_in):
+        dupes = [b for b in recurs_in if recurs_in.count(b) > 1]
+        return json.dumps({"error": f"recurs_in contains duplicate band ids: {sorted(set(dupes))}"})
+
+    invalid_bands = [b for b in recurs_in if not _RE_BAND_ID.match(str(b))]
+    if invalid_bands:
+        return json.dumps(
+            {"error": f"recurs_in contains invalid band ids: {invalid_bands} — each must match B<N> (e.g. 'B1')"}
+        )
+
+    if tracker_type not in _VALID_TRACKER_TYPES:
+        return json.dumps(
+            {"error": f"tracker_type must be one of {sorted(_VALID_TRACKER_TYPES)} — got {tracker_type!r}"}
+        )
+
+    config = _app.load_config()
+    series_dir = resolve_series_path(config, series_slug)
+    if not series_dir.exists():
+        return json.dumps({"error": f"Series '{series_slug}' not found"})
+
+    chars_dir = series_dir / "characters"
+    chars_dir.mkdir(parents=True, exist_ok=True)
+
+    tracker_path = chars_dir / f"{slug}.md"
+    if tracker_path.exists():
+        return json.dumps({"error": f"Tracker '{slug}' already exists in series '{series_slug}'"})
+
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    content = _build_tracker_content(
+        name=name,
+        slug=slug,
+        role=role,
+        recurs_in=[str(b) for b in recurs_in],
+        species=species,
+        tracker_type=tracker_type,
+        book_slug=book_slug,
+        today=today,
+    )
+    tracker_path.write_text(content, encoding="utf-8")
+
+    _cache.invalidate()
+    return json.dumps({"success": True, "slug": slug, "path": str(tracker_path)})

--- a/skills/series-planner/SKILL.md
+++ b/skills/series-planner/SKILL.md
@@ -11,6 +11,13 @@ argument-hint: "<series-name>"
 
 # Series Planner
 
+## Session Start
+
+Before asking questions, check whether the user is resuming work on an existing series:
+- If a series slug is provided or deducible, call `list_series_trackers_for_book(series_slug, "B1")` to surface existing trackers.
+- Report how many trackers exist and which characters are already tracked — this prevents duplicates and gives the user immediate orientation.
+- Skip the check when the series doesn't exist yet (Step 2 will create it).
+
 ## Workflow
 
 ### Step 1: Series Concept
@@ -29,14 +36,34 @@ Ask the user:
 ### Step 2: Create Series
 Use MCP `create_series()` with collected info.
 
-### Step 3: Series Arc
-For sequential/trilogy series — plan the OVERARCHING arc:
-- What's the BIG question across all books?
-- How does each book answer a piece of it?
-- What escalates between books?
-- How does the protagonist grow across the series?
+`create_series()` scaffolds the directory and creates placeholder files including `series-arc.md`, `timeline.md`, `world/canon.md`, and `README.md`. Confirm the path from the response before proceeding to Step 3.
 
-Write to `{series}/series-arc.md`.
+### Step 3: Series Arc
+For sequential/trilogy series — plan the OVERARCHING arc with the user:
+- **Big Question**: What is the central dramatic question that spans ALL books?
+- **Per-Book Answers**: How does each book answer one piece of it (without resolving the whole)?
+- **Escalation Map**: What raises the stakes between each book?
+- **Protagonist Growth Arc**: How does the main character change across the entire series?
+
+Once agreed, use the Write tool to populate `series-arc.md` at the path returned by `create_series()`. Structure the file as:
+
+```markdown
+# {Title} — Series Arc
+
+## The Big Question
+{The central dramatic question spanning all books}
+
+## Per-Book Arc
+- **Book 1 ({title}):** {What this book answers / contributes}
+- **Book 2 ({title}):** {What this book answers / contributes}
+...
+
+## Escalation Between Books
+{What raises the stakes from book to book — stakes, scope, personal cost}
+
+## Protagonist Growth Arc
+{How the protagonist changes across the full series — wound → growth → resolution}
+```
 
 **Wait for user approval of the series arc before proceeding to Step 4.** Per-book planning depends on a locked overarching arc.
 
@@ -57,28 +84,37 @@ Set up `{series}/world/canon.md`:
 - World rules (magic systems, technology, geography)
 - Timeline of events across books
 
-Set up `{series}/characters/` from `templates/series-character-tracker.md`:
-- One tracker file per recurring character (`recurs_in: [B1, B2, ...]`)
-- `## Snapshot` (essence at series scope), `## Evolution per Band` (B1 Start/Ende, B2 geplant), `## Beziehungen über die Bände`, `## Updates Log`
-- `tracker_type: thin` for characters whose full profile lives in their home book; `full` is rare and only for characters that span books equally without a home book
+Set up series character trackers for every recurring character:
 
-**`book_slug:` mapping (Issue #194).** When you propose a tracker slug that differs from the slugified character name (and from the existing book-level character slug — e.g. you pick `king-caelan` for a character whose book-level file is `caelan.md`), write the optional `book_slug:` frontmatter field on the tracker. This is what the future harvest, bootstrap, and brief-source tooling (Issue #195) consumes to bridge between scopes:
+For each recurring character, call MCP `create_character_tracker()`:
 
-```yaml
----
-name: "King Caelan"
-slug: "king-caelan"
-book_slug: "caelan"        # ← explicit book-level equivalent
-role: "supporting"
-recurs_in: ["B1", "B2", "B3"]
-tracker_type: "thin"
----
+```
+create_character_tracker(
+  series_slug="{series-slug}",
+  name="{Full Character Name}",
+  slug="{tracker-slug}",           # kebab-case; use role-prefix if needed (e.g. "king-caelan")
+  role="{protagonist|antagonist|supporting|love-interest|mentor|minor}",
+  recurs_in=["{B1}", "{B2}", ...],  # all books this character appears in
+  species="{species}",              # optional
+  tracker_type="thin",              # "full" only for characters with no single home book
+  book_slug="{book-level-slug}",    # set ONLY when tracker slug differs from book-level file name
+                                    # e.g. tracker "king-caelan" ↔ book file "caelan.md"
+)
 ```
 
-When the tracker slug already matches the book-level slug (e.g. `kael` ↔ `kael.md`), omit `book_slug:` — the resolver falls back to the tracker slug. Zero-config for the common case.
+`book_slug:` mapping rule (Issue #194): When the tracker slug differs from the book-level character file stem, set `book_slug` explicitly. When they match (e.g. tracker `kael` ↔ book file `kael.md`), omit it — the resolver falls back to the tracker slug automatically.
+
+`tracker_type: thin` is correct for characters whose full profile lives in their home book. Use `full` only for characters that span books equally without a "home" book — this is rare.
+
+**Wait for user review of each tracker before creating the next.** The `recurs_in` list is load-bearing for bootstrap, harvest, and brief-source tooling.
 
 ### Step 6: Link Books
-As books are created, link them via MCP `add_book_to_series()`.
+As books are created, link them via MCP `add_book_to_series(series_slug, book_slug, number)`.
+
+After each `add_book_to_series()` call, verify the link with `get_book_full(book_slug)`:
+- Check `book["series"]` matches the series slug
+- Check `book["series_number"]` is the expected number
+- Report status and any warnings to the user before continuing
 
 ## Rules
 - Canon.md is sacred — once established, treat it as permanent. Changes require a series-level revision pass.

--- a/tests/server/test_create_character_tracker.py
+++ b/tests/server/test_create_character_tracker.py
@@ -1,0 +1,372 @@
+"""Tests for ``create_character_tracker`` MCP tool (Issue #237).
+
+Verifies that the tool scaffolds a series character tracker from
+parameters: correct frontmatter, h3-shape Evolution sections for all
+bands in ``recurs_in`` plus one ``(geplant)`` section for the next
+band, and an initial Updates Log entry.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+import routers._app as _app
+from routers.series import create_character_tracker
+
+
+@pytest.fixture
+def content_root(tmp_path: Path) -> Path:
+    root = tmp_path / "content"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def mock_config(content_root: Path, monkeypatch: pytest.MonkeyPatch) -> dict:
+    cfg = {
+        "paths": {
+            "content_root": str(content_root),
+            "authors_root": str(content_root / "authors"),
+        },
+        "defaults": {"language": "en", "book_type": "novel"},
+    }
+    monkeypatch.setattr(_app, "load_config", lambda: cfg)
+    _app._cache.invalidate()
+    return cfg
+
+
+def _make_series(content_root: Path, slug: str) -> Path:
+    series_dir = content_root / "series" / slug
+    (series_dir / "characters").mkdir(parents=True)
+    (series_dir / "world").mkdir()
+    readme = f"---\ntitle: {slug}\nslug: {slug}\n---\n\n# {slug}\n"
+    (series_dir / "README.md").write_text(readme, encoding="utf-8")
+    return series_dir
+
+
+class TestCreateCharacterTrackerBasics:
+    def test_creates_tracker_file(self, mock_config, content_root: Path):
+        _make_series(content_root, "my-series")
+        result = json.loads(
+            create_character_tracker(
+                series_slug="my-series",
+                name="Kael Dawnfire",
+                slug="kael",
+                role="protagonist",
+                recurs_in=["B1", "B2"],
+            )
+        )
+        assert result.get("error") is None
+        assert result["success"] is True
+        tracker_path = content_root / "series" / "my-series" / "characters" / "kael.md"
+        assert tracker_path.exists()
+        assert result["path"] == str(tracker_path)
+
+    def test_returns_slug_in_response(self, mock_config, content_root: Path):
+        _make_series(content_root, "my-series")
+        result = json.loads(
+            create_character_tracker(
+                series_slug="my-series",
+                name="Kael",
+                slug="kael",
+                role="protagonist",
+                recurs_in=["B1"],
+            )
+        )
+        assert result["slug"] == "kael"
+
+    def test_creates_characters_dir_when_missing(self, mock_config, content_root: Path):
+        # Series exists but characters/ was removed after creation.
+        series_dir = content_root / "series" / "my-series"
+        series_dir.mkdir(parents=True)
+        (series_dir / "README.md").write_text("---\nslug: my-series\n---\n", encoding="utf-8")
+        # No characters/ dir.
+
+        result = json.loads(
+            create_character_tracker(
+                series_slug="my-series",
+                name="Viktor",
+                slug="viktor",
+                role="antagonist",
+                recurs_in=["B1"],
+            )
+        )
+        assert result.get("error") is None
+        tracker_path = content_root / "series" / "my-series" / "characters" / "viktor.md"
+        assert tracker_path.exists()
+
+
+class TestCreateCharacterTrackerFrontmatter:
+    def _parse_frontmatter(self, path: Path) -> dict:
+        text = path.read_text(encoding="utf-8")
+        assert text.startswith("---\n")
+        end = text.index("---\n", 4)
+        return yaml.safe_load(text[4:end])
+
+    def test_frontmatter_has_required_fields(self, mock_config, content_root: Path):
+        _make_series(content_root, "my-series")
+        create_character_tracker(
+            series_slug="my-series",
+            name="Kael Dawnfire",
+            slug="kael",
+            role="protagonist",
+            recurs_in=["B1", "B2"],
+            species="vampire",
+        )
+        tracker_path = content_root / "series" / "my-series" / "characters" / "kael.md"
+        meta = self._parse_frontmatter(tracker_path)
+        assert meta["name"] == "Kael Dawnfire"
+        assert meta["slug"] == "kael"
+        assert meta["role"] == "protagonist"
+        assert meta["species"] == "vampire"
+        assert meta["status"] == "Profile"
+        assert meta["recurs_in"] == ["B1", "B2"]
+        assert meta["tracker_type"] == "thin"
+
+    def test_default_tracker_type_is_thin(self, mock_config, content_root: Path):
+        _make_series(content_root, "my-series")
+        create_character_tracker(
+            series_slug="my-series",
+            name="Minor",
+            slug="minor",
+            role="supporting",
+            recurs_in=["B1"],
+        )
+        tracker_path = content_root / "series" / "my-series" / "characters" / "minor.md"
+        meta = self._parse_frontmatter(tracker_path)
+        assert meta["tracker_type"] == "thin"
+
+    def test_full_tracker_type_written_when_set(self, mock_config, content_root: Path):
+        _make_series(content_root, "my-series")
+        create_character_tracker(
+            series_slug="my-series",
+            name="Central",
+            slug="central",
+            role="protagonist",
+            recurs_in=["B1", "B2", "B3"],
+            tracker_type="full",
+        )
+        tracker_path = content_root / "series" / "my-series" / "characters" / "central.md"
+        meta = self._parse_frontmatter(tracker_path)
+        assert meta["tracker_type"] == "full"
+
+    def test_book_slug_written_when_different_from_slug(self, mock_config, content_root: Path):
+        _make_series(content_root, "my-series")
+        create_character_tracker(
+            series_slug="my-series",
+            name="King Caelan",
+            slug="king-caelan",
+            role="supporting",
+            recurs_in=["B1", "B2", "B3"],
+            book_slug="caelan",
+        )
+        tracker_path = content_root / "series" / "my-series" / "characters" / "king-caelan.md"
+        meta = self._parse_frontmatter(tracker_path)
+        assert meta["book_slug"] == "caelan"
+
+    def test_book_slug_omitted_when_not_provided(self, mock_config, content_root: Path):
+        _make_series(content_root, "my-series")
+        create_character_tracker(
+            series_slug="my-series",
+            name="Kael",
+            slug="kael",
+            role="protagonist",
+            recurs_in=["B1"],
+        )
+        tracker_path = content_root / "series" / "my-series" / "characters" / "kael.md"
+        meta = self._parse_frontmatter(tracker_path)
+        assert "book_slug" not in meta
+
+    def test_empty_species_omitted_from_frontmatter(self, mock_config, content_root: Path):
+        _make_series(content_root, "my-series")
+        create_character_tracker(
+            series_slug="my-series",
+            name="Kael",
+            slug="kael",
+            role="protagonist",
+            recurs_in=["B1"],
+            species="",
+        )
+        tracker_path = content_root / "series" / "my-series" / "characters" / "kael.md"
+        meta = self._parse_frontmatter(tracker_path)
+        assert "species" not in meta
+
+
+class TestCreateCharacterTrackerEvolutionSections:
+    def test_single_band_generates_start_ende_and_planned_next(
+        self, mock_config, content_root: Path
+    ):
+        _make_series(content_root, "my-series")
+        create_character_tracker(
+            series_slug="my-series",
+            name="Kael",
+            slug="kael",
+            role="protagonist",
+            recurs_in=["B1"],
+        )
+        text = (
+            content_root / "series" / "my-series" / "characters" / "kael.md"
+        ).read_text(encoding="utf-8")
+        assert "### B1 Start" in text
+        assert "### B1 Ende" in text
+        assert "### B2" in text
+        assert "geplant" in text.lower() or "(geplant)" in text
+
+    def test_multiple_bands_generate_start_ende_for_each(
+        self, mock_config, content_root: Path
+    ):
+        _make_series(content_root, "my-series")
+        create_character_tracker(
+            series_slug="my-series",
+            name="Viktor",
+            slug="viktor",
+            role="antagonist",
+            recurs_in=["B1", "B2", "B3"],
+        )
+        text = (
+            content_root / "series" / "my-series" / "characters" / "viktor.md"
+        ).read_text(encoding="utf-8")
+        for band in ("B1", "B2", "B3"):
+            assert f"### {band} Start" in text
+            assert f"### {band} Ende" in text
+        # B4 (geplant) for the next planned band.
+        assert "### B4" in text
+
+    def test_evolution_sections_parseable_by_loader(
+        self, mock_config, content_root: Path
+    ):
+        from tools.state.loaders.series import parse_evolution_sections
+
+        _make_series(content_root, "my-series")
+        create_character_tracker(
+            series_slug="my-series",
+            name="Kael",
+            slug="kael",
+            role="protagonist",
+            recurs_in=["B1", "B2"],
+        )
+        tracker_path = (
+            content_root / "series" / "my-series" / "characters" / "kael.md"
+        )
+        sections = parse_evolution_sections(tracker_path)
+        assert "B1" in sections
+        assert "B2" in sections
+        assert sections["B1"]["shape"] == "h3"
+        assert sections["B2"]["shape"] == "h3"
+
+
+class TestCreateCharacterTrackerUpdatesLog:
+    def test_updates_log_has_initial_entry(self, mock_config, content_root: Path):
+        _make_series(content_root, "my-series")
+        create_character_tracker(
+            series_slug="my-series",
+            name="Kael",
+            slug="kael",
+            role="protagonist",
+            recurs_in=["B1"],
+        )
+        from tools.state.loaders.series import parse_updates_log
+
+        tracker_path = (
+            content_root / "series" / "my-series" / "characters" / "kael.md"
+        )
+        entries = parse_updates_log(tracker_path)
+        assert len(entries) == 1
+        assert "series-planner" in entries[0].lower() or "scaffolded" in entries[0].lower()
+
+
+class TestCreateCharacterTrackerValidation:
+    def test_error_when_series_not_found(self, mock_config, content_root: Path):
+        result = json.loads(
+            create_character_tracker(
+                series_slug="ghost-series",
+                name="Kael",
+                slug="kael",
+                role="protagonist",
+                recurs_in=["B1"],
+            )
+        )
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_error_when_tracker_already_exists(self, mock_config, content_root: Path):
+        _make_series(content_root, "my-series")
+        create_character_tracker(
+            series_slug="my-series",
+            name="Kael",
+            slug="kael",
+            role="protagonist",
+            recurs_in=["B1"],
+        )
+        result = json.loads(
+            create_character_tracker(
+                series_slug="my-series",
+                name="Kael",
+                slug="kael",
+                role="protagonist",
+                recurs_in=["B1"],
+            )
+        )
+        assert "error" in result
+        assert "already exists" in result["error"].lower()
+
+    def test_error_on_invalid_band_in_recurs_in(self, mock_config, content_root: Path):
+        _make_series(content_root, "my-series")
+        result = json.loads(
+            create_character_tracker(
+                series_slug="my-series",
+                name="Kael",
+                slug="kael",
+                role="protagonist",
+                recurs_in=["Book1"],
+            )
+        )
+        assert "error" in result
+        assert "band" in result["error"].lower() or "recurs_in" in result["error"].lower()
+
+    def test_error_on_duplicate_bands_in_recurs_in(self, mock_config, content_root: Path):
+        _make_series(content_root, "my-series")
+        result = json.loads(
+            create_character_tracker(
+                series_slug="my-series",
+                name="Kael",
+                slug="kael",
+                role="protagonist",
+                recurs_in=["B1", "B2", "B1"],
+            )
+        )
+        assert "error" in result
+        assert "duplicate" in result["error"].lower()
+
+    def test_error_on_empty_recurs_in(self, mock_config, content_root: Path):
+        _make_series(content_root, "my-series")
+        result = json.loads(
+            create_character_tracker(
+                series_slug="my-series",
+                name="Kael",
+                slug="kael",
+                role="protagonist",
+                recurs_in=[],
+            )
+        )
+        assert "error" in result
+        assert "recurs_in" in result["error"].lower()
+
+    def test_error_on_invalid_tracker_type(self, mock_config, content_root: Path):
+        _make_series(content_root, "my-series")
+        result = json.loads(
+            create_character_tracker(
+                series_slug="my-series",
+                name="Kael",
+                slug="kael",
+                role="protagonist",
+                recurs_in=["B1"],
+                tracker_type="mega",
+            )
+        )
+        assert "error" in result
+        assert "tracker_type" in result["error"].lower()


### PR DESCRIPTION
## Summary

- **New MCP tool `create_character_tracker()`** — scaffolds a series character tracker file from parameters (h3-shape, YAML frontmatter, Evolution per Band per `recurs_in`, Updates Log). Replaces the manual template-copy pattern with a single validated MCP call.
- **series-planner skill improvements** — 5 gaps from #237 closed: Session Start tracker listing, Step 2 path confirmation, Step 3 explicit series-arc.md Write with 4-section structure, Step 5 `create_character_tracker()` call, Step 6 `get_book_full()` verification.
- **19 TDD tests** covering basics, frontmatter, evolution sections, Updates Log, and validation.

## What create_character_tracker() does

```python
create_character_tracker(
    series_slug="blood-and-binary",
    name="King Caelan",
    slug="king-caelan",
    role="supporting",
    recurs_in=["B1", "B2", "B3"],
    species="vampire",
    tracker_type="thin",
    book_slug="caelan",   # only when tracker slug ≠ book-level slug
)
```

Generates `series/{series_slug}/characters/{slug}.md` with:
- YAML frontmatter in canonical key order (`sort_keys=False`)
- h3-shape Evolution per Band: `### BN Start` + `### BN Ende` per band, plus `### B{N+1} (geplant)`
- Empty Snapshot and Beziehungen sections
- Initial Updates Log entry dated today

Validates: series exists, tracker not duplicate, `recurs_in` not empty, no duplicate band ids, all bands match `B<N>`, `tracker_type` in `{thin, full}`.

## Test plan

- [x] 19 unit tests in `tests/server/test_create_character_tracker.py` — all pass
- [x] Full suite of 1898 tests pass (no regressions)
- [x] `parse_evolution_sections()` confirms generated sections are parseable by the loader

## Related

Epic: #234

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)