### PR TITLE
feat: add next-step hints to mid-pipeline skills (#239)

### DIFF
--- a/skills/book-conceptualizer/SKILL.md
+++ b/skills/book-conceptualizer/SKILL.md
@@ -2,6 +2,7 @@
 name: book-conceptualizer
 description: |
   Develop a book concept through 5 phases. Fiction: premise → theme → conflict → structure → pitch. Memoir: premise → theme → scope → structure → pitch.
+  Run after `/storyforge:brainstorm` + `/storyforge:new-book`, before `/storyforge:plot-architect`.
   Use when: (1) User says "Konzept", "develop concept", "Buchkonzept",
   (2) After brainstorming, to deepen an idea into a workable concept.
 model: claude-opus-4-7
@@ -10,6 +11,8 @@ argument-hint: "<book-slug>"
 ---
 
 # Book Conceptualizer
+
+**Position in workflow:** `brainstorm → new-book → book-conceptualizer → plot-architect → character-creator → world-builder → chapter-writer`
 
 Concept development branches on `book_category` (Path E #97 Phase 2 #60). Fiction runs the historical 5-phase flow. Memoir runs a memoir-shaped 5-phase flow that replaces Phase 3 *Conflict* with Phase 3 *Scope* and pulls memoir-specific craft.
 
@@ -104,6 +107,8 @@ Write to `{project}/synopsis.md`.
 
 Update book status to "Concept" via MCP `update_field()`.
 
+Ask: *"Ready to structure the plot? → `/storyforge:plot-architect`"*
+
 ## Workflow — Memoir (5 phases)
 
 The phase numbering matches fiction (1-5) so downstream skills can reference *"Phase 4"* without branching. The shape of each phase is memoir-specific.
@@ -196,6 +201,8 @@ Anti-pattern check: re-read `memoir-anti-ai-patterns.md` against the generated b
 Write to `{project}/synopsis.md`.
 
 Update book status to "Concept" via MCP `update_field()`.
+
+Ask: *"Ready to shape the narrative arc? → `/storyforge:plot-architect-memoir`"*
 
 ## Rules
 - Resolve `book_category` in Step 0 before any phase. Never assume fiction.

--- a/skills/book-conceptualizer/SKILL.md
+++ b/skills/book-conceptualizer/SKILL.md
@@ -107,7 +107,7 @@ Write to `{project}/synopsis.md`.
 
 Update book status to "Concept" via MCP `update_field()`.
 
-Ask: *"Ready to structure the plot? → `/storyforge:plot-architect`"*
+Ask: *"Outliner/Plantser → `/storyforge:plot-architect`. Discovery writer → `/storyforge:rolling-planner` before each chapter session."*
 
 ## Workflow — Memoir (5 phases)
 

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -3,6 +3,7 @@ name: brainstorm
 description: |
   Brainstorm book ideas interactively — fiction (What if?) or memoir (What happened?).
   Use ONLY for book/novel/memoir concepts — NOT for software, code, video, or dev project ideas.
+  Run before `/storyforge:book-conceptualizer` (create the project first with `/storyforge:new-book`).
   Use when: (1) User says "Buch-Idee", "Story-Idee", "Roman-Idee", "Memoir-Idee", "brainstorm a story/book/novel/memoir",
   "was könnte ich schreiben", "neue Geschichte", (2) User explicitly invokes `/storyforge:brainstorm`,
   (3) Context is clearly a book (genre mentions, character/plot/world, memoir/life-writing, reading material).
@@ -13,6 +14,8 @@ argument-hint: "[idea-slug]"
 ---
 
 # Brainstorm
+
+**Position in workflow:** `brainstorm → new-book → book-conceptualizer → plot-architect → character-creator → world-builder → chapter-writer`
 
 ## Step 0 — Detect Book Category
 
@@ -56,7 +59,7 @@ Save via MCP `create_idea` with `title`, `genres`, `logline`, `concept`, and `bo
 
 The idea gets status `raw` by default. If fully developed (logline + themes + comps), call `update_idea(slug, "status", "explored")` immediately.
 
-Tell the user the slug. Ask: "Ready to turn this into a project? → `/storyforge:new-book --from-idea {slug}`"
+Tell the user the slug. Ask: *"Ready to turn this into a project? → `/storyforge:new-book --from-idea {slug}` — then develop the concept with `/storyforge:book-conceptualizer`."*
 
 ---
 
@@ -99,7 +102,7 @@ Save via MCP `create_idea` with `title`, `genres` (use scope tags as thematic an
 
 The idea gets status `raw`. If three questions are fully answered and scope is clear, call `update_idea(slug, "status", "explored")`.
 
-Tell the user the slug. Ask: "Ready to turn this into a memoir project? → `/storyforge:new-book --from-idea {slug}` (choose memoir when prompted)"
+Tell the user the slug. Ask: *"Ready to turn this into a memoir project? → `/storyforge:new-book --from-idea {slug}` (choose memoir when prompted) — then shape the concept with `/storyforge:book-conceptualizer`."*
 
 ---
 

--- a/skills/character-creator-memoir/SKILL.md
+++ b/skills/character-creator-memoir/SKILL.md
@@ -4,6 +4,7 @@ description: |
   Memoir real-people handler. Captures real people with relationship,
   person_category, consent_status, and anonymization decisions.
   Produces people files at `people/{slug}.md` via MCP `create_person()`.
+  Run after `/storyforge:plot-architect-memoir`, before `/storyforge:chapter-writer-memoir`.
   Use when: (1) `book_category == "memoir"` AND user says "Charakter",
   "character", "Figur", "Person", "real people",
   (2) After plot/structure is outlined, to populate the memoir's cast.
@@ -14,6 +15,8 @@ argument-hint: "<book-slug> [name]"
 ---
 
 # Character Creator (Memoir)
+
+**Position in workflow:** `plot-architect-memoir → character-creator-memoir → chapter-writer-memoir`
 
 This skill is the memoir variant of character-creator, split out per Issue #177 so memoir-only sessions never load the fiction character-arc machinery (GMC, Fatal Flaw, The Ghost, Want vs. Need, arc design) and fiction-only sessions never load the memoir real-people handler.
 
@@ -113,6 +116,8 @@ The MCP tool validates each enum value and refuses to write the file on unknown 
 After creation, expand the file body with the Memory anchors from Step M5. Update `{project}/people/INDEX.md` to list the new person under their relationship category (Family / Friends & relationships / Public figures / Pseudonymized / composite).
 
 After all structural-cast people are captured, update book status to "Characters Created" (the status label is shared with fiction; the meaning shifts per `book_categories/memoir/status-model.md`).
+
+Ask: *"Ready to write? → `/storyforge:chapter-writer-memoir`"*
 
 ## Rules
 

--- a/skills/character-creator/SKILL.md
+++ b/skills/character-creator/SKILL.md
@@ -3,6 +3,7 @@ name: character-creator
 description: |
   Fiction character developer. Builds deep, three-dimensional characters with
   arcs, voice, motivation, and backstory across 14 structured steps.
+  Run after `/storyforge:plot-architect`, before `/storyforge:world-builder` or `/storyforge:chapter-writer`.
   Use when: (1) `book_category == "fiction"` (or missing) AND user says
   "Charakter", "character", "Figur", "Person",
   (2) After plot/structure is outlined, to populate the story.
@@ -13,6 +14,8 @@ argument-hint: "<book-slug> [name]"
 ---
 
 # Character Creator (Fiction)
+
+**Position in workflow:** `plot-architect → character-creator → world-builder → chapter-writer`
 
 This skill is the fiction variant of character-creator, split out per Issue #177 so fiction-only sessions never load the memoir real-people handler and memoir-only sessions never load the fiction character-arc machinery.
 
@@ -157,6 +160,8 @@ Update the character file with all developed details via direct Write.
 Update `{project}/characters/INDEX.md` with the new character.
 
 After all major characters are created, update book status to "Characters Created".
+
+Ask: *"Need world-building? → `/storyforge:world-builder`. Ready to write? → `/storyforge:chapter-writer`."*
 
 ## Rules
 

--- a/skills/plot-architect-memoir/SKILL.md
+++ b/skills/plot-architect-memoir/SKILL.md
@@ -4,6 +4,7 @@ description: |
   Memoir narrative-arc architect. Picks one of four structure types
   (chronological / thematic / braided / vignette) and shapes the chapter
   spine per that type.
+  Run after `/storyforge:book-conceptualizer` (memoir mode), before `/storyforge:character-creator-memoir`.
   Use when: (1) `book_category == "memoir"` AND user says "Plot",
   "Handlung", "Struktur", "narrative arc", "Aufbau", (2) After
   book-conceptualizer (memoir mode) has populated the `## Scope` section.
@@ -14,6 +15,8 @@ argument-hint: "<book-slug>"
 ---
 
 # Plot Architect (Memoir)
+
+**Position in workflow:** `book-conceptualizer → plot-architect-memoir → character-creator-memoir → chapter-writer-memoir`
 
 This skill is the memoir variant of `plot-architect`, split out per Issue #126 so memoir-only sessions never load the fiction structure catalog (3-Act, Hero's Journey, Save the Cat, Snowflake) and fiction-only sessions never load the memoir structure types.
 
@@ -188,6 +191,8 @@ Steps:
 5. Write the completed document to `{project}/plot/tone.md`.
 
 Update book status to "Plot Outlined" via MCP `update_field()`.
+
+Ask: *"People profiles next? → `/storyforge:character-creator-memoir`"*
 
 ## Rules
 

--- a/skills/plot-architect/SKILL.md
+++ b/skills/plot-architect/SKILL.md
@@ -4,6 +4,7 @@ description: |
   Fiction plot architect. Structures the plot with acts, beats, turning
   points, and character arcs across nine standard structures (3-Act,
   Hero's Journey, Save the Cat, Snowflake, etc.).
+  Run after `/storyforge:book-conceptualizer`, before `/storyforge:character-creator`.
   Use when: (1) `book_category == "fiction"` (or missing) AND user says
   "Plot", "Handlung", "Struktur", "outline", "plot beats",
   (2) After concept is developed, before character creation.
@@ -14,6 +15,8 @@ argument-hint: "<book-slug>"
 ---
 
 # Plot Architect (Fiction)
+
+**Position in workflow:** `book-conceptualizer → plot-architect → character-creator → world-builder → chapter-writer`
 
 This skill is the fiction variant of plot-architect, split out per Issue #126 so fiction-only sessions never load the memoir structure types and memoir-only sessions never load the fiction structure catalog.
 
@@ -173,6 +176,8 @@ Create `{project}/plot/tone.md` from template `plot-tone.md`. This step is MANDA
 
 This document guards against tonal drift during long-form writing. Without it, books tend to collapse into generic "literary" mode after ~15 chapters.
 
+Ask: *"Characters next? → `/storyforge:character-creator`"*
+
 ---
 
 ## Snowflake Workflow
@@ -307,6 +312,8 @@ Revision between steps is **built into the method**, not a failure signal:
 After completing Step 8, update book status to "Plot Outlined" via MCP `update_field()`.
 Then proceed to Steps 9–10 (optional scene descriptions + first draft).
 Also create the tonal document (original Step 9 of the standard workflow) at this point.
+
+Ask: *"Characters next? → `/storyforge:character-creator`"*
 
 ## Rules
 

--- a/skills/world-builder/SKILL.md
+++ b/skills/world-builder/SKILL.md
@@ -2,7 +2,7 @@
 name: world-builder
 description: |
   Build settings, magic systems, societies, and history for the story world.
-  Run after `/storyforge:character-creator`, before `/storyforge:chapter-writer`.
+  For fantasy/sci-fi/supernatural/historical: run after `/storyforge:character-creator`, before `/storyforge:chapter-writer`. Optional for contemporary, romance, mystery, drama, literary.
   Use when: (1) User says "Welt", "world", "Setting", "Magic System",
   (2) For fantasy, sci-fi, supernatural, or historical genres.
 model: claude-opus-4-7
@@ -12,7 +12,7 @@ argument-hint: "<book-slug>"
 
 # World Builder
 
-**Position in workflow:** `character-creator → world-builder → chapter-writer`
+**Position in workflow:** Optional. For fantasy/sci-fi/supernatural/historical: `character-creator → world-builder → chapter-writer`. Skip for contemporary, romance, mystery, drama, literary.
 
 ## Step 0 — Resolve Book Category
 

--- a/skills/world-builder/SKILL.md
+++ b/skills/world-builder/SKILL.md
@@ -2,6 +2,7 @@
 name: world-builder
 description: |
   Build settings, magic systems, societies, and history for the story world.
+  Run after `/storyforge:character-creator`, before `/storyforge:chapter-writer`.
   Use when: (1) User says "Welt", "world", "Setting", "Magic System",
   (2) For fantasy, sci-fi, supernatural, or historical genres.
 model: claude-opus-4-7
@@ -10,6 +11,8 @@ argument-hint: "<book-slug>"
 ---
 
 # World Builder
+
+**Position in workflow:** `character-creator → world-builder → chapter-writer`
 
 ## Step 0 — Resolve Book Category
 
@@ -104,6 +107,8 @@ Create a consistency checklist in `{project}/world/rules.md`:
 - [ ] Characters can't know things they shouldn't
 
 Update book status to "World Built" via MCP `update_field()`.
+
+Ask: *"Ready to write? → `/storyforge:chapter-writer`"*
 
 ## Rules (Fiction)
 - ICEBERG PRINCIPLE: Know 100%, show ~10% in-story. The reader discovers through scene; the author keeps the rest as reference.


### PR DESCRIPTION
## Summary

- Adds `Run after X, before Y` to the frontmatter description of all 5 listed skills — mirrors the `chapter-humanizer` pattern
- Adds `**Position in workflow:** …` line at the top of each skill's body
- Adds inline `Ask: *"…"*` prompts at the natural end of each workflow so Claude offers the next skill without the user having to consult CLAUDE.md

## Affected skills

| Skill | Added hint |
|-------|-----------|
| `brainstorm` | → `new-book` → `book-conceptualizer` (fiction + memoir) |
| `book-conceptualizer` | → `plot-architect` / `plot-architect-memoir` |
| `plot-architect` | → `character-creator` (standard + snowflake paths) |
| `character-creator` | → `world-builder` or `chapter-writer` |
| `world-builder` | → `chapter-writer` |

## Test plan

- [x] All 12 smoke tests pass (`pytest tests/smoke/ -q`)
- [ ] Load `brainstorm` skill and verify the position line appears and the Phase 4 ending prompts the next step correctly
- [ ] Load `book-conceptualizer` and verify fiction Phase 5 and memoir Phase 5 each offer the correct next skill
- [ ] Load `plot-architect` and verify Step 9 and Snowflake completion both prompt `character-creator`

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)