### PR TITLE
fix(routing): disambiguate unblock vs next-step trigger conditions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Phase 1 (#54–#56, #67) adds the field plus knowledge scaffold. Skill branching
 | "Buch-Idee" / "Story-Idee" / "Roman-Idee" / "Fiction-Idee" / "Brainstorm a story/book/novel" / "Was könnte ich schreiben?" / "neue Geschichte" | `/storyforge:brainstorm` (only when fiction context is clear; defer if ambiguous) |
 | "Meine Buch-Ideen" / "Story-Ideen" / "Was habe ich an Buchideen gespeichert?" | `/storyforge:ideas` |
 | Book title/name mentioned | `/storyforge:resume [name]` |
-| "What's next?" / "Was steht an?" | `/storyforge:next-step` |
+| "What's next?" / "Was steht an?" | `/storyforge:next-step` — workflow status question, NOT emotional block |
 | "Dashboard" / "Status" / "Fortschritt" | `/storyforge:book-dashboard` |
 | "Konzept" / "Develop concept" | `/storyforge:book-conceptualizer` |
 | "Serie planen" / "Series" | `/storyforge:series-planner` |
@@ -89,7 +89,7 @@ Phase 1 (#54–#56, #67) adds the field plus knowledge scaffold. Skill branching
 | "Promo" / "Social Media" / "Marketing" / "bewerben" | `/storyforge:promo-writer` |
 | "Klappentext" / "Blurb" / "Back cover" / "Back-cover copy" | `/storyforge:promo-writer` (starts at blurb step) |
 | "Neues Genre" / "Genre-Mix" | `/storyforge:genre-creator` |
-| "I'm stuck" / "Ich komme nicht weiter" / "blockiert" / "kann nicht schreiben" / "keine Motivation" / "Schreibblockade" / "keine Lust" | `/storyforge:unblock` |
+| "I'm stuck" / "Ich komme nicht weiter" / "blockiert" / "kann nicht schreiben" / "keine Motivation" / "Schreibblockade" / "keine Lust" | `/storyforge:unblock` — emotional/creative block, NOT a workflow question |
 | "Rolling planner" / "Next scene" / "Was kommt als nächstes?" / "Nächste Szene planen" / "Discovery writer" | `/storyforge:rolling-planner` |
 | `Regel:` / `Workflow:` / `Callback:` prefix, "merke dir" | `/storyforge:register-callback` |
 | "Hilfe" / "Help" | `/storyforge:help` |

--- a/skills/next-step/SKILL.md
+++ b/skills/next-step/SKILL.md
@@ -3,6 +3,7 @@ name: next-step
 description: |
   Suggest the next step based on current book status and workflow.
   Use when: (1) User asks "was steht an?", "next step", "was als nächstes?"
+  NOT for writer's block or creative resistance — use /storyforge:unblock instead.
 model: claude-sonnet-4-6
 user-invocable: true
 ---

--- a/skills/unblock/SKILL.md
+++ b/skills/unblock/SKILL.md
@@ -4,6 +4,7 @@ description: |
   Diagnose and resolve writer's block with targeted, book-context-aware interventions.
   Use when: User says "I'm stuck", "Ich komme nicht weiter", "blocked", "can't write",
   "keine Motivation", "keine Lust", "Schreibblockade", or similar signals of creative resistance.
+  NOT for workflow questions ("what's next?", "was steht an?") — use /storyforge:next-step instead.
 model: claude-opus-4-7
 user-invocable: true
 argument-hint: "[book-slug]"


### PR DESCRIPTION
## Summary

- Add `NOT for workflow questions — use /storyforge:next-step` to `unblock` SKILL.md description
- Add `NOT for writer's block — use /storyforge:unblock` to `next-step` SKILL.md description
- Annotate both routing table rows in CLAUDE.md with the NOT-for note

## Why

A user who says "I don't know what to do next" could route to either skill. The distinction is tone-based (emotional block vs. workflow status), which is easy to misroute. Explicit anti-triggers give the model a hard signal at decision time.

## Test plan

- [x] YAML frontmatter valid (verified via `python3 yaml.safe_load`)
- [x] 1910 tests pass, no regressions
- [ ] Manual: say "I don't know what to do next" → confirm routes to `next-step`, not `unblock`
- [ ] Manual: say "I'm stuck and frustrated" → confirm routes to `unblock`, not `next-step`

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)