### PR TITLE
feat(author-check): positive style compliance verification gate (#258)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Phase 1 (#54–#56, #67) adds the field plus knowledge scaffold. Skill branching
 | "Kapitel proofreaden" / "Proofread chapter" / "Korrekturlesen" / "Spelling check" / "Grammar check" | `/storyforge:chapter-proofreader` |
 | "Continuity prüfen" / "Check continuity" / "Zeitlinie prüfen" / "Timeline prüfen" | `/storyforge:continuity-checker` |
 | "Voice check" / "Klingt das nach AI?" | `/storyforge:voice-checker` |
+| "Author check" / "Style check" / "Positive check" / "Banter fehlt" / "Sarcasm fehlt" / "Stil prüfen" / "Positive Marker" | `/storyforge:author-check` |
 | "Manuscript check" / "Prose check" / "Repetition check" / "Wiederholungen prüfen" / "Prose tics" / "Buch prüfen" | `/storyforge:manuscript-checker` |
 | "Beta feedback" / "ARC feedback" / "Reader feedback" / "Beta-Feedback verarbeiten" | `/storyforge:beta-feedback` |
 | "problem:" / "recurring issue:" / "report issue" / "regel melden" / "Regel eintragen" | `/storyforge:report-issue` |
@@ -134,10 +135,11 @@ Phase 1 (#54–#56, #67) adds the field plus knowledge scaffold. Skill branching
 8. `/storyforge:chapter-writer` — Write chapters in author's voice (loads timeline + travel matrix + tonal document + chapter timeline)
 9. `/storyforge:continuity-checker` — (Optional, after several chapters) Validate timeline and location consistency
 10. `/storyforge:chapter-reviewer` — Review each chapter for craft, voice, structure, and AI-tells
-10a. `/storyforge:chapter-humanizer` — Targeted AI-construction scan; identifies Section 11 elegant-abstraction shapes and flagged vocabulary; proposes human alternatives interactively; runs AFTER chapter-reviewer craft fixes
-10b. `/storyforge:chapter-proofreader` — Language correctness per chapter: spelling, grammar, punctuation — runs AFTER humanizer pass; explanations in author's native_language
-10c. `/storyforge:manuscript-checker` — (At drafting → revision transition) Scan the whole manuscript for book-rule violations, clichés, dialogue punctuation, filter words, adverb density, and cross-chapter repetition
-10d. `/storyforge:beta-feedback` — (After eBook/ARC stage) Process curated beta-reader feedback, triage, revision plan
+10a. `/storyforge:author-check` — (Optional, after chapter-writer or chapter-reviewer) Positive style compliance gate: checks presence of style_principles Writing Discoveries and quantitative prose targets; counterpart to the constraint-only tools
+10b. `/storyforge:chapter-humanizer` — Targeted AI-construction scan; identifies Section 11 elegant-abstraction shapes and flagged vocabulary; proposes human alternatives interactively; runs AFTER chapter-reviewer craft fixes
+10c. `/storyforge:chapter-proofreader` — Language correctness per chapter: spelling, grammar, punctuation — runs AFTER humanizer pass; explanations in author's native_language
+10d. `/storyforge:manuscript-checker` — (At drafting → revision transition) Scan the whole manuscript for book-rule violations, clichés, dialogue punctuation, filter words, adverb density, and cross-chapter repetition
+10e. `/storyforge:beta-feedback` — (After eBook/ARC stage) Process curated beta-reader feedback, triage, revision plan
 11. `/storyforge:voice-checker` — (Optional) Holistic AI-authenticity score (0–100) across 7 dimensions; use when you want a scorecard rather than targeted fixes; not a required step in the standard workflow
 11. `/storyforge:cover-artist` — Generate cover prompts
 12. `/storyforge:export-engineer` — EPUB/PDF/MOBI via Pandoc
@@ -284,6 +286,7 @@ Skills MUST load relevant craft references before generating creative content. U
 - `character-creator-memoir` (memoir-only, split out in #177) → 6-step real-people handler (#59) that loads `book_categories/memoir/craft/real-people-ethics.md`, `emotional-truth.md`, `memoir-anti-ai-patterns.md`; writes to `people/{slug}.md` via `create_person` MCP tool with the four-category ethics schema.
 - `world-builder` → loads: world-building (memoir typically skips this skill — real settings are documented in `world/setting.md` via research, not invention)
 - `voice-checker` → loads: anti-ai-patterns, prose-style, dos-and-donts (memoir mode adds: `book_categories/memoir/craft/memoir-anti-ai-patterns.md`; runs Dimension 8 memoir-specific AI-tells: reflective platitude, "looking back" hinges, tidy lesson endings, hedging-as-humility, therapeutic reframe, explanation-after-image — Issue #62)
+- `author-check` → loads: author profile (style_principles Writing Discoveries + quantitative targets) via `get_author()`; reads chapter draft directly; optionally reads existing `review.md` for constraint violation count (balance warning). No craft references needed — checks positive presence, not craft quality.
 - `manuscript-checker` → memoir mode adds memoir-specific patterns (Phase 3 #61)
 - `promo-writer` → loads: genre README(s) for blurb tone guidance, `reference/promo/platforms.md` for platform characteristics
 

--- a/skills/author-check/SKILL.md
+++ b/skills/author-check/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: author-check
+description: |
+  Verify positive style compliance after chapter drafting.
+  Checks presence of style_principles Writing Discoveries and quantitative prose targets.
+  Use when: (1) User says "author check", "style check", "positive check",
+  (2) After chapter-writer to verify positive style markers are present,
+  (3) When chapter-reviewer finds many violations — catches the flip side,
+  (4) Suspicion that banter, sarcasm, or other documented voice traits are missing.
+  Counterpart to manuscript-checker (which only catches negatives).
+model: claude-opus-4-7
+user-invocable: true
+argument-hint: "<book-slug> <chapter-slug>"
+---
+
+# Author Check — Positive Style Compliance Gate
+
+The constraint system in StoryForge is structurally biased toward negatives.
+`manuscript-checker` and `chapter-reviewer` flag what should NOT be there.
+Nothing verifies what SHOULD be there.
+
+This skill is that verification.
+
+It checks the draft against:
+1. **Style Principles** from the author's Writing Discoveries — positive patterns the author has trained into the profile
+2. **Quantitative prose targets** derived from studied works (dialog ratio, fragment rate, etc.)
+3. **Balance** — too many violations + zero positive hits signals generic-AI drift
+
+---
+
+## Phase 1 — Load Context
+
+### 1a. Resolve book and author
+
+Call MCP `get_book_full(book_slug)`. From the result, extract:
+- `author_slug` — to load the author profile
+- `project_path` — to locate chapter files
+
+If `book_slug` is missing, call MCP `list_books()` and ask the user to pick one.
+
+### 1b. Load author profile
+
+Call MCP `get_author(author_slug)`. From the result, extract:
+
+- **Writing Discoveries → Style Principles** (`writing_discoveries.style_principles`) — the list of positive patterns extracted from studied works. This is what chapter-writer is instructed to "lean into." This skill verifies that leaning actually happened.
+- **Writing Discoveries → Recurring Tics** (`writing_discoveries.recurring_tics`) — constraint list; not checked here but used for balance warning.
+- **Quantitative targets** — look for fields set by `study-author`:
+  - `dialog_ratio_target` (format: "45–55%")
+  - `fragment_ratio_target` (format: "12–18%")
+  - `single_line_paragraph_ratio_target` (format: "15–25%")
+  - `avg_sentence_length_target` (format: "11–15 words")
+  - If these fields are absent, fall back to defaults (see Phase 3).
+
+- **Tone descriptors** (`tone`) — e.g. "sarcastic, playful, warm". Used as a soft lens for qualitative checks.
+
+### 1c. Load the chapter draft
+
+Read `{project_path}/chapters/{chapter_slug}/draft.md`.
+
+If the file is missing, stop. Report: "Draft not found at expected path — run chapter-writer first or check the chapter slug."
+
+### 1d. Check for existing reviewer output (optional)
+
+Look for `{project_path}/chapters/{chapter_slug}/review.md`. If it exists, extract constraint violation count from its summary section (look for "Major findings: N" or similar). Store as `constraint_violations` (default: unknown).
+
+---
+
+## Phase 2 — Parse Style Principles
+
+From `writing_discoveries.style_principles`, build a checklist.
+
+Each style principle is one of:
+- **Quantitative** — contains a specific number, minimum, ratio, or frequency target. Examples:
+  - "Mindestens 2 Banter-Exchanges pro Kapitel"
+  - "Dialog ratio: 45–55%"
+  - "Fragment ratio: 12–18%"
+- **Qualitative** — documents a pattern or technique without a hard number. Examples:
+  - "Sarcasm as default register in tense scenes"
+  - "Vulnerability reveals follow banter, not during it"
+  - "Humor-as-armor: characters deflect with wit before breaking open"
+
+Separate the two lists. Quantitative entries get numeric verification. Qualitative entries get prose-scanning verification.
+
+If Writing Discoveries → Style Principles is empty, report: "No style_principles Writing Discoveries found for this author. Run `/storyforge:study-author` on at least one book to populate positive targets. Skipping compliance checks."
+
+---
+
+## Phase 3 — Quantitative Metrics
+
+Run these counts on the raw draft text. Present actual values vs. targets.
+
+### 3a. Dialog ratio
+Count characters inside opening and closing quotation marks (`"…"`) as dialog.
+Ratio = dialog characters / total non-whitespace characters.
+
+**Default target:** 45–55% (override with `dialog_ratio_target` from profile if set).
+
+### 3b. Fragment ratio
+Count sentences of 5 words or fewer as fragments. (Split on sentence-ending punctuation: `.` `!` `?` — exclude dialog fragments inside quotes.)
+Ratio = fragment sentences / total sentences.
+
+**Default target:** 12–18% (override with `fragment_ratio_target` from profile if set).
+
+### 3c. Single-line paragraph ratio
+Count paragraphs that consist of a single sentence (or ≤75 characters).
+Ratio = single-line paragraphs / total paragraphs.
+
+**Default target:** 15–25% (override with `single_line_paragraph_ratio_target` from profile if set).
+
+### 3d. Average sentence length
+Total words (excluding dialog punctuation markup) / total sentence count.
+
+**Default target:** 11–15 words (override with `avg_sentence_length_target` from profile if set).
+
+> **Note on targets:** These defaults represent a readable contemporary fiction average.
+> Author-specific targets from `study-author` always take precedence.
+> If the author's profile shows a studied-work average of 18 words, that IS the target, not 11–15.
+
+---
+
+## Phase 4 — Qualitative Style Principles Check
+
+For each **qualitative** style_principle entry, scan the chapter draft for evidence.
+
+**Method:**
+Read the draft carefully. For each principle:
+1. Identify what evidence would look like in prose
+2. Scan for 1–3 concrete examples (short quote + line context)
+3. Classify as:
+   - **FOUND** — clear evidence, can quote at least one instance
+   - **PARTIAL** — something approximating the pattern, but weak or infrequent
+   - **NOT FOUND** — no evidence detected after full read
+
+Do not invent evidence. If you can't quote it, mark NOT FOUND.
+
+**Quantitative style_principles** from Writing Discoveries that weren't already covered in Phase 3 get the same treatment here (count-based check).
+
+---
+
+## Phase 5 — Balance Warning
+
+Compute:
+- `positive_hits` = number of qualitative + quantitative checks with result FOUND or on-target
+- `positive_total` = total checks run
+- `constraint_violations` = from Phase 1d (or "unknown" if no reviewer output found)
+
+**Trigger balance warning if:**
+- `constraint_violations` is a known number AND > 5
+- AND `positive_hits` < 1
+
+**Warning text:**
+> "This chapter has {N} constraint violations on record but no detectable positive style markers. The draft may be defaulting to generic AI register by omission — the author's documented voice traits are absent, not just suppressed."
+
+Even without a known violation count, flag if `positive_hits == 0` and `positive_total > 0`:
+> "No positive style markers detected. Constraint-free writing is not the same as voice-accurate writing. Check that the author's positive style_principles (banter, sarcasm, preferred structures) are actually present."
+
+---
+
+## Output Format
+
+```markdown
+## Author Check — {Book Title}, Chapter {N}: {Chapter Title}
+**Author profile:** {author_slug} | **Checked:** {date}
+
+---
+
+### Quantitative Targets
+
+| Metric | Actual | Target | Status |
+|--------|--------|--------|--------|
+| Dialog ratio | 38% | 45–55% | ⚠️ Below target |
+| Fragment ratio | 15.2% | 12–18% | ✅ On target |
+| Single-line paragraphs | 8% | 15–25% | ❌ Below target |
+| Avg sentence length | 14.2 words | 11–15 words | ✅ On target |
+
+---
+
+### Style Principles Compliance
+
+*(From Writing Discoveries → Style Principles)*
+
+✅ **[Principle name]** — Found. Quote: "..."
+⚠️  **[Principle name]** — Partial. Weak presence; only 1 instance in 4200 words. Quote: "..."
+❌ **[Principle name]** — Not found. No evidence of this pattern in the draft.
+
+*(Repeat for each style_principle entry)*
+
+---
+
+### Balance
+
+| | Count |
+|---|---|
+| Positive markers found | 2 / 5 |
+| Constraint violations on record | 7 |
+
+⚠️ **Balance warning:** 7 constraint violations recorded, but only 2/5 positive style markers
+present. The draft suppresses negatives but does not demonstrate the author's positive voice.
+
+---
+
+### Verdict
+
+PASS | WARN | FAIL
+
+**Verdict rationale:** [One sentence.]
+
+---
+
+### Next Steps
+
+[2–4 concrete actions, ranked by impact. Example:]
+- Dialog ratio (38%) is 7 points below target. Expand the {scene name} confrontation with actual back-and-forth rather than narrated summary.
+- [Principle X] (NOT FOUND). This chapter has no banter. The protagonist and antagonist meet twice — both encounters are narrated at a remove. Add one direct exchange.
+```
+
+**Verdict thresholds:**
+
+| Result | Condition |
+|--------|-----------|
+| PASS | ≥80% positive hits, all quantitative within target or at most 1 metric off by ≤5 points |
+| WARN | 50–79% positive hits, OR 2 metrics off target, OR balance warning triggered |
+| FAIL | <50% positive hits, OR 3+ metrics off target, OR balance warning with 0 positive hits |
+
+---
+
+## Rules
+
+- This skill checks PRESENCE of positives, not absence of negatives. Constraint-checking is `chapter-reviewer`'s job. Don't cross-contaminate.
+- If Writing Discoveries → Style Principles is empty: run only quantitative checks (Phase 3). Report the empty Discoveries as a finding — it means no positive extraction has been done yet.
+- Quantitative metrics are approximations. Sentence and dialog boundary detection by text scan is not 100% accurate. Mark calculated values as "~" (approximately) if the draft uses unusual punctuation styles.
+- Quote concrete evidence for every FOUND verdict. An unquoted FOUND is unverifiable.
+- When writing Next Steps, be specific: which scene, which character pair, what type of change. "Add more banter" is not actionable. "Add a back-and-forth exchange between X and Y in the {scene} — they currently argue via narrated summary" is.
+- Do not suggest removing constraint violations here. That's the reviewer's domain. Focus only on what's missing from the positive side.
+- After report output: ask the user "Would you like me to pass this author-check result to chapter-reviewer as an additional section?" If yes, append a condensed version to the existing `review.md` (or note it for the next reviewer run).


### PR DESCRIPTION
## Summary

- Adds `/storyforge:author-check` skill — a post-write gate that checks **presence** of positive style markers (the counterpart to `manuscript-checker`'s constraint-only approach)
- Checks style_principles Writing Discoveries (qualitative + quantitative) against the chapter draft
- Checks quantitative prose targets: dialog ratio, fragment ratio, single-line paragraph ratio, average sentence length
- Emits a balance warning when constraint violations > 5 but positive hits == 0 — catching the silent drift into generic-AI register
- Routing wired in CLAUDE.md: trigger table, workflow pipeline (step 10a), and skill context registry

## Motivation

The constraint system in StoryForge is structurally biased toward negatives. `manuscript-checker` and `chapter-reviewer` flag what should NOT be there. Nothing verifies what SHOULD be there. An author profile that documents "Sarcasm as default" and "minimum 2–3 banter exchanges per chapter" has zero enforcement — chapter-writer receives the instruction but Claude can silently omit banter without triggering any warning.

This was the direct root cause of the banter/sarcasm absence in ethan-cole's Blood & Binary: Firelight drafts, discovered during the study-author analysis in #259.

## Test plan

- [ ] Invoke `/storyforge:author-check` on a chapter draft for a book with style_principles Writing Discoveries — should produce a compliance report with ✅/⚠️/❌ per check
- [ ] Invoke on a chapter with no Writing Discoveries — should report "no style_principles found" and fall back to quantitative checks only
- [ ] Invoke on a chapter where reviewer found > 5 violations — balance warning should fire if positive hits == 0
- [ ] Verify routing: typing "Banter fehlt" in a StoryForge context should route to this skill

## Related

Closes #258
Companion to #259 (genre-driven positive extraction in study-author)

🤖 Generated with [Claude Code](https://claude.com/claude-code)