### PR TITLE
refactor(skills): session-start → start-session (#241)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,7 +65,7 @@ body:
         - /storyforge:help
         - /storyforge:setup
         - /storyforge:configure
-        - /storyforge:session-start
+        - /storyforge:start-session
         - Other (specify in description)
     validations:
       required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Nothing yet
 
 ### Changed
-- Nothing yet
+- Renamed skill `session-start` to `start-session` for verb-noun naming consistency (`/storyforge:session-start` → `/storyforge:start-session`). Natural-language triggers (`/start`, "start session", "Session starten") continue to work. (#241)
 
 ### Deprecated
 - Nothing yet
 
 ### Removed
+- Slash command `/storyforge:session-start` (renamed to `/storyforge:start-session`, no deprecated stub). (#241)
 - Deprecated MCP tools `get_chapter`, `get_character`, `get_series`, `update_book_claudemd_facts` (#236). Migration: use `get_book_full()` for chapter/character projections; series-planner reads series files directly; edit the book's CLAUDE.md directly for Book Facts fields.
 
 ### Fixed

--- a/reference/model-strategy.md
+++ b/reference/model-strategy.md
@@ -5,7 +5,7 @@
 | Model | Purpose | Skills |
 |-------|---------|--------|
 | **Opus** | Creative work, deep analysis, style-sensitive writing | chapter-writer, chapter-reviewer, voice-checker, book-conceptualizer, plot-architect, character-creator, world-builder, create-author, study-author, brainstorm, researcher, sensitivity-reader, translator, cover-artist, genre-creator, series-planner |
-| **Sonnet** | Structured coordination, project management, validation | new-book, session-start, resume, next-step, book-dashboard, export-engineer, setup, configure |
+| **Sonnet** | Structured coordination, project management, validation | new-book, start-session, resume, next-step, book-dashboard, export-engineer, setup, configure |
 | **Haiku** | Fast lookups, simple output | help |
 
 ## Rationale

--- a/skills/start-session/SKILL.md
+++ b/skills/start-session/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: session-start
+name: start-session
 description: |
   Initialize a StoryForge session: verify setup, load context, report status.
   Use when: (1) User types /start, (2) User says "start session", "Session starten".
@@ -7,7 +7,7 @@ model: claude-sonnet-4-6
 user-invocable: true
 ---
 
-# Session Start
+# Start Session
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

- Renamed `skills/session-start/` → `skills/start-session/` via `git mv` (history preserved)
- Updated `SKILL.md` frontmatter: `name: session-start` → `name: start-session`, heading aligned
- Updated `reference/model-strategy.md` skill list
- Updated `.github/ISSUE_TEMPLATE/bug_report.yml` dropdown option
- Added `CHANGELOG.md` entries (### Changed + ### Removed)

## Breaking Change

`/storyforge:session-start` is removed. Use `/storyforge:start-session` going forward.
Natural-language triggers (`/start`, "start session", "Session starten") are unaffected.
Hard cut, no deprecated stub — aligns with other breaking changes in this release cycle.

## Test Plan

- [x] `pytest tests/smoke/test_skill_pairs.py tests/skills/ -q` → 130/130 passed
- [x] Full grep for `session-start` in source tree → zero hits after rename

## Related

Closes #241
Part of Epic #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)