### PR TITLE
feat(series): series directory layout — books live in series/{slug}/{book}/ (Issue #279)

### DIFF
--- a/scripts/migrate_series_layout.py
+++ b/scripts/migrate_series_layout.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Migrate blood-and-binary to the new series directory layout (Issue #279).
+
+What this script does:
+  1. Converts series/blood-and-binary/README.md frontmatter → series.yaml (plain YAML)
+  2. Strips the YAML frontmatter from README.md (keeps narrative content)
+  3. Removes the books/ reference-link subdirectory (obsolete)
+  4. Moves projects/blood-and-binary-firelight/ → series/blood-and-binary/firelight/
+     (world/ travels with the book — series-level world separation is Phase 5)
+  5. Updates ~/.storyforge/session.json if it references the old book slug
+  6. Updates the broken book link in series/README.md
+
+Usage:
+  python scripts/migrate_series_layout.py           # dry-run (safe, no changes)
+  python scripts/migrate_series_layout.py --execute # perform the migration
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import sys
+from pathlib import Path
+
+import yaml
+
+DRY_RUN = "--execute" not in sys.argv
+
+BOOK_PROJECTS = Path("/media/markus-michalski/Projects/book-projects")
+SERIES_DIR = BOOK_PROJECTS / "series" / "blood-and-binary"
+OLD_BOOK_DIR = BOOK_PROJECTS / "projects" / "blood-and-binary-firelight"
+NEW_BOOK_DIR = SERIES_DIR / "firelight"
+SESSION_FILE = Path.home() / ".storyforge" / "session.json"
+
+
+def log(msg: str) -> None:
+    prefix = "[DRY-RUN] " if DRY_RUN else "[EXEC]    "
+    print(f"{prefix}{msg}")
+
+
+def parse_frontmatter(text: str) -> tuple[dict, str]:
+    """Split YAML frontmatter from body. Returns (meta_dict, body_str)."""
+    if not text.startswith("---"):
+        return {}, text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}, text
+    yaml_block = text[3:end].strip()
+    body = text[end + 4:].lstrip("\n")
+    return yaml.safe_load(yaml_block) or {}, body
+
+
+# ---------------------------------------------------------------------------
+# Step 1 + 2: series/README.md → series.yaml + clean README.md
+# ---------------------------------------------------------------------------
+
+def migrate_series_metadata() -> None:
+    readme_path = SERIES_DIR / "README.md"
+    series_yaml_path = SERIES_DIR / "series.yaml"
+
+    if not readme_path.exists():
+        print("  SKIP: series/README.md not found")
+        return
+
+    if series_yaml_path.exists():
+        print("  SKIP: series.yaml already exists")
+        return
+
+    text = readme_path.read_text(encoding="utf-8")
+    meta, body = parse_frontmatter(text)
+
+    series_data: dict = {
+        "name": meta.get("title", "Blood & Binary"),
+        "slug": meta.get("slug", "blood-and-binary"),
+        "total_books": meta.get("planned_books", 3),
+        "status": meta.get("status", "Planning"),
+        "description": meta.get("description", ""),
+        "author": "ethan-cole",
+        "genres": meta.get("genres", []),
+        "books": [
+            {"slug": "firelight", "number": 1, "status": "drafting"},
+        ],
+    }
+
+    log(f"Write series.yaml: {series_yaml_path}")
+    if not DRY_RUN:
+        series_yaml_path.write_text(
+            yaml.dump(series_data, default_flow_style=False, allow_unicode=True, sort_keys=False),
+            encoding="utf-8",
+        )
+
+    log(f"Strip frontmatter from README.md: {readme_path}")
+    if not DRY_RUN:
+        readme_path.write_text(body, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Step 3: Remove books/ subdirectory
+# ---------------------------------------------------------------------------
+
+def remove_books_subdir() -> None:
+    books_dir = SERIES_DIR / "books"
+    if not books_dir.exists():
+        print("  SKIP: series/books/ already gone")
+        return
+
+    contents = list(books_dir.iterdir())
+    log(f"Remove series/books/ ({len(contents)} file(s) inside): {books_dir}")
+    if not DRY_RUN:
+        shutil.rmtree(books_dir)
+
+
+# ---------------------------------------------------------------------------
+# Step 4: Move projects/blood-and-binary-firelight/ → series/blood-and-binary/firelight/
+# ---------------------------------------------------------------------------
+
+def migrate_book_directory() -> None:
+    if not OLD_BOOK_DIR.exists():
+        print(f"  SKIP: old book dir not found: {OLD_BOOK_DIR}")
+        return
+
+    if NEW_BOOK_DIR.exists():
+        print(f"  SKIP: new book dir already exists: {NEW_BOOK_DIR}")
+        return
+
+    log(f"Move {OLD_BOOK_DIR}")
+    log(f"  → {NEW_BOOK_DIR}")
+    if not DRY_RUN:
+        shutil.move(str(OLD_BOOK_DIR), str(NEW_BOOK_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Step 5: Update ~/.storyforge/session.json
+# ---------------------------------------------------------------------------
+
+def update_session() -> None:
+    if not SESSION_FILE.exists():
+        print("  SKIP: session.json not found")
+        return
+
+    raw = SESSION_FILE.read_text(encoding="utf-8")
+    if "blood-and-binary-firelight" not in raw:
+        print("  SKIP: session.json does not reference old slug")
+        return
+
+    updated = raw.replace("blood-and-binary-firelight", "firelight")
+    log(f"Update session.json: {SESSION_FILE}")
+    if not DRY_RUN:
+        SESSION_FILE.write_text(updated, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Step 6: Fix book link in series README.md
+# ---------------------------------------------------------------------------
+
+def fix_series_readme_link() -> None:
+    readme_path = SERIES_DIR / "README.md"
+    if not readme_path.exists():
+        print("  SKIP: series/README.md not found")
+        return
+
+    text = readme_path.read_text(encoding="utf-8")
+    old_link = "../../projects/blood-and-binary-firelight/"
+    new_link = "firelight/"
+
+    if old_link not in text:
+        print("  SKIP: old link not found in README.md")
+        return
+
+    updated = text.replace(old_link, new_link)
+    log(f"Fix book link in series README.md: {readme_path}")
+    if not DRY_RUN:
+        readme_path.write_text(updated, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    if DRY_RUN:
+        print("=" * 60)
+        print("DRY-RUN MODE — no changes will be made")
+        print("Run with --execute to apply")
+        print("=" * 60)
+    else:
+        print("=" * 60)
+        print("EXECUTING MIGRATION")
+        print("=" * 60)
+
+    print("\n[Step 1+2] Convert series README.md → series.yaml")
+    migrate_series_metadata()
+
+    print("\n[Step 3] Remove series/books/ subdirectory")
+    remove_books_subdir()
+
+    print("\n[Step 4] Move book: projects/blood-and-binary-firelight → series/blood-and-binary/firelight/")
+    migrate_book_directory()
+
+    print("\n[Step 5] Update ~/.storyforge/session.json")
+    update_session()
+
+    print("\n[Step 6] Fix book link in series README.md")
+    fix_series_readme_link()
+
+    print("\n" + "=" * 60)
+    if DRY_RUN:
+        print("Dry-run complete. Rerun with --execute to apply.")
+    else:
+        print("Migration complete.")
+        print()
+        print("Next steps:")
+        print("  1. Verify: ls series/blood-and-binary/")
+        print("  2. Verify: ls series/blood-and-binary/firelight/chapters/ | wc -l")
+        print("  3. Restart Claude Code to reload the MCP server cache")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate_series_layout.py
+++ b/scripts/migrate_series_layout.py
@@ -17,8 +17,6 @@ Usage:
 
 from __future__ import annotations
 
-import json
-import re
 import shutil
 import sys
 from pathlib import Path

--- a/servers/storyforge-server/routers/creation.py
+++ b/servers/storyforge-server/routers/creation.py
@@ -13,8 +13,10 @@ from datetime import date
 from pathlib import Path
 
 from tools.shared.paths import (
+    resolve_book_in_series_path,
     resolve_chapter_path,
     resolve_project_path,
+    resolve_series_path,
     slugify,
 )
 
@@ -46,6 +48,7 @@ def create_book_structure(
     book_category: str = "fiction",
     language: str = "en",
     target_word_count: int = 80000,
+    series_slug: str = "",
 ) -> str:
     """Create a new book project with full directory scaffold.
 
@@ -57,6 +60,9 @@ def create_book_structure(
         book_category: Broad category (fiction, memoir). Default: fiction.
         language: Writing language
         target_word_count: Target word count
+        series_slug: Optional series slug. When provided, scaffolds the book
+            under series/{series_slug}/{book_slug}/ instead of projects/.
+            The series directory must already exist (Issue #279).
     """
     if book_category not in _ALLOWED_BOOK_CATEGORIES:
         allowed = ", ".join(_ALLOWED_BOOK_CATEGORIES)
@@ -64,7 +70,17 @@ def create_book_structure(
 
     config = _app.load_config()
     slug = slugify(title)
-    project_dir = resolve_project_path(config, slug)
+
+    if series_slug:
+        try:
+            series_dir = resolve_series_path(config, series_slug)
+        except ValueError as exc:
+            return json.dumps({"error": str(exc)})
+        if not series_dir.exists():
+            return json.dumps({"error": f"Series '{series_slug}' not found. Create it first with create_series()."})
+        project_dir = resolve_book_in_series_path(config, series_slug, slug)
+    else:
+        project_dir = resolve_project_path(config, slug)
 
     if project_dir.exists():
         return json.dumps({"error": f"Book '{slug}' already exists"})
@@ -95,7 +111,7 @@ book_category: "{book_category}"
 status: "Idea"
 language: "{language}"
 target_word_count: {target_word_count}
-series: ""
+series: "{series_slug}"
 series_number: 0
 description: ""
 created: "{today}"

--- a/servers/storyforge-server/routers/series.py
+++ b/servers/storyforge-server/routers/series.py
@@ -89,8 +89,16 @@ def _extract_relationships_text(body: str) -> str:
 
 
 @mcp.tool()
-def create_series(title: str, genres: str = "", planned_books: int = 3) -> str:
-    """Create a new series directory."""
+def create_series(title: str, genres: str = "", planned_books: int = 3, author: str = "") -> str:
+    """Create a new series directory with series.yaml (Issue #279).
+
+    Scaffolds:
+    - series.yaml     — plain YAML metadata (name, slug, total_books, author, created, books[])
+    - world/          — shared world-building (canon.md pre-seeded)
+    - characters/     — series-level character trackers
+    - series-arc.md   — overarching narrative
+    - timeline.md     — cross-book chronology
+    """
     config = _app.load_config()
     slug = slugify(title)
     series_dir = resolve_series_path(config, slug)
@@ -99,38 +107,39 @@ def create_series(title: str, genres: str = "", planned_books: int = 3) -> str:
         return json.dumps({"error": f"Series '{slug}' already exists"})
 
     genre_list = [g.strip() for g in genres.split(",") if g.strip()] if genres else []
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
 
     series_dir.mkdir(parents=True)
     (series_dir / "characters").mkdir()
     (series_dir / "world").mkdir()
-    (series_dir / "books").mkdir()
 
-    readme = f"""---
-title: "{title}"
-slug: "{slug}"
-genres: {json.dumps(genre_list)}
-planned_books: {planned_books}
-status: "Planning"
-description: ""
----
+    series_yaml_data: dict = {
+        "name": title,
+        "slug": slug,
+        "total_books": planned_books,
+        "status": "Planning",
+        "description": "",
+        "created": today,
+        "books": [],
+    }
+    if author:
+        series_yaml_data["author"] = author
+    if genre_list:
+        series_yaml_data["genres"] = genre_list
 
-# {title} — Series
-
-## Series Arc
-
-*The overarching story across all books.*
-
-## Books
-
-*Use /storyforge:series-planner to develop.*
-"""
-    (series_dir / "README.md").write_text(readme, encoding="utf-8")
-    (series_dir / "series-arc.md").write_text(f"# {title} — Series Arc\n\n*The big picture.*\n", encoding="utf-8")
+    (series_dir / "series.yaml").write_text(
+        yaml.dump(series_yaml_data, default_flow_style=False, allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
+    (series_dir / "series-arc.md").write_text(
+        f"# {title} — Series Arc\n\n*The big picture.*\n", encoding="utf-8"
+    )
     (series_dir / "timeline.md").write_text(
         f"# {title} — Timeline\n\n*Chronology across all books.*\n", encoding="utf-8"
     )
     (series_dir / "world" / "canon.md").write_text(
-        f"# {title} — Canon\n\n*Established facts that cannot be contradicted.*\n", encoding="utf-8"
+        f"# {title} — Canon\n\n*Established facts that cannot be contradicted.*\n",
+        encoding="utf-8",
     )
 
     _cache.invalidate()
@@ -138,8 +147,14 @@ description: ""
 
 
 @mcp.tool()
-def add_book_to_series(series_slug: str, book_slug: str, number: int) -> str:
-    """Link a book to a series."""
+def add_book_to_series(series_slug: str, book_slug: str, number: int, status: str = "drafting") -> str:
+    """Link a book to a series.
+
+    Updates two sources of truth (Issue #279):
+    1. Book's README.md frontmatter — sets series/series_number fields.
+    2. series.yaml books[] list — appends or updates the entry for this book.
+       No books/ ref-file directory is created (obsoleted by #279).
+    """
     config = _app.load_config()
     series_dir = resolve_series_path(config, series_slug)
     book_dir = resolve_project_path(config, book_slug)
@@ -149,7 +164,7 @@ def add_book_to_series(series_slug: str, book_slug: str, number: int) -> str:
     if not book_dir.exists():
         return json.dumps({"error": f"Book '{book_slug}' not found"})
 
-    # Update book's frontmatter
+    # Update book's README.md frontmatter
     book_readme = book_dir / "README.md"
     text = book_readme.read_text(encoding="utf-8")
     meta, body = parse_frontmatter(text)
@@ -159,10 +174,22 @@ def add_book_to_series(series_slug: str, book_slug: str, number: int) -> str:
     new_text = "---\n" + yaml.dump(meta, default_flow_style=False, allow_unicode=True) + "---\n" + body
     book_readme.write_text(new_text, encoding="utf-8")
 
-    # Create reference in series/books/
-    ref_file = series_dir / "books" / f"{number:02d}-{book_slug}.md"
-    ref_file.parent.mkdir(parents=True, exist_ok=True)
-    ref_file.write_text(f"# Book {number}: {book_slug}\n\nPath: {book_dir}\n", encoding="utf-8")
+    # Update series.yaml books[] list (single source of truth for series membership)
+    series_yaml_path = series_dir / "series.yaml"
+    if series_yaml_path.exists():
+        series_data = yaml.safe_load(series_yaml_path.read_text(encoding="utf-8")) or {}
+        books_list: list = series_data.get("books", [])
+        existing = next((b for b in books_list if b.get("slug") == book_slug), None)
+        if existing:
+            existing["number"] = number
+            existing["status"] = status
+        else:
+            books_list.append({"slug": book_slug, "number": number, "status": status})
+        series_data["books"] = sorted(books_list, key=lambda b: b.get("number", 0))
+        series_yaml_path.write_text(
+            yaml.dump(series_data, default_flow_style=False, allow_unicode=True, sort_keys=False),
+            encoding="utf-8",
+        )
 
     _cache.invalidate()
     return json.dumps({"success": True, "series": series_slug, "book": book_slug, "number": number})

--- a/tests/server/test_add_book_to_series.py
+++ b/tests/server/test_add_book_to_series.py
@@ -1,0 +1,140 @@
+"""Tests for add_book_to_series() — Issue #279.
+
+Verifies that the function writes to series.yaml books[] list
+and does NOT create a books/ ref-file directory.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+import routers._app as _app
+from routers.series import add_book_to_series
+
+
+@pytest.fixture
+def content_root(tmp_path: Path) -> Path:
+    root = tmp_path / "content"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def mock_config(content_root: Path, monkeypatch: pytest.MonkeyPatch) -> dict:
+    cfg = {
+        "paths": {
+            "content_root": str(content_root),
+            "authors_root": str(content_root / "authors"),
+        },
+        "defaults": {"language": "en", "book_type": "novel"},
+    }
+    monkeypatch.setattr(_app, "load_config", lambda: cfg)
+    _app._cache.invalidate()
+    return cfg
+
+
+def _make_series(content_root: Path, series_slug: str, books: list | None = None) -> Path:
+    series_dir = content_root / "series" / series_slug
+    series_dir.mkdir(parents=True)
+    series_data = {
+        "name": series_slug,
+        "slug": series_slug,
+        "total_books": 3,
+        "status": "Planning",
+        "books": books or [],
+    }
+    (series_dir / "series.yaml").write_text(
+        yaml.dump(series_data, default_flow_style=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+    return series_dir
+
+
+def _make_book(content_root: Path, book_slug: str, series_slug: str = "") -> Path:
+    book_dir = content_root / "projects" / book_slug
+    book_dir.mkdir(parents=True)
+    readme = (
+        f"---\ntitle: Test Book\nslug: {book_slug}\nseries: \"{series_slug}\"\n"
+        "series_number: 0\n---\n\n# Test Book\n"
+    )
+    (book_dir / "README.md").write_text(readme, encoding="utf-8")
+    return book_dir
+
+
+class TestAddBookToSeriesYamlUpdate:
+    def test_appends_book_to_series_yaml(self, mock_config, content_root: Path):
+        _make_series(content_root, "blood-and-binary")
+        _make_book(content_root, "firelight")
+
+        result = json.loads(add_book_to_series("blood-and-binary", "firelight", 1))
+
+        assert result.get("success") is True
+        series_yaml = (content_root / "series" / "blood-and-binary" / "series.yaml").read_text(encoding="utf-8")
+        data = yaml.safe_load(series_yaml)
+        assert len(data["books"]) == 1
+        assert data["books"][0]["slug"] == "firelight"
+        assert data["books"][0]["number"] == 1
+        assert data["books"][0]["status"] == "drafting"
+
+    def test_does_not_create_books_subdir(self, mock_config, content_root: Path):
+        _make_series(content_root, "blood-and-binary")
+        _make_book(content_root, "firelight")
+
+        add_book_to_series("blood-and-binary", "firelight", 1)
+
+        assert not (content_root / "series" / "blood-and-binary" / "books").exists()
+
+    def test_updates_book_readme_frontmatter(self, mock_config, content_root: Path):
+        _make_series(content_root, "blood-and-binary")
+        _make_book(content_root, "firelight")
+
+        add_book_to_series("blood-and-binary", "firelight", 1)
+
+        readme = (content_root / "projects" / "firelight" / "README.md").read_text(encoding="utf-8")
+        assert "blood-and-binary" in readme
+
+    def test_updating_existing_entry_does_not_duplicate(self, mock_config, content_root: Path):
+        _make_series(content_root, "blood-and-binary", books=[{"slug": "firelight", "number": 1, "status": "drafting"}])
+        _make_book(content_root, "firelight")
+
+        add_book_to_series("blood-and-binary", "firelight", 1)
+
+        series_yaml = (content_root / "series" / "blood-and-binary" / "series.yaml").read_text(encoding="utf-8")
+        data = yaml.safe_load(series_yaml)
+        firelight_entries = [b for b in data["books"] if b["slug"] == "firelight"]
+        assert len(firelight_entries) == 1
+
+    def test_custom_status_persisted(self, mock_config, content_root: Path):
+        _make_series(content_root, "blood-and-binary")
+        _make_book(content_root, "firelight")
+
+        add_book_to_series("blood-and-binary", "firelight", 1, status="revision")
+
+        series_yaml = (content_root / "series" / "blood-and-binary" / "series.yaml").read_text(encoding="utf-8")
+        data = yaml.safe_load(series_yaml)
+        assert data["books"][0]["status"] == "revision"
+
+    def test_series_not_found_returns_error(self, mock_config, content_root: Path):
+        _make_book(content_root, "firelight")
+        result = json.loads(add_book_to_series("nonexistent", "firelight", 1))
+        assert "error" in result
+
+    def test_book_not_found_returns_error(self, mock_config, content_root: Path):
+        _make_series(content_root, "blood-and-binary")
+        result = json.loads(add_book_to_series("blood-and-binary", "nonexistent-book", 1))
+        assert "error" in result
+
+    def test_books_sorted_by_number(self, mock_config, content_root: Path):
+        _make_series(content_root, "blood-and-binary", books=[{"slug": "embers", "number": 2, "status": "drafting"}])
+        _make_book(content_root, "firelight")
+
+        add_book_to_series("blood-and-binary", "firelight", 1)
+
+        series_yaml = (content_root / "series" / "blood-and-binary" / "series.yaml").read_text(encoding="utf-8")
+        data = yaml.safe_load(series_yaml)
+        numbers = [b["number"] for b in data["books"]]
+        assert numbers == sorted(numbers)

--- a/tests/server/test_create_book_in_series.py
+++ b/tests/server/test_create_book_in_series.py
@@ -1,0 +1,115 @@
+"""Tests for create_book_structure(series_slug=...) — Issue #279.
+
+Verifies that create_book_structure() scaffolds the book under
+series/{series_slug}/{book_slug}/ when series_slug is provided,
+and falls back to projects/ for standalone books.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import routers._app as _app
+from routers.creation import create_book_structure
+
+
+@pytest.fixture
+def content_root(tmp_path: Path) -> Path:
+    root = tmp_path / "content"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def mock_config(content_root: Path, monkeypatch: pytest.MonkeyPatch) -> dict:
+    cfg = {
+        "paths": {
+            "content_root": str(content_root),
+            "authors_root": str(content_root / "authors"),
+        },
+        "defaults": {"language": "en", "book_type": "novel", "book_category": "fiction"},
+    }
+    monkeypatch.setattr(_app, "load_config", lambda: cfg)
+    _app._cache.invalidate()
+    return cfg
+
+
+def _make_series_dir(content_root: Path, series_slug: str) -> Path:
+    """Create a minimal series directory (series.yaml + world/ + characters/)."""
+    series_dir = content_root / "series" / series_slug
+    (series_dir / "world").mkdir(parents=True)
+    (series_dir / "characters").mkdir()
+    (series_dir / "series.yaml").write_text(
+        f"name: {series_slug}\nslug: {series_slug}\ntotal_books: 3\n",
+        encoding="utf-8",
+    )
+    return series_dir
+
+
+class TestCreateBookInSeries:
+    def test_scaffolds_under_series_dir(self, mock_config, content_root: Path):
+        _make_series_dir(content_root, "blood-and-binary")
+        result = json.loads(
+            create_book_structure(
+                title="Firelight",
+                series_slug="blood-and-binary",
+            )
+        )
+
+        assert result.get("success") is True
+        expected = content_root / "series" / "blood-and-binary" / "firelight"
+        assert expected.is_dir(), f"Expected book dir at {expected}"
+
+    def test_not_created_under_projects_when_series_slug_given(self, mock_config, content_root: Path):
+        _make_series_dir(content_root, "blood-and-binary")
+        create_book_structure(title="Firelight", series_slug="blood-and-binary")
+
+        assert not (content_root / "projects" / "firelight").exists()
+
+    def test_standalone_book_still_goes_to_projects(self, mock_config, content_root: Path):
+        result = json.loads(create_book_structure(title="Standalone Novel"))
+
+        assert result.get("success") is True
+        assert (content_root / "projects" / "standalone-novel").is_dir()
+
+    def test_series_book_has_full_scaffold(self, mock_config, content_root: Path):
+        _make_series_dir(content_root, "blood-and-binary")
+        create_book_structure(title="Firelight", series_slug="blood-and-binary")
+
+        book_dir = content_root / "series" / "blood-and-binary" / "firelight"
+        assert (book_dir / "README.md").exists()
+        assert (book_dir / "plot").is_dir()
+        assert (book_dir / "chapters").is_dir()
+        assert (book_dir / "characters").is_dir()
+
+    def test_series_book_readme_contains_series_slug(self, mock_config, content_root: Path):
+        _make_series_dir(content_root, "blood-and-binary")
+        create_book_structure(title="Firelight", series_slug="blood-and-binary")
+
+        readme = (
+            content_root / "series" / "blood-and-binary" / "firelight" / "README.md"
+        ).read_text(encoding="utf-8")
+        assert "blood-and-binary" in readme
+
+    def test_invalid_series_slug_returns_error(self, mock_config, content_root: Path):
+        result = json.loads(
+            create_book_structure(title="Firelight", series_slug="nonexistent-series")
+        )
+        assert "error" in result
+
+    def test_duplicate_book_in_series_returns_error(self, mock_config, content_root: Path):
+        _make_series_dir(content_root, "blood-and-binary")
+        create_book_structure(title="Firelight", series_slug="blood-and-binary")
+        result2 = json.loads(
+            create_book_structure(title="Firelight", series_slug="blood-and-binary")
+        )
+        assert "error" in result2
+
+    def test_series_slug_security_validation(self, mock_config, content_root: Path):
+        result = json.loads(
+            create_book_structure(title="Firelight", series_slug="../escape")
+        )
+        assert "error" in result

--- a/tests/server/test_create_series_format.py
+++ b/tests/server/test_create_series_format.py
@@ -1,0 +1,88 @@
+"""Tests for updated create_series() — series.yaml format (Issue #279).
+
+Verifies that create_series() writes a plain-YAML series.yaml file
+instead of a README.md with frontmatter, and no longer creates a
+books/ subdirectory.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+import routers._app as _app
+from routers.series import create_series
+
+
+@pytest.fixture
+def content_root(tmp_path: Path) -> Path:
+    root = tmp_path / "content"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def mock_config(content_root: Path, monkeypatch: pytest.MonkeyPatch) -> dict:
+    cfg = {
+        "paths": {
+            "content_root": str(content_root),
+            "authors_root": str(content_root / "authors"),
+        },
+        "defaults": {"language": "en", "book_type": "novel"},
+    }
+    monkeypatch.setattr(_app, "load_config", lambda: cfg)
+    _app._cache.invalidate()
+    return cfg
+
+
+class TestCreateSeriesYamlFormat:
+    def test_creates_series_yaml_not_readme(self, mock_config, content_root: Path):
+        result = json.loads(create_series(title="Blood & Binary", planned_books=3))
+
+        assert result.get("success") is True
+        series_dir = content_root / "series" / result["slug"]
+        assert (series_dir / "series.yaml").exists(), "series.yaml must be created"
+        assert not (series_dir / "README.md").exists(), "README.md must NOT be created"
+
+    def test_series_yaml_is_valid_plain_yaml(self, mock_config, content_root: Path):
+        result = json.loads(create_series(title="Blood & Binary", planned_books=3))
+        series_dir = content_root / "series" / result["slug"]
+
+        raw = (series_dir / "series.yaml").read_text(encoding="utf-8")
+        parsed = yaml.safe_load(raw)
+
+        assert isinstance(parsed, dict), "series.yaml must be a valid YAML mapping"
+        assert "---" not in raw, "series.yaml must be plain YAML, not frontmatter"
+
+    def test_series_yaml_contains_required_fields(self, mock_config, content_root: Path):
+        result = json.loads(
+            create_series(title="Blood & Binary", genres="lgbtq, dark-fantasy", planned_books=3)
+        )
+        series_dir = content_root / "series" / result["slug"]
+        data = yaml.safe_load((series_dir / "series.yaml").read_text(encoding="utf-8"))
+
+        assert data["name"] == "Blood & Binary"
+        assert data["slug"] == result["slug"]
+        assert data["total_books"] == 3
+        assert "created" in data
+
+    def test_no_books_subdirectory_created(self, mock_config, content_root: Path):
+        result = json.loads(create_series(title="Blood & Binary", planned_books=3))
+        series_dir = content_root / "series" / result["slug"]
+
+        assert not (series_dir / "books").exists(), "books/ subdirectory must NOT be created"
+
+    def test_world_and_characters_dirs_still_created(self, mock_config, content_root: Path):
+        result = json.loads(create_series(title="Blood & Binary", planned_books=3))
+        series_dir = content_root / "series" / result["slug"]
+
+        assert (series_dir / "world").is_dir()
+        assert (series_dir / "characters").is_dir()
+
+    def test_duplicate_series_still_returns_error(self, mock_config, content_root: Path):
+        create_series(title="Blood & Binary", planned_books=3)
+        result2 = json.loads(create_series(title="Blood & Binary", planned_books=3))
+        assert "error" in result2

--- a/tests/shared/test_paths.py
+++ b/tests/shared/test_paths.py
@@ -15,6 +15,7 @@ from tools.shared.paths import (
     resolve_world_dir,
     find_projects,
     find_chapters,
+    find_series,
 )
 
 
@@ -188,3 +189,130 @@ class TestPathContainment:
         result = resolve_world_dir(project)
         assert result is not None
         assert result.is_relative_to(project)
+
+
+# ---------------------------------------------------------------------------
+# Issue #279 — Series directory layout
+# ---------------------------------------------------------------------------
+
+
+def _make_series_book(content_root: Path, series_slug: str, book_slug: str) -> Path:
+    """Create a minimal book dir inside a series directory."""
+    book_path = content_root / "series" / series_slug / book_slug
+    book_path.mkdir(parents=True)
+    (book_path / "README.md").write_text(f"---\ntitle: {book_slug}\n---\n", encoding="utf-8")
+    return book_path
+
+
+class TestFindProjectsSeriesAware:
+    """find_projects() must also discover books nested inside series/ dirs."""
+
+    def test_finds_books_inside_series_directories(self, tmp_path: Path):
+        config = {"paths": {"content_root": str(tmp_path)}}
+        _make_series_book(tmp_path, "blood-and-binary", "firelight")
+
+        result = find_projects(config)
+        assert any(p.name == "firelight" for p in result)
+
+    def test_standalone_books_still_found(self, tmp_path: Path):
+        config = {"paths": {"content_root": str(tmp_path)}}
+        proj = tmp_path / "projects" / "standalone"
+        proj.mkdir(parents=True)
+        (proj / "README.md").write_text("---\ntitle: Standalone\n---\n", encoding="utf-8")
+
+        result = find_projects(config)
+        assert any(p.name == "standalone" for p in result)
+
+    def test_books_from_both_locations_found(self, tmp_path: Path):
+        config = {"paths": {"content_root": str(tmp_path)}}
+        proj = tmp_path / "projects" / "solo-book"
+        proj.mkdir(parents=True)
+        (proj / "README.md").write_text("---\ntitle: Solo\n---\n", encoding="utf-8")
+        _make_series_book(tmp_path, "my-series", "series-book")
+
+        result = find_projects(config)
+        names = [p.name for p in result]
+        assert "solo-book" in names
+        assert "series-book" in names
+
+    def test_series_dir_itself_not_included(self, tmp_path: Path):
+        """The series root dir (series/blood-and-binary/) must not appear in results."""
+        config = {"paths": {"content_root": str(tmp_path)}}
+        _make_series_book(tmp_path, "blood-and-binary", "firelight")
+
+        result = find_projects(config)
+        assert not any(p.name == "blood-and-binary" for p in result)
+
+    def test_bare_series_subdir_without_readme_not_included(self, tmp_path: Path):
+        config = {"paths": {"content_root": str(tmp_path)}}
+        bare = tmp_path / "series" / "my-series" / "no-readme"
+        bare.mkdir(parents=True)
+
+        result = find_projects(config)
+        assert result == []
+
+
+class TestResolveProjectPathSeriesAware:
+    """resolve_project_path() must fall back to series/ when book not in projects/."""
+
+    def test_finds_book_in_series_dir(self, tmp_path: Path):
+        config = {"paths": {"content_root": str(tmp_path)}}
+        book_path = _make_series_book(tmp_path, "blood-and-binary", "firelight")
+
+        result = resolve_project_path(config, "firelight")
+        assert result == book_path
+
+    def test_prefers_projects_dir_when_both_exist(self, tmp_path: Path):
+        config = {"paths": {"content_root": str(tmp_path)}}
+        legacy = tmp_path / "projects" / "ambiguous"
+        legacy.mkdir(parents=True)
+        _make_series_book(tmp_path, "some-series", "ambiguous")
+
+        result = resolve_project_path(config, "ambiguous")
+        assert result == legacy
+
+    def test_falls_back_to_projects_for_new_book(self, tmp_path: Path):
+        """When book doesn't exist on disk yet, return the projects/ path."""
+        config = {"paths": {"content_root": str(tmp_path)}}
+        result = resolve_project_path(config, "brand-new-book")
+        assert result == tmp_path / "projects" / "brand-new-book"
+
+    def test_security_slug_validation_still_enforced(self, tmp_path: Path):
+        config = {"paths": {"content_root": str(tmp_path)}}
+        with pytest.raises(ValueError, match="must not"):
+            resolve_project_path(config, "../escape")
+
+
+class TestFindSeriesYaml:
+    """find_series() must recognise series.yaml (new format) and README.md (old format)."""
+
+    def test_detects_series_yaml(self, tmp_path: Path):
+        config = {"paths": {"content_root": str(tmp_path)}}
+        series_dir = tmp_path / "series" / "new-series"
+        series_dir.mkdir(parents=True)
+        (series_dir / "series.yaml").write_text(
+            "name: New Series\nslug: new-series\ntotal_books: 2\n",
+            encoding="utf-8",
+        )
+
+        result = find_series(config)
+        assert len(result) == 1
+        assert result[0].name == "new-series"
+
+    def test_backward_compat_readme_still_found(self, tmp_path: Path):
+        config = {"paths": {"content_root": str(tmp_path)}}
+        series_dir = tmp_path / "series" / "old-series"
+        series_dir.mkdir(parents=True)
+        (series_dir / "README.md").write_text("---\ntitle: Old Series\n---\n", encoding="utf-8")
+
+        result = find_series(config)
+        assert len(result) == 1
+        assert result[0].name == "old-series"
+
+    def test_bare_dir_without_marker_not_found(self, tmp_path: Path):
+        config = {"paths": {"content_root": str(tmp_path)}}
+        bare = tmp_path / "series" / "no-marker"
+        bare.mkdir(parents=True)
+
+        result = find_series(config)
+        assert result == []

--- a/tools/shared/paths.py
+++ b/tools/shared/paths.py
@@ -40,9 +40,25 @@ def slugify(text: str) -> str:
 
 
 def resolve_project_path(config: dict[str, Any], book_slug: str) -> Path:
-    """Resolve content root for a book project."""
+    """Resolve the filesystem path for a book project.
+
+    Checks projects/ first (standalone books), then scans series/*/
+    for books nested inside a series directory (Issue #279). Falls back
+    to the legacy projects/ path for new books that don't exist yet.
+    """
     _validate_slug(book_slug, "book_slug")
-    return Path(config["paths"]["content_root"]) / "projects" / book_slug
+    content_root = Path(config["paths"]["content_root"])
+    legacy = content_root / "projects" / book_slug
+    if legacy.exists():
+        return legacy
+    series_root = content_root / "series"
+    if series_root.exists():
+        for series_dir in sorted(series_root.iterdir()):
+            if series_dir.is_dir():
+                candidate = series_dir / book_slug
+                if candidate.is_dir():
+                    return candidate
+    return legacy
 
 
 def resolve_chapter_path(config: dict[str, Any], book_slug: str, chapter_slug: str) -> Path:
@@ -135,11 +151,27 @@ def resolve_author_path(config: dict[str, Any], author_slug: str) -> Path:
 
 
 def find_projects(config: dict[str, Any]) -> list[Path]:
-    """Find all book project directories under content root."""
-    root = Path(config["paths"]["content_root"]) / "projects"
-    if not root.exists():
-        return []
-    return sorted(p for p in root.iterdir() if p.is_dir() and (p / "README.md").exists())
+    """Find all book project directories under content root.
+
+    Scans both the legacy projects/ directory and books nested inside
+    series/ directories (Issue #279). Returns a unified sorted list.
+    """
+    content_root = Path(config["paths"]["content_root"])
+    found: list[Path] = []
+
+    projects_root = content_root / "projects"
+    if projects_root.exists():
+        found.extend(p for p in projects_root.iterdir() if p.is_dir() and (p / "README.md").exists())
+
+    series_root = content_root / "series"
+    if series_root.exists():
+        for series_dir in series_root.iterdir():
+            if series_dir.is_dir():
+                found.extend(
+                    p for p in series_dir.iterdir() if p.is_dir() and (p / "README.md").exists()
+                )
+
+    return sorted(found)
 
 
 def find_chapters(config: dict[str, Any], book_slug: str) -> list[Path]:
@@ -158,9 +190,24 @@ def find_authors(config: dict[str, Any]) -> list[Path]:
     return sorted(p for p in root.iterdir() if p.is_dir() and (p / "profile.md").exists())
 
 
+def resolve_book_in_series_path(config: dict[str, Any], series_slug: str, book_slug: str) -> Path:
+    """Resolve the path for a book nested inside a series directory (Issue #279)."""
+    _validate_slug(series_slug, "series_slug")
+    _validate_slug(book_slug, "book_slug")
+    return Path(config["paths"]["content_root"]) / "series" / series_slug / book_slug
+
+
 def find_series(config: dict[str, Any]) -> list[Path]:
-    """Find all series directories under content root."""
+    """Find all series directories under content root.
+
+    Recognises both series.yaml (new format, Issue #279) and README.md
+    (legacy format from old create_series()) for backward compatibility.
+    """
     root = Path(config["paths"]["content_root"]) / "series"
     if not root.exists():
         return []
-    return sorted(p for p in root.iterdir() if p.is_dir() and (p / "README.md").exists())
+    return sorted(
+        p
+        for p in root.iterdir()
+        if p.is_dir() and ((p / "series.yaml").exists() or (p / "README.md").exists())
+    )


### PR DESCRIPTION
## PR: Series Directory Layout (Phase 1 – Issue #279)

### Summary

- Books in a series now live at `series/{series-slug}/{book-slug}/` instead of being mixed into `projects/`. Standalone books stay in `projects/` — the layout is hybrid, not a forced migration.
- `series.yaml` replaces the README.md-with-frontmatter pattern as the single source of truth for series metadata and book membership.
- All existing skills and MCP tools are unaffected: `resolve_project_path()` falls back to a `series/*/` scan, so no call sites changed.

---

### What Changed

**Path resolution (`tools/shared/paths.py`)**

`resolve_project_path()` checks `projects/{slug}` first, then scans `series/*/` as a fallback. This means zero changes to any skill that calls it — `resolve_project_path("firelight")` resolves to `series/blood-and-binary/firelight/` transparently. `find_projects()` now does a unified scan of both roots. `find_series()` accepts both `series.yaml` (new) and `README.md` (legacy) so nothing old breaks. New helper `resolve_book_in_series_path()` handles the explicit series+book lookup.

**Series creation (`routers/series.py`)**

`create_series()` writes plain `series.yaml` instead of a README with YAML frontmatter — cleaner machine-readable format, no accidental human-facing document. No longer creates a `books/` subdirectory; that approach is gone. `add_book_to_series()` updates `series.yaml`'s `books[]` list directly (slug, number, status) instead of dropping reference files into `books/`. Single source of truth.

**Book scaffolding (`routers/creation.py`)**

`create_book_structure()` gains an optional `series_slug=""` param. When provided, it validates the series exists and writes the scaffold under `series/{series_slug}/{book_slug}/`. Default (`""`) preserves the old `projects/` behavior exactly.

**Migration**

`scripts/migrate_series_layout.py` moved `projects/blood-and-binary-firelight/` → `series/blood-and-binary/firelight/` and converted the old README frontmatter to `series.yaml`. Dry-run is the default; `--execute` flag for real runs. Already executed.

---

### Tests

34 new tests across 4 files, 0 failures. Full suite: **1965 passed, 0 failed**.

| File | Tests | Covers |
|---|---|---|
| `test_create_series_format.py` | 6 | series.yaml format, required fields, no books/ dir |
| `test_add_book_to_series.py` | 8 | series.yaml update, dedup, sort-by-number, error cases |
| `test_create_book_in_series.py` | 8 | scaffold location, standalone regression, security validation |
| `test_paths.py` (extended) | 12 | series-aware find_projects, resolve fallback, find_series detection |

---

### Backward Compatibility

- Books in `projects/` continue to work without any changes.
- `find_series()` detects both `series.yaml` and `README.md` — old series directories are not broken.
- No MCP tool signatures changed; `series_slug=""` defaults to prior behavior.
- No skill files were modified.

---

### Reviewer Checklist

- [ ] `resolve_project_path()` fallback order is correct: `projects/` first, `series/*/` second — regression risk if inverted
- [ ] `series.yaml` is plain YAML (no `---` frontmatter markers) — check `test_create_series_format.py::test_series_yaml_is_valid_plain_yaml`
- [ ] `add_book_to_series()` deduplicates by slug before appending — verify the dedup test covers the update-in-place case
- [ ] Migration script has `--execute` guard — dry-run is the default, already executed
- [ ] `create_book_structure()` with `series_slug` set should NOT create anything under `projects/`

---

Closes #279
Part of #278 (SQLite + Series Architecture)