### PR TITLE
fix: sync genre-filter and world-rules.md to chapter-reviewer and author-check

### DIFF
--- a/skills/author-check/SKILL.md
+++ b/skills/author-check/SKILL.md
@@ -67,7 +67,7 @@ Look for `{project_path}/chapters/{chapter_slug}/review.md`. If it exists, extra
 
 ## Phase 2 — Parse Style Principles
 
-From `writing_discoveries.style_principles`, build a checklist.
+From `writing_discoveries.style_principles`, build a checklist. **Genre filter first:** skip any entry whose `genres` list has no overlap with this book's genres. Entries without a `genres` field are universal and always included.
 
 Each style principle is one of:
 - **Quantitative** — contains a specific number, minimum, ratio, or frequency target. Examples:

--- a/skills/chapter-reviewer/SKILL.md
+++ b/skills/chapter-reviewer/SKILL.md
@@ -39,7 +39,8 @@ Honor every populated field. Empty lists / null means "file missing — degrade 
 
 ### Step 2 — Load author and craft context
 
-- **Author profile** via MCP `get_author()`. **Why:** Voice consistency check needs the documented baseline. `writing_discoveries.recurring_tics` (Issue #151) lists cross-book tics — flag any hit as Major findings. `style_principles` and `donts` feed the same review pass.
+- **Author profile** via MCP `get_author()`. **Why:** Voice consistency check needs the documented baseline. `writing_discoveries.recurring_tics` (Issue #151) lists cross-book tics — flag any hit as Major findings. `style_principles` (genre-filtered — skip entries whose `genres` list shares no genre with this book; entries without `genres` are universal) and `donts` feed the same review pass.
+- **World rules cheat sheet** — Read `{project}/world-rules.md` if it exists. **Why:** Canonically fragile facts (room inventories, biology details, dates) that `world/rules.md` documents in prose but the model still tends to get wrong. Use alongside check 20e. Missing file → skip silently.
 - **Author vocabulary** from `~/.storyforge/authors/{slug}/vocabulary.md`. **Why:** Banned-word scan and preferred-word check both run against this list.
 - **Craft references** via MCP `get_craft_reference()`:
   - `dos-and-donts` — general craft baseline for the Craft section (5 points).
@@ -131,7 +132,7 @@ Load `analyze_plot_logic(book_slug, scope="chapter", chapter_slug=...)` once bef
 20b. **Information leak** — Does the POV character reference any fact established in a later chapter, or in an earlier chapter where the POV was absent? Severity: **high (FAIL)** if demonstrably absent; **WARN** otherwise.
 20c. **Motivation chain** — Does each significant decision follow from the character's established wants and knowledge? Flag contradictions without on-page justification. Severity: **WARN**.
 20d. **Causality direction** — Run static `causality_inversion` findings for this chapter. **FAIL** on any.
-20e. **World rule consistency** — Does the chapter break any rule from the canon log "World / Setting Facts" or `world/rules.md`? Look for negation patterns that the prose violates without an exception clause. Severity: **high (FAIL)**.
+20e. **World rule consistency** — Does the chapter break any rule from the canon log "World / Setting Facts", `world/rules.md`, or `world-rules.md` (fragile-facts cheat sheet)? Look for negation patterns that the prose violates without an exception clause. Severity: **high (FAIL)**.
 20f. **Chapter promise** — If the chapter places a setup-element, is it logged in `## Promises`? Suggest missing promises; on approval call `register_chapter_promises`. Severity: **WARN**.
 
 ### Tonal Consistency (5 points) — only if `plot/tone.md` exists


### PR DESCRIPTION
## Problem

After #266 (genre-tagging) and #270 (world-rules scaffold), two gaps remained:

1. `chapter-reviewer` and `author-check` applied **all** `style_principles` without the `when:` genre filter — so banter/lightness principles from a light-fantasy study would trigger false FAIL findings in dark-fantasy chapters where the chapter-writer had correctly skipped them.

2. `chapter-reviewer` had no visibility into `world-rules.md` (the fragile-facts cheat sheet) — only `chapter-writer` loaded it. The reviewer was checking world consistency only against `world/rules.md` (full creative bible), missing the targeted fragile-fact overrides.

## Fix

**`chapter-reviewer/SKILL.md`**
- Step 2 prerequisites: load `world-rules.md` alongside `world/rules.md` (skip silently if missing)
- Step 2: `style_principles` now noted as genre-filtered (same rule as chapter-writer)
- Check 20e: references `world-rules.md` explicitly

**`author-check/SKILL.md`**
- Phase 2: genre filter applied before building the checklist

## Test plan

- [ ] 1931/1931 tests pass (no logic changes, SKILL.md only)
- [ ] CI green
- [ ] chapter-reviewer on a dark-fantasy chapter does not flag missing banter as FAIL when the banter principle has `when: light-fantasy`
- [ ] chapter-reviewer check 20e catches fragile-fact violations from `world-rules.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)