### PR TITLE
refactor(db): author_discoveries + character_snapshots in SQLite (#281)

### DIFF
--- a/scripts/migrate_phase3.py
+++ b/scripts/migrate_phase3.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Migration script: Phase 3 — profile.md Writing Discoveries + character YAML → SQLite.
+
+Reads existing author profile.md files (Writing Discoveries section) and
+character *.md YAML frontmatter (dynamic state fields) and inserts them into
+the new SQLite tables (author_discoveries, character_snapshots).
+
+Safe to re-run: INSERT OR IGNORE on discoveries, INSERT OR REPLACE on snapshots.
+
+Usage:
+    python scripts/migrate_phase3.py [--dry-run] [--storyforge-home PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Ensure the tools package is importable when run from the repo root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "servers" / "storyforge-server"))
+
+import yaml
+
+from tools.db.author_discoveries import insert_discovery
+from tools.db.character_snapshots import upsert_snapshot
+from tools.db.connection import (
+    ensure_authors_schema,
+    get_authors_db_path,
+    get_book_num,
+    get_db_slug_for_book,
+    open_canon_db,
+    open_db,
+)
+from tools.state.parsers import parse_frontmatter
+
+
+# ---------------------------------------------------------------------------
+# Author discoveries migration
+# ---------------------------------------------------------------------------
+
+_RE_DISCOVERIES_SECTION = re.compile(
+    r"^##\s+Writing\s+Discoveries\s*$(.*?)(?=^##\s|\Z)",
+    re.MULTILINE | re.DOTALL | re.IGNORECASE,
+)
+_RE_ORIGIN = re.compile(
+    r"_\(\s*emerged\s+from\s+(?P<book>[a-z0-9][a-z0-9_-]*)\s*,\s*(?P<date>\d{4}-\d{2})\s*\)_",
+    re.IGNORECASE,
+)
+_BUCKET_RE: list[tuple[str, re.Pattern[str]]] = [
+    ("recurring_tics", re.compile(r"^###\s+Recurring\s+Tics\s*$", re.IGNORECASE)),
+    ("style_principles", re.compile(r"^###\s+Style\s+Principles\s*$", re.IGNORECASE)),
+    ("donts", re.compile(r"^###\s+Don[''`´]?ts.*$", re.IGNORECASE)),
+]
+_RE_PLACEHOLDER = re.compile(r"^_(?:frei|free|empty|tba|tbd)\.?_\s*$", re.IGNORECASE)
+_RE_WHEN = re.compile(r"`when:\s*([^`\n]+)`")
+_RE_EXAMPLE = re.compile(r"`example:`\s*\n((?:[ \t]*>[ \t]*.+\n?)+)", re.MULTILINE)
+
+
+def _parse_discoveries_from_body(body: str) -> list[dict]:
+    """Extract discoveries from profile.md body. Returns flat list of dicts."""
+    section_m = _RE_DISCOVERIES_SECTION.search(body)
+    if not section_m:
+        return []
+
+    section_text = section_m.group(1)
+    entries: list[dict] = []
+    current_type: str | None = None
+    pending: list[str] = []
+
+    def _flush() -> None:
+        if not pending or current_type is None:
+            return
+        raw = "\n".join(pending)
+        pending.clear()
+
+        source_genres = ""
+        when_m = _RE_WHEN.search(raw)
+        if when_m:
+            source_genres = when_m.group(1).strip()
+            raw = _RE_WHEN.sub("", raw).strip()
+
+        example = ""
+        ex_m = _RE_EXAMPLE.search(raw)
+        if ex_m:
+            example = "\n".join(
+                ln.strip().lstrip(">").strip()
+                for ln in ex_m.group(1).splitlines()
+                if ln.strip()
+            )
+            raw = raw[: ex_m.start()].strip()
+
+        origins = [
+            {"book": m.group("book"), "date": m.group("date")}
+            for m in _RE_ORIGIN.finditer(raw)
+        ]
+        cleaned = _RE_ORIGIN.sub("", raw).rstrip(" \t_").strip()
+        cleaned = re.sub(r"\s{2,}", " ", cleaned).strip()
+        if not cleaned:
+            return
+
+        book_slug = origins[0]["book"] if origins else ""
+        date_added = origins[0]["date"] if origins else ""
+
+        entries.append({
+            "discovery_type": current_type,
+            "text": cleaned,
+            "book_slug": book_slug,
+            "date_added": date_added,
+            "source_genres": source_genres,
+            "example": example,
+        })
+
+    for line in section_text.splitlines():
+        stripped = line.strip()
+        matched_bucket = next(
+            (key for key, pat in _BUCKET_RE if pat.match(stripped)), None
+        )
+        if matched_bucket is not None:
+            _flush()
+            current_type = matched_bucket
+            continue
+        if current_type is None or _RE_PLACEHOLDER.match(stripped):
+            continue
+        if stripped.startswith("- "):
+            _flush()
+            pending.append(stripped[2:].strip())
+        elif stripped and pending:
+            pending.append(stripped)
+
+    _flush()
+    return entries
+
+
+def migrate_author_discoveries(authors_root: Path, dry_run: bool) -> None:
+    print(f"\n[author_discoveries] Scanning {authors_root} ...")
+    if not authors_root.is_dir():
+        print("  authors_root not found — skipping.")
+        return
+
+    db_path = get_authors_db_path()
+    if not dry_run:
+        conn = open_db(db_path)
+        ensure_authors_schema(conn)
+    else:
+        conn = None
+
+    total_inserted = 0
+    total_skipped = 0
+
+    for author_dir in sorted(authors_root.iterdir()):
+        if not author_dir.is_dir():
+            continue
+        profile = author_dir / "profile.md"
+        if not profile.is_file():
+            continue
+
+        author_slug = author_dir.name
+        text = profile.read_text(encoding="utf-8")
+        _, body = parse_frontmatter(text)
+        entries = _parse_discoveries_from_body(body)
+
+        for e in entries:
+            label = f"  [{author_slug}] {e['discovery_type']}: {e['text'][:60]!r}"
+            if dry_run:
+                print(f"  [DRY] {label}")
+                total_inserted += 1
+            else:
+                assert conn is not None
+                inserted = insert_discovery(
+                    conn,
+                    author_slug=author_slug,
+                    discovery_type=e["discovery_type"],
+                    text=e["text"],
+                    book_slug=e["book_slug"],
+                    source_genres=e["source_genres"],
+                    example=e["example"],
+                    date_added=e["date_added"],
+                )
+                if inserted:
+                    print(f"  INSERTED {label}")
+                    total_inserted += 1
+                else:
+                    total_skipped += 1
+
+    if conn is not None:
+        conn.close()
+
+    print(f"  Done: {total_inserted} inserted, {total_skipped} skipped (duplicates).")
+
+
+# ---------------------------------------------------------------------------
+# Character snapshots migration
+# ---------------------------------------------------------------------------
+
+_SNAPSHOT_MAP = {
+    "current_injuries": "injuries",
+    "current_clothing": "clothing",
+    "current_inventory": "inventory",
+    "altered_states": "altered_states",
+    "environmental_limiters": "environmental_limiters",
+    "as_of_chapter": "as_of_chapter",
+}
+_SNAPSHOT_LIST_FIELDS = {"injuries", "clothing", "inventory", "altered_states"}
+
+
+def _read_char_snapshot_from_file(char_file: Path) -> dict | None:
+    """Read dynamic state fields from character file frontmatter."""
+    try:
+        text = char_file.read_text(encoding="utf-8")
+        meta, _ = parse_frontmatter(text)
+    except (OSError, ValueError):
+        return None
+
+    snapshot = {}
+    for src_key, dst_key in _SNAPSHOT_MAP.items():
+        if src_key in meta:
+            snapshot[dst_key] = meta[src_key]
+
+    return snapshot if snapshot else None
+
+
+def _parse_chapter_num(as_of: str) -> int:
+    try:
+        return int(str(as_of).split("-")[0])
+    except (ValueError, IndexError):
+        return 0
+
+
+def migrate_character_snapshots(content_root: Path, dry_run: bool) -> None:
+    print(f"\n[character_snapshots] Scanning {content_root} ...")
+    projects_dir = content_root / "projects"
+    if not projects_dir.is_dir():
+        print("  projects/ not found — skipping.")
+        return
+
+    total_inserted = 0
+
+    for book_dir in sorted(projects_dir.iterdir()):
+        if not book_dir.is_dir():
+            continue
+
+        db_slug = get_db_slug_for_book(book_dir)
+        book_num = get_book_num(book_dir)
+
+        conn = open_canon_db(db_slug) if not dry_run else None
+        try:
+            for subdir in ("characters", "people"):
+                chars_dir = book_dir / subdir
+                if not chars_dir.is_dir():
+                    continue
+
+                for char_file in sorted(chars_dir.glob("*.md")):
+                    if char_file.name.upper() == "INDEX.MD":
+                        continue
+                    snap = _read_char_snapshot_from_file(char_file)
+                    if snap is None:
+                        continue
+
+                    char_slug = char_file.stem
+                    chapter_num = _parse_chapter_num(snap.get("as_of_chapter", "0"))
+
+                    # Normalize list fields (YAML may have already parsed them)
+                    for field in _SNAPSHOT_LIST_FIELDS:
+                        val = snap.get(field)
+                        if isinstance(val, str):
+                            snap[field] = [val] if val else []
+                        elif not isinstance(val, list):
+                            snap[field] = []
+
+                    env = snap.get("environmental_limiters", "")
+                    if isinstance(env, list):
+                        env = ", ".join(env)
+
+                    label = f"  [{db_slug}] {char_slug} ch{chapter_num}"
+                    if dry_run:
+                        print(f"  [DRY] {label}: inventory={snap.get('inventory', [])}")
+                        total_inserted += 1
+                    else:
+                        assert conn is not None
+                        upsert_snapshot(
+                            conn,
+                            char_slug=char_slug,
+                            book_num=book_num,
+                            chapter_num=chapter_num,
+                            injuries=snap.get("injuries"),
+                            clothing=snap.get("clothing"),
+                            inventory=snap.get("inventory"),
+                            altered_states=snap.get("altered_states"),
+                            environmental_limiters=env or None,
+                        )
+                        print(f"  UPSERTED {label}")
+                        total_inserted += 1
+        finally:
+            if conn is not None:
+                conn.close()
+
+    print(f"  Done: {total_inserted} snapshots written.")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="Print what would be done, write nothing.")
+    parser.add_argument(
+        "--storyforge-home",
+        default=str(Path.home() / ".storyforge"),
+        help="Path to ~/.storyforge (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--content-root",
+        default=None,
+        help="Override content_root (default: read from config.yaml)",
+    )
+    args = parser.parse_args()
+
+    storyforge_home = Path(args.storyforge_home)
+    authors_root = storyforge_home / "authors"
+
+    if args.content_root:
+        content_root = Path(args.content_root)
+    else:
+        config_path = storyforge_home / "config.yaml"
+        if not config_path.is_file():
+            print(f"Config not found at {config_path}. Pass --content-root explicitly.")
+            sys.exit(1)
+        try:
+            with config_path.open() as f:
+                config = yaml.safe_load(f)
+            content_root = Path(config["paths"]["content_root"])
+        except (KeyError, TypeError) as exc:
+            print(f"Could not read content_root from config: {exc}")
+            sys.exit(1)
+
+    print(f"StoryForge home : {storyforge_home}")
+    print(f"Authors root    : {authors_root}")
+    print(f"Content root    : {content_root}")
+    print(f"Dry run         : {args.dry_run}")
+
+    migrate_author_discoveries(authors_root, dry_run=args.dry_run)
+    migrate_character_snapshots(content_root, dry_run=args.dry_run)
+
+    print("\nMigration complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/servers/storyforge-server/routers/authors.py
+++ b/servers/storyforge-server/routers/authors.py
@@ -15,18 +15,21 @@ from typing import Any
 
 import yaml
 
-from tools.author.discovery_writer import (
-    AlreadyPresent,
-    SectionMissing,
-    WriteResult,
-    write_discovery,
-)
+from tools.author.discovery_lint import lint_author_discovery
 from tools.author.rule_harvester import harvest
 from tools.claudemd.rules_editor import (
     MarkersNotFoundError,
     list_rules,
 )
-from tools.rule_writer import write_author_rule
+from tools.db.author_discoveries import (
+    VALID_TYPES,
+    discoveries_as_writing_discoveries,
+    discovery_exists,
+    get_discoveries,
+    insert_discovery,
+    update_source_genres,
+)
+from tools.db.connection import open_authors_db
 from tools.shared.paths import (
     resolve_author_path,
     resolve_project_path,
@@ -57,17 +60,23 @@ def list_authors() -> str:
 
 @mcp.tool()
 def get_author(slug: str) -> str:
-    """Get full author profile data."""
+    """Get full author profile data — writing_discoveries read from SQLite (Issue #281)."""
     state = _cache.get()
     author = state.get("authors", {}).get(slug)
     if not author:
         return json.dumps({"error": f"Author '{slug}' not found"})
 
-    # Also load vocabulary if exists
     config = _app.load_config()
     vocab_path = resolve_author_path(config, slug) / "vocabulary.md"
     if vocab_path.exists():
         author["vocabulary"] = vocab_path.read_text(encoding="utf-8")
+
+    conn = open_authors_db()
+    try:
+        rows = get_discoveries(conn, slug)
+    finally:
+        conn.close()
+    author["writing_discoveries"] = discoveries_as_writing_discoveries(rows)
 
     return json.dumps(author)
 
@@ -281,41 +290,33 @@ def write_author_discovery(
     validate: bool = True,
     example: str = "",
     genres: str = "",
+    universal: bool = False,
 ) -> str:
-    """Append a discovery to ``profile.md`` ``## Writing Discoveries`` (Issue #151).
+    """Append a discovery to the author_discoveries SQLite table (Issue #281).
 
-    Writes through ``tools.author.discovery_writer.write_discovery`` and
-    invalidates the state cache so subsequent ``get_author`` calls pick up
-    the new entry without a session restart. The harvest skill should call
-    this MCP tool rather than the underlying Python function so the cache
-    invalidation happens automatically.
+    Replaces the profile.md Markdown write from Issue #151. Idempotent via
+    UNIQUE(author_slug, discovery_type, text). Cache is invalidated so
+    subsequent get_author() calls reflect the new entry immediately.
 
     Args:
         author_slug: Author whose profile gets the entry.
         section: One of ``recurring_tics``, ``style_principles``, ``donts``.
         text: Entry body (single line), e.g. ``**"thing"** — concretize on sight.``.
-            Origin tag is appended automatically.
         book_slug: Book the discovery emerged from.
         year_month: ``YYYY-MM`` stamp; defaults to today's year-month.
-        validate: When ``True`` (default), the response also carries
-            ``warnings`` and ``extracted_patterns`` fields populated by
-            :func:`tools.author.discovery_lint.lint_author_discovery`
-            (Issue #218). Set ``False`` to skip lint and emit the legacy
-            response shape.
-        example: Optional prose or dialogue demonstration of the principle
-            (Issue #268). Only stored for ``style_principles``. Formatted as
-            a blockquote block under the entry so the chapter-writer can quote
-            it verbatim in Pre-Logic Audit 4.5.
-        genres: Optional comma-separated genre slugs (Issue #266). Only stored
-            for ``style_principles`` as `` `when: genre1, genre2` ``.
-            Chapter-writer skips the entry when the book's genres have no
-            overlap. Entries without ``genres`` are universal.
+        validate: When ``True`` (default), attaches ``warnings`` and
+            ``extracted_patterns`` from the lint check (Issue #218).
+        example: Optional illustrative prose (Issue #268).
+        genres: Optional comma-separated genre slugs (Issue #266).
+        universal: When ``True``, the discovery applies across all genres.
 
-    Returns ``{written, already_present, path, message}`` on success — with
-    ``warnings`` and ``extracted_patterns`` appended when ``validate=True``
-    — or ``{error: ...}`` on failure (unknown author, invalid section,
-    missing profile, missing Writing Discoveries section).
+    Returns ``{written, already_present, message}`` on success — with
+    ``warnings`` and ``extracted_patterns`` when ``validate=True``
+    — or ``{error: ...}`` on failure.
     """
+    if section not in VALID_TYPES:
+        return json.dumps({"error": f"Invalid section '{section}'. Must be one of: {sorted(VALID_TYPES)}"})
+
     if not year_month:
         year_month = date.today().strftime("%Y-%m")
 
@@ -331,51 +332,42 @@ def write_author_discovery(
     lint_result: dict[str, Any] | None = None
     if validate:
         try:
-            from tools.author.discovery_lint import lint_author_discovery
             lint_result = lint_author_discovery(section, text)
         except ValueError as exc:
             return json.dumps({"error": str(exc)})
 
-    genres_list = [g.strip() for g in genres.split(",") if g.strip()] if genres else []
+    source_genres = ",".join(g.strip() for g in genres.split(",") if g.strip()) if genres else ""
 
+    conn = open_authors_db()
     try:
-        result = write_discovery(
-            profile_path=profile_path,
-            section=section,
-            text=text,
-            book_slug=book_slug,
-            year_month=year_month,
-            example=example,
-            genres=genres_list or None,
-        )
-    except ValueError as exc:
-        return json.dumps({"error": str(exc)})
-    except SectionMissing as exc:
-        return json.dumps({"error": f"section_missing: {exc}", "code": "section_missing"})
-    except FileNotFoundError as exc:
-        return json.dumps({"error": str(exc)})
+        already = discovery_exists(conn, author_slug, section, text)
+        if not already:
+            insert_discovery(
+                conn,
+                author_slug=author_slug,
+                discovery_type=section,
+                text=text,
+                book_slug=book_slug,
+                source_genres=source_genres,
+                example=example,
+                date_added=year_month,
+                universal=universal,
+            )
+        written = not already
+    finally:
+        conn.close()
 
-    # Invalidate so chapter-writer's get_author() picks up the new entry.
     _cache.invalidate()
 
-    if isinstance(result, WriteResult):
-        payload: dict[str, Any] = {
-            "written": True,
-            "already_present": False,
-            "path": str(result.path),
-            "message": result.message,
-        }
-    elif isinstance(result, AlreadyPresent):
-        payload = {
-            "written": False,
-            "already_present": True,
-            "path": str(result.path),
-            "message": result.message,
-        }
-    else:
-        # Unreachable, but keep mypy happy and the JSON contract well-formed.
-        return json.dumps({"error": "unexpected write result"})
-
+    payload: dict[str, Any] = {
+        "written": written,
+        "already_present": already,
+        "message": (
+            f"Discovery added for {author_slug} [{section}]."
+            if written
+            else f"Discovery already present for {author_slug} [{section}]."
+        ),
+    }
     if lint_result is not None:
         payload["warnings"] = lint_result["warnings"]
         payload["extracted_patterns"] = lint_result["extracted_patterns"]
@@ -384,42 +376,100 @@ def write_author_discovery(
 
 @mcp.tool()
 def write_author_banned_phrase(author_slug: str, phrase: str, reason: str = "") -> str:
-    """Append a banned phrase to the author's ``vocabulary.md`` (Issue #151).
+    """Append a banned phrase to author_discoveries (discovery_type='donts') — Issue #281.
 
-    Wraps :func:`tools.rule_writer.write_author_rule` and invalidates the
-    state cache. Idempotent — already-present phrases return
-    ``{written: false}`` without erroring.
+    Replaces the vocabulary.md write from Issue #151. Idempotent via the
+    UNIQUE constraint. Cache is invalidated on write.
 
     Args:
         author_slug: Target author.
         phrase: Phrase to ban (e.g. ``thing``).
-        reason: Short rationale shown in the metadata tag.
+        reason: Short rationale stored alongside the phrase.
 
-    Returns ``{written, path?, message}`` or ``{error: ...}``.
+    Returns ``{written, message}`` or ``{error: ...}``.
     """
     config = _app.load_config()
-    # Derive storyforge_home from authors_root so the writer hits the
-    # configured tree (test fixtures use a different home than ~/.storyforge).
     try:
-        authors_root = Path(config["paths"]["authors_root"])
-        storyforge_home = authors_root.parent
-    except (KeyError, TypeError):
-        storyforge_home = None
+        profile_path = resolve_author_path(config, author_slug) / "profile.md"
+    except (KeyError, ValueError) as exc:
+        return json.dumps({"error": str(exc)})
 
-    written, message = write_author_rule(
-        phrase=phrase,
-        reason=reason or "promoted from book findings",
-        author_slug=author_slug,
-        source_context="harvest-author-rules",
-        storyforge_home=storyforge_home,
-    )
-    if not written and "not found" in message.lower():
-        return json.dumps({"error": message})
+    if not profile_path.is_file():
+        return json.dumps({"error": f"Author '{author_slug}' not found at {profile_path}"})
 
-    # Invalidate so subsequent get_author / brief loads see the new phrase.
+    text = f"**{phrase}**" + (f" — {reason}" if reason else "")
+
+    conn = open_authors_db()
+    try:
+        already = discovery_exists(conn, author_slug, "donts", text)
+        if not already:
+            insert_discovery(
+                conn,
+                author_slug=author_slug,
+                discovery_type="donts",
+                text=text,
+            )
+        written = not already
+    finally:
+        conn.close()
+
     _cache.invalidate()
 
-    return json.dumps({"written": written, "message": message})
+    return json.dumps({
+        "written": written,
+        "message": (
+            f"Banned phrase '{phrase}' added for {author_slug}."
+            if written
+            else f"Banned phrase '{phrase}' already present."
+        ),
+    })
+
+
+@mcp.tool()
+def update_discovery_metadata(
+    author_slug: str,
+    book_slug: str,
+    source_genres: str,
+) -> str:
+    """Set source_genres for all discoveries from a specific book (Issue #277 / #281).
+
+    Replaces the complex migrate-source-genres skill with a single SQL UPDATE.
+
+    Args:
+        author_slug: Target author.
+        book_slug: Book whose discoveries get the genre tag.
+        source_genres: Comma-separated genre slugs, e.g. ``"shifter-romance,omega-verse"``.
+
+    Returns ``{updated, author_slug, book_slug, source_genres}`` or ``{error: ...}``.
+    """
+    config = _app.load_config()
+    try:
+        profile_path = resolve_author_path(config, author_slug) / "profile.md"
+    except (KeyError, ValueError) as exc:
+        return json.dumps({"error": str(exc)})
+
+    if not profile_path.is_file():
+        return json.dumps({"error": f"Author '{author_slug}' not found"})
+
+    conn = open_authors_db()
+    try:
+        updated = update_source_genres(
+            conn,
+            author_slug=author_slug,
+            book_slug=book_slug,
+            source_genres=source_genres,
+        )
+    finally:
+        conn.close()
+
+    _cache.invalidate()
+
+    return json.dumps({
+        "updated": updated,
+        "author_slug": author_slug,
+        "book_slug": book_slug,
+        "source_genres": source_genres,
+    })
 
 
 @mcp.tool()

--- a/servers/storyforge-server/routers/claudemd.py
+++ b/servers/storyforge-server/routers/claudemd.py
@@ -32,6 +32,8 @@ from tools.claudemd.rules_lint import (
     lint_book_rules as _lint_book_rules_impl,
     lint_rule_text as _lint_rule_text_impl,
 )
+from tools.db.character_snapshots import upsert_snapshot
+from tools.db.connection import get_db_slug_for_book, get_book_num, open_canon_db
 from tools.shared.paths import (
     resolve_character_path,
     resolve_people_dir,
@@ -122,16 +124,14 @@ def update_character_snapshot(
     snapshot_json: str,
     book_category: str = "fiction",
 ) -> str:
-    """Persist end-of-chapter POV character snapshot to the character file.
+    """Persist end-of-chapter POV character snapshot to SQLite (Issue #281).
 
-    Writes the structured list fields that the chapter-writing brief extracts
-    (``pov_character_inventory`` from Issue #157; ``pov_character_state`` from
-    Issue #160) back to the character frontmatter so the *next* chapter's brief
-    picks them up from the highest-priority ``frontmatter`` source rather than
-    falling through to timeline regex or draft heuristics.
+    Writes inventory, clothing, injuries, altered_states, environmental_limiters,
+    and as_of_chapter to the ``character_snapshots`` table in the per-series DB
+    (``~/.storyforge/db/{series-slug}.db``). The character file is NOT modified.
 
-    Only the five snapshot fields (plus ``as_of_chapter``) are touched — all
-    other frontmatter fields are left unchanged.
+    The character file must still exist — its presence is used as a validity gate
+    to confirm the character is real (not a stale slug from a deleted file).
 
     Args:
         book_slug: Book project slug.
@@ -147,12 +147,7 @@ def update_character_snapshot(
         ``{success, character, book, updated_fields}`` on success, or
         ``{error}`` on validation / IO failure.
     """
-    import yaml
-
-    from tools.state.parsers import parse_frontmatter
-
     config = _app.load_config()
-    content_root = Path(config["paths"]["content_root"]).resolve()
 
     try:
         snapshot: dict[str, Any] = json.loads(snapshot_json)
@@ -193,21 +188,42 @@ def update_character_snapshot(
     else:
         char_file = resolve_character_path(config, book_slug, character_slug)
 
-    try:
-        resolved = char_file.resolve()
-    except (OSError, RuntimeError) as exc:
-        return json.dumps({"error": f"Invalid path: {exc}"})
-    if not resolved.is_relative_to(content_root):
-        return json.dumps({"error": "Resolved character path escapes content_root"})
-
+    # Validity gate: confirm the character slug refers to a real file even though
+    # we no longer write to it. Prevents snapshotting stale/deleted characters.
     if not char_file.exists():
         return json.dumps({"error": f"Character file not found: {char_file}"})
 
-    text = char_file.read_text(encoding="utf-8")
-    meta, body = parse_frontmatter(text)
-    meta.update(snapshot)
-    new_text = "---\n" + yaml.dump(meta, default_flow_style=False, allow_unicode=True) + "---\n" + body
-    char_file.write_text(new_text, encoding="utf-8")
+    # Parse chapter number from as_of_chapter (e.g. "26-the-basement" → 26).
+    chapter_num = 0
+    if "as_of_chapter" in snapshot:
+        raw_ch = snapshot["as_of_chapter"]
+        try:
+            chapter_num = int(str(raw_ch).split("-")[0])
+        except (ValueError, IndexError):
+            chapter_num = 0
+
+    db_slug = get_db_slug_for_book(project_dir)
+    book_num = get_book_num(project_dir)
+
+    conn = open_canon_db(db_slug)
+    try:
+        upsert_snapshot(
+            conn,
+            char_slug=character_slug,
+            book_num=book_num,
+            chapter_num=chapter_num,
+            injuries=snapshot.get("current_injuries"),
+            clothing=snapshot.get("current_clothing"),
+            inventory=snapshot.get("current_inventory"),
+            altered_states=snapshot.get("altered_states"),
+            environmental_limiters=(
+                ", ".join(snapshot["environmental_limiters"])
+                if isinstance(snapshot.get("environmental_limiters"), list)
+                else snapshot.get("environmental_limiters") or None
+            ),
+        )
+    finally:
+        conn.close()
 
     _app._cache.invalidate()
     return json.dumps(

--- a/tests/db/test_author_discoveries.py
+++ b/tests/db/test_author_discoveries.py
@@ -1,0 +1,201 @@
+"""Tests for author_discoveries CRUD — Issue #281."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.db.author_discoveries import (
+    VALID_TYPES,
+    discoveries_as_writing_discoveries,
+    discovery_exists,
+    get_discoveries,
+    insert_discovery,
+    update_source_genres,
+)
+from tools.db.connection import ensure_authors_schema, open_db
+
+
+@pytest.fixture
+def conn(tmp_path: Path):
+    db = open_db(tmp_path / "authors.db")
+    ensure_authors_schema(db)
+    yield db
+    db.close()
+
+
+class TestValidTypes:
+    def test_valid_types_contains_expected(self):
+        assert "recurring_tics" in VALID_TYPES
+        assert "style_principles" in VALID_TYPES
+        assert "donts" in VALID_TYPES
+
+
+class TestInsertDiscovery:
+    def test_inserts_basic_discovery(self, conn):
+        inserted = insert_discovery(
+            conn,
+            author_slug="ethan-cole",
+            discovery_type="recurring_tics",
+            text='**"thing"** — concretize on sight.',
+            book_slug="firelight",
+            date_added="2026-05",
+        )
+        assert inserted is True
+        rows = conn.execute("SELECT * FROM author_discoveries").fetchall()
+        assert len(rows) == 1
+        assert rows[0]["author_slug"] == "ethan-cole"
+        assert rows[0]["discovery_type"] == "recurring_tics"
+
+    def test_unique_constraint_returns_false_on_duplicate(self, conn):
+        insert_discovery(
+            conn, author_slug="ethan-cole", discovery_type="recurring_tics",
+            text="**Bold** — note.", book_slug="firelight",
+        )
+        again = insert_discovery(
+            conn, author_slug="ethan-cole", discovery_type="recurring_tics",
+            text="**Bold** — note.", book_slug="firelight",
+        )
+        assert again is False
+        count = conn.execute("SELECT COUNT(*) FROM author_discoveries").fetchone()[0]
+        assert count == 1
+
+    def test_different_types_same_text_allowed(self, conn):
+        insert_discovery(conn, author_slug="a", discovery_type="donts", text="x")
+        insert_discovery(conn, author_slug="a", discovery_type="recurring_tics", text="x")
+        count = conn.execute("SELECT COUNT(*) FROM author_discoveries").fetchone()[0]
+        assert count == 2
+
+    def test_stores_source_genres_and_universal(self, conn):
+        insert_discovery(
+            conn,
+            author_slug="ethan-cole",
+            discovery_type="style_principles",
+            text="Avoid purple prose.",
+            source_genres="shifter-romance,omega-verse",
+            universal=True,
+        )
+        row = conn.execute("SELECT source_genres, universal FROM author_discoveries").fetchone()
+        assert row["source_genres"] == "shifter-romance,omega-verse"
+        assert row["universal"] == 1
+
+    def test_stores_example(self, conn):
+        insert_discovery(
+            conn, author_slug="a", discovery_type="style_principles",
+            text="Use concrete detail.", example="He smelled burnt oil, not fear.",
+        )
+        row = conn.execute("SELECT example FROM author_discoveries").fetchone()
+        assert row["example"] == "He smelled burnt oil, not fear."
+
+
+class TestGetDiscoveries:
+    def test_returns_all_for_author(self, conn):
+        insert_discovery(conn, author_slug="a", discovery_type="recurring_tics", text="tic1")
+        insert_discovery(conn, author_slug="a", discovery_type="donts", text="dont1")
+        insert_discovery(conn, author_slug="b", discovery_type="recurring_tics", text="other")
+        rows = get_discoveries(conn, "a")
+        assert len(rows) == 2
+        slugs = {r["author_slug"] for r in rows}
+        assert slugs == {"a"}
+
+    def test_filters_by_type(self, conn):
+        insert_discovery(conn, author_slug="a", discovery_type="recurring_tics", text="tic1")
+        insert_discovery(conn, author_slug="a", discovery_type="donts", text="dont1")
+        rows = get_discoveries(conn, "a", "recurring_tics")
+        assert len(rows) == 1
+        assert rows[0]["discovery_type"] == "recurring_tics"
+
+    def test_returns_empty_for_unknown_author(self, conn):
+        rows = get_discoveries(conn, "nobody")
+        assert rows == []
+
+    def test_ordered_by_id_within_type(self, conn):
+        insert_discovery(conn, author_slug="a", discovery_type="donts", text="first")
+        insert_discovery(conn, author_slug="a", discovery_type="donts", text="second")
+        rows = get_discoveries(conn, "a", "donts")
+        assert rows[0]["text"] == "first"
+        assert rows[1]["text"] == "second"
+
+
+class TestDiscoveryExists:
+    def test_returns_true_if_exists(self, conn):
+        insert_discovery(conn, author_slug="a", discovery_type="donts", text="x")
+        assert discovery_exists(conn, "a", "donts", "x") is True
+
+    def test_returns_false_if_not_exists(self, conn):
+        assert discovery_exists(conn, "a", "donts", "x") is False
+
+    def test_case_sensitive_match(self, conn):
+        insert_discovery(conn, author_slug="a", discovery_type="donts", text="Thing")
+        assert discovery_exists(conn, "a", "donts", "thing") is False
+
+
+class TestUpdateSourceGenres:
+    def test_updates_all_discoveries_for_book(self, conn):
+        insert_discovery(conn, author_slug="a", discovery_type="donts", text="x", book_slug="book1")
+        insert_discovery(conn, author_slug="a", discovery_type="donts", text="y", book_slug="book1")
+        insert_discovery(conn, author_slug="a", discovery_type="donts", text="z", book_slug="book2")
+
+        count = update_source_genres(conn, author_slug="a", book_slug="book1", source_genres="shifter-romance")
+        assert count == 2
+
+        rows = conn.execute(
+            "SELECT source_genres FROM author_discoveries WHERE book_slug='book1'"
+        ).fetchall()
+        for r in rows:
+            assert r["source_genres"] == "shifter-romance"
+
+    def test_returns_zero_for_unknown_book(self, conn):
+        count = update_source_genres(conn, author_slug="a", book_slug="missing", source_genres="x")
+        assert count == 0
+
+
+class TestDiscoveriesAsWritingDiscoveries:
+    def test_groups_by_type(self, conn):
+        insert_discovery(conn, author_slug="a", discovery_type="recurring_tics", text="tic1", book_slug="b1", date_added="2026-01")
+        insert_discovery(conn, author_slug="a", discovery_type="style_principles", text="principle1")
+        insert_discovery(conn, author_slug="a", discovery_type="donts", text="dont1")
+        rows = get_discoveries(conn, "a")
+        result = discoveries_as_writing_discoveries(rows)
+        assert len(result["recurring_tics"]) == 1
+        assert len(result["style_principles"]) == 1
+        assert len(result["donts"]) == 1
+
+    def test_origins_populated_from_book_slug_and_date(self, conn):
+        insert_discovery(conn, author_slug="a", discovery_type="recurring_tics",
+                         text="tic1", book_slug="firelight", date_added="2026-05")
+        rows = get_discoveries(conn, "a")
+        result = discoveries_as_writing_discoveries(rows)
+        origins = result["recurring_tics"][0]["origins"]
+        assert origins == [{"book": "firelight", "date": "2026-05"}]
+
+    def test_no_origins_when_no_book_slug(self, conn):
+        insert_discovery(conn, author_slug="a", discovery_type="donts", text="x")
+        rows = get_discoveries(conn, "a")
+        result = discoveries_as_writing_discoveries(rows)
+        assert result["donts"][0]["origins"] == []
+
+    def test_genres_key_present_when_source_genres_set(self, conn):
+        insert_discovery(conn, author_slug="a", discovery_type="style_principles",
+                         text="p", source_genres="romance,thriller")
+        rows = get_discoveries(conn, "a")
+        result = discoveries_as_writing_discoveries(rows)
+        assert result["style_principles"][0]["genres"] == ["romance", "thriller"]
+
+    def test_example_key_present_when_set(self, conn):
+        insert_discovery(conn, author_slug="a", discovery_type="style_principles",
+                         text="p", example="He burned it.")
+        rows = get_discoveries(conn, "a")
+        result = discoveries_as_writing_discoveries(rows)
+        assert result["style_principles"][0]["example"] == "He burned it."
+
+    def test_unknown_type_rows_are_skipped(self, conn):
+        conn.execute(
+            "INSERT INTO author_discoveries (author_slug, discovery_type, text) VALUES (?, ?, ?)",
+            ("a", "unknown_type", "x"),
+        )
+        conn.commit()
+        rows = get_discoveries(conn, "a")
+        result = discoveries_as_writing_discoveries(rows)
+        assert all(len(v) == 0 for v in result.values())

--- a/tests/db/test_character_snapshots.py
+++ b/tests/db/test_character_snapshots.py
@@ -1,0 +1,154 @@
+"""Tests for character_snapshots CRUD — Issue #281."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.db.character_snapshots import (
+    get_all_latest_snapshots,
+    get_latest_snapshot,
+    get_latest_snapshot_for_book,
+    upsert_snapshot,
+)
+from tools.db.connection import ensure_schema, open_db
+
+
+@pytest.fixture
+def conn(tmp_path: Path):
+    db = open_db(tmp_path / "series.db")
+    ensure_schema(db)
+    yield db
+    db.close()
+
+
+class TestUpsertSnapshot:
+    def test_inserts_basic_snapshot(self, conn):
+        upsert_snapshot(conn, char_slug="kael", book_num=1, chapter_num=5,
+                        inventory=["sword", "shield"])
+        row = conn.execute("SELECT inventory FROM character_snapshots WHERE char_slug='kael'").fetchone()
+        assert row is not None
+        import json
+        assert json.loads(row["inventory"]) == ["sword", "shield"]
+
+    def test_replaces_snapshot_for_same_key(self, conn):
+        upsert_snapshot(conn, char_slug="kael", book_num=1, chapter_num=5,
+                        inventory=["old-item"])
+        upsert_snapshot(conn, char_slug="kael", book_num=1, chapter_num=5,
+                        inventory=["new-item"])
+        count = conn.execute("SELECT COUNT(*) FROM character_snapshots").fetchone()[0]
+        assert count == 1
+        import json
+        row = conn.execute("SELECT inventory FROM character_snapshots").fetchone()
+        assert json.loads(row["inventory"]) == ["new-item"]
+
+    def test_stores_all_fields(self, conn):
+        upsert_snapshot(
+            conn,
+            char_slug="kael",
+            book_num=1,
+            chapter_num=10,
+            injuries=["bruised ribs"],
+            clothing=["tactical jacket"],
+            inventory=["compass"],
+            altered_states=["sleep-deprived"],
+            environmental_limiters="no phone signal",
+        )
+        import json
+        row = conn.execute("SELECT * FROM character_snapshots").fetchone()
+        assert json.loads(row["injuries"]) == ["bruised ribs"]
+        assert json.loads(row["clothing"]) == ["tactical jacket"]
+        assert json.loads(row["inventory"]) == ["compass"]
+        assert json.loads(row["altered_states"]) == ["sleep-deprived"]
+        assert row["environmental_limiters"] == "no phone signal"
+
+    def test_empty_lists_stored_correctly(self, conn):
+        upsert_snapshot(conn, char_slug="kael", book_num=1, chapter_num=1,
+                        inventory=[], injuries=[])
+        import json
+        row = conn.execute("SELECT inventory, injuries FROM character_snapshots").fetchone()
+        assert json.loads(row["inventory"]) == []
+        assert json.loads(row["injuries"]) == []
+
+    def test_partial_update_merges_with_existing(self, conn):
+        upsert_snapshot(conn, char_slug="kael", book_num=1, chapter_num=5,
+                        inventory=["compass"], clothing=["jacket"])
+        upsert_snapshot(conn, char_slug="kael", book_num=1, chapter_num=6,
+                        injuries=["bruised ribs"])
+        import json
+        row = conn.execute(
+            "SELECT * FROM character_snapshots WHERE chapter_num=6"
+        ).fetchone()
+        assert json.loads(row["inventory"]) == ["compass"]
+        assert json.loads(row["clothing"]) == ["jacket"]
+        assert json.loads(row["injuries"]) == ["bruised ribs"]
+
+    def test_multiple_characters_stored_independently(self, conn):
+        upsert_snapshot(conn, char_slug="kael", book_num=1, chapter_num=3, inventory=["sword"])
+        upsert_snapshot(conn, char_slug="lyra", book_num=1, chapter_num=3, inventory=["bow"])
+        count = conn.execute("SELECT COUNT(*) FROM character_snapshots").fetchone()[0]
+        assert count == 2
+
+
+class TestGetLatestSnapshot:
+    def test_returns_none_for_unknown_character(self, conn):
+        assert get_latest_snapshot(conn, "nobody") is None
+
+    def test_returns_latest_chapter(self, conn):
+        upsert_snapshot(conn, char_slug="kael", book_num=1, chapter_num=5, inventory=["old"])
+        upsert_snapshot(conn, char_slug="kael", book_num=1, chapter_num=10, inventory=["new"])
+        snap = get_latest_snapshot(conn, "kael")
+        assert snap is not None
+        assert snap["inventory"] == ["new"]
+
+    def test_latest_across_books(self, conn):
+        upsert_snapshot(conn, char_slug="kael", book_num=1, chapter_num=30, inventory=["b1-item"])
+        upsert_snapshot(conn, char_slug="kael", book_num=2, chapter_num=1, inventory=["b2-item"])
+        snap = get_latest_snapshot(conn, "kael")
+        assert snap["inventory"] == ["b2-item"]
+        assert snap["book_num"] == 2
+
+    def test_list_fields_decoded_as_python_lists(self, conn):
+        upsert_snapshot(conn, char_slug="kael", book_num=1, chapter_num=1,
+                        injuries=["cut hand"], clothing=["coat"])
+        snap = get_latest_snapshot(conn, "kael")
+        assert isinstance(snap["injuries"], list)
+        assert isinstance(snap["clothing"], list)
+        assert snap["injuries"] == ["cut hand"]
+
+
+class TestGetLatestSnapshotForBook:
+    def test_returns_latest_within_book(self, conn):
+        upsert_snapshot(conn, char_slug="kael", book_num=1, chapter_num=5, inventory=["ch5"])
+        upsert_snapshot(conn, char_slug="kael", book_num=1, chapter_num=10, inventory=["ch10"])
+        upsert_snapshot(conn, char_slug="kael", book_num=2, chapter_num=1, inventory=["b2"])
+        snap = get_latest_snapshot_for_book(conn, "kael", book_num=1)
+        assert snap["inventory"] == ["ch10"]
+        assert snap["chapter_num"] == 10
+
+    def test_returns_none_if_no_snapshots_for_book(self, conn):
+        upsert_snapshot(conn, char_slug="kael", book_num=1, chapter_num=1, inventory=["x"])
+        assert get_latest_snapshot_for_book(conn, "kael", book_num=2) is None
+
+
+class TestGetAllLatestSnapshots:
+    def test_returns_one_per_character(self, conn):
+        upsert_snapshot(conn, char_slug="kael", book_num=1, chapter_num=5, inventory=["sword"])
+        upsert_snapshot(conn, char_slug="kael", book_num=1, chapter_num=10, inventory=["dagger"])
+        upsert_snapshot(conn, char_slug="lyra", book_num=1, chapter_num=3, inventory=["bow"])
+
+        snaps = get_all_latest_snapshots(conn)
+        assert len(snaps) == 2
+        by_slug = {s["char_slug"]: s for s in snaps}
+        assert by_slug["kael"]["inventory"] == ["dagger"]
+        assert by_slug["lyra"]["inventory"] == ["bow"]
+
+    def test_returns_empty_list_when_no_snapshots(self, conn):
+        assert get_all_latest_snapshots(conn) == []
+
+    def test_picks_highest_book_and_chapter(self, conn):
+        upsert_snapshot(conn, char_slug="kael", book_num=1, chapter_num=30, inventory=["b1"])
+        upsert_snapshot(conn, char_slug="kael", book_num=2, chapter_num=1, inventory=["b2"])
+        snaps = get_all_latest_snapshots(conn)
+        assert snaps[0]["inventory"] == ["b2"]

--- a/tests/server/test_author_write_tools.py
+++ b/tests/server/test_author_write_tools.py
@@ -1,13 +1,8 @@
-"""Tests for ``write_author_discovery`` + ``write_author_banned_phrase`` MCP
-tools (Issue #151 follow-up).
+"""Tests for write_author_discovery + write_author_banned_phrase MCP tools — Issue #281.
 
-The harvest skill needs MCP tools (not raw Python calls) to write into the
-author profile so that:
-
-- The state cache gets invalidated after each write.
-- The skill walks ONE call surface for both promotion paths.
-- The chapter-writer/reviewer ``get_author()`` consumers see fresh data
-  immediately, without a Claude-Code session restart.
+Phase 3 rewrite: discoveries and banned phrases now write to author_discoveries
+in SQLite (authors.db) instead of profile.md / vocabulary.md. profile.md still
+exists for author-existence validation; vocabulary.md is no longer written to.
 """
 
 from __future__ import annotations
@@ -24,10 +19,17 @@ from routers.authors import (
 )
 
 
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
 @pytest.fixture
 def author_setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict:
-    """Stand up a config that points at a temp authors_root and a fresh
-    profile + vocabulary for ``ethan-cole``."""
+    """Stand up a config pointing at tmp dirs, with a minimal ethan-cole profile.
+
+    Also patches tools.db.connection.DB_DIR so authors.db lands in tmp_path.
+    """
     content_root = tmp_path / "books"
     content_root.mkdir()
     authors_root = tmp_path / "authors"
@@ -35,17 +37,9 @@ def author_setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict:
     author_dir = authors_root / "ethan-cole"
     author_dir.mkdir()
 
+    # profile.md still required for author-existence check
     (author_dir / "profile.md").write_text(
-        '---\nname: "Ethan Cole"\nslug: "ethan-cole"\n---\n\n'
-        "# Ethan Cole\n\n"
-        "## Writing Discoveries\n\n"
-        "### Recurring Tics\n\n_Frei._\n\n"
-        "### Style Principles\n\n_Frei._\n\n"
-        "### Don'ts (beyond banned phrases)\n\n_Frei._\n",
-        encoding="utf-8",
-    )
-    (author_dir / "vocabulary.md").write_text(
-        "# Ethan Cole — Vocabulary\n\n## Banned Words\n\n### Absolutely Forbidden\n\n- delve\n",
+        '---\nname: "Ethan Cole"\nslug: "ethan-cole"\n---\n\n# Ethan Cole\n',
         encoding="utf-8",
     )
 
@@ -56,7 +50,23 @@ def author_setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict:
         },
     }
     monkeypatch.setattr(_app, "load_config", lambda: config)
-    return {"config": config, "author_dir": author_dir}
+    _app._cache.invalidate()
+
+    import tools.db.connection as conn_mod
+    db_dir = tmp_path / "db"
+    db_dir.mkdir()
+    monkeypatch.setattr(conn_mod, "DB_DIR", db_dir)
+
+    return {"config": config, "author_dir": author_dir, "db_dir": db_dir}
+
+
+def _open_authors_db(author_setup: dict):
+    """Open the test authors DB directly for assertion."""
+    from tools.db.connection import ensure_authors_schema, open_db
+    db_path = author_setup["db_dir"] / "authors.db"
+    conn = open_db(db_path)
+    ensure_authors_schema(conn)
+    return conn
 
 
 # ---------------------------------------------------------------------------
@@ -65,7 +75,7 @@ def author_setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict:
 
 
 class TestWriteAuthorDiscovery:
-    def test_appends_recurring_tic_with_origin(self, author_setup):
+    def test_inserts_recurring_tic_into_db(self, author_setup):
         result = json.loads(
             write_author_discovery(
                 author_slug="ethan-cole",
@@ -76,9 +86,17 @@ class TestWriteAuthorDiscovery:
             )
         )
         assert result["written"] is True
-        content = (author_setup["author_dir"] / "profile.md").read_text(encoding="utf-8")
-        assert '**"thing"**' in content
-        assert "_(emerged from firelight, 2026-05)_" in content
+
+        conn = _open_authors_db(author_setup)
+        rows = conn.execute(
+            "SELECT * FROM author_discoveries WHERE author_slug='ethan-cole'"
+        ).fetchall()
+        conn.close()
+        assert len(rows) == 1
+        assert rows[0]["discovery_type"] == "recurring_tics"
+        assert '**"thing"**' in rows[0]["text"]
+        assert rows[0]["book_slug"] == "firelight"
+        assert rows[0]["date_added"] == "2026-05"
 
     def test_idempotent_returns_already_present(self, author_setup):
         write_author_discovery(
@@ -99,6 +117,11 @@ class TestWriteAuthorDiscovery:
         )
         assert result["written"] is False
         assert result.get("already_present") is True
+
+        conn = _open_authors_db(author_setup)
+        count = conn.execute("SELECT COUNT(*) FROM author_discoveries").fetchone()[0]
+        conn.close()
+        assert count == 1
 
     def test_invalid_section_returns_error(self, author_setup):
         result = json.loads(
@@ -124,21 +147,59 @@ class TestWriteAuthorDiscovery:
         )
         assert "error" in result
 
-    def test_year_month_defaults_to_today_when_omitted(self, author_setup):
-        result = json.loads(
-            write_author_discovery(
-                author_slug="ethan-cole",
-                section="recurring_tics",
-                text='**"foo"** — concretize.',
-                book_slug="firelight",
-            )
+    def test_year_month_stored_as_date_added(self, author_setup):
+        write_author_discovery(
+            author_slug="ethan-cole",
+            section="recurring_tics",
+            text='**"foo"** — concretize.',
+            book_slug="firelight",
+            year_month="2026-03",
         )
-        assert result["written"] is True
-        # Some year-month tag must be in the file now.
-        content = (author_setup["author_dir"] / "profile.md").read_text(encoding="utf-8")
-        import re
+        conn = _open_authors_db(author_setup)
+        row = conn.execute("SELECT date_added FROM author_discoveries").fetchone()
+        conn.close()
+        assert row["date_added"] == "2026-03"
 
-        assert re.search(r"_\(emerged from firelight, \d{4}-\d{2}\)_", content)
+    def test_year_month_defaults_to_current_when_omitted(self, author_setup):
+        import re
+        write_author_discovery(
+            author_slug="ethan-cole",
+            section="recurring_tics",
+            text='**"bar"** — concrete.',
+            book_slug="firelight",
+        )
+        conn = _open_authors_db(author_setup)
+        row = conn.execute("SELECT date_added FROM author_discoveries").fetchone()
+        conn.close()
+        assert re.match(r"\d{4}-\d{2}", row["date_added"])
+
+    def test_genres_stored_as_source_genres(self, author_setup):
+        write_author_discovery(
+            author_slug="ethan-cole",
+            section="style_principles",
+            text="Use concrete detail.",
+            book_slug="firelight",
+            year_month="2026-05",
+            genres="shifter-romance,omega-verse",
+        )
+        conn = _open_authors_db(author_setup)
+        row = conn.execute("SELECT source_genres FROM author_discoveries").fetchone()
+        conn.close()
+        assert "shifter-romance" in row["source_genres"]
+
+    def test_example_stored_in_db(self, author_setup):
+        write_author_discovery(
+            author_slug="ethan-cole",
+            section="style_principles",
+            text="Ground emotion in sensation.",
+            book_slug="firelight",
+            year_month="2026-05",
+            example="His knuckles were white on the rail.",
+        )
+        conn = _open_authors_db(author_setup)
+        row = conn.execute("SELECT example FROM author_discoveries").fetchone()
+        conn.close()
+        assert "knuckles" in row["example"]
 
 
 # ---------------------------------------------------------------------------
@@ -147,15 +208,6 @@ class TestWriteAuthorDiscovery:
 
 
 class TestWriteAuthorDiscoveryValidate:
-    """The MCP response must carry ``warnings`` + ``extracted_patterns``
-    fields when ``validate=True`` (the default), and must omit them when
-    ``validate=False``.
-
-    The lint runs BEFORE the write — but a lint warning never blocks the
-    write; the response surfaces both so the skill can show the warnings
-    to the user and the write still goes through.
-    """
-
     def test_validate_true_attaches_warnings_and_patterns(self, author_setup):
         result = json.loads(
             write_author_discovery(
@@ -173,7 +225,6 @@ class TestWriteAuthorDiscoveryValidate:
         assert "The room received it." in labels
 
     def test_validate_true_surfaces_lint_warning(self, author_setup):
-        """Don't with ban cue + no scannable pattern → scanner_extracts_nothing."""
         result = json.loads(
             write_author_discovery(
                 author_slug="ethan-cole",
@@ -183,7 +234,6 @@ class TestWriteAuthorDiscoveryValidate:
                 year_month="2026-05",
             )
         )
-        # Write still succeeded — lint is observability, not a block.
         assert result["written"] is True
         codes = [w["code"] for w in result["warnings"]]
         assert "scanner_extracts_nothing" in codes
@@ -204,8 +254,6 @@ class TestWriteAuthorDiscoveryValidate:
         assert "extracted_patterns" not in result
 
     def test_validate_true_works_for_already_present(self, author_setup):
-        """Idempotent already-present writes must still attach lint data so
-        the skill can surface warnings on retry."""
         text = '**Never use rooms** — *The room received it.*'
         write_author_discovery(
             author_slug="ethan-cole",
@@ -244,8 +292,6 @@ class TestWriteAuthorDiscoveryValidate:
         assert "bold_title_unscannable" in codes
 
     def test_validate_true_style_principles_no_scanner_warnings(self, author_setup):
-        """Style Principles are not machine-scanned — lint must NOT emit
-        scanner_extracts_nothing even when there's a ban cue."""
         result = json.loads(
             write_author_discovery(
                 author_slug="ethan-cole",
@@ -261,12 +307,12 @@ class TestWriteAuthorDiscoveryValidate:
 
 
 # ---------------------------------------------------------------------------
-# write_author_banned_phrase
+# write_author_banned_phrase — now goes to author_discoveries (type='donts')
 # ---------------------------------------------------------------------------
 
 
 class TestWriteAuthorBannedPhrase:
-    def test_appends_phrase_to_vocabulary(self, author_setup):
+    def test_inserts_banned_phrase_into_db(self, author_setup):
         result = json.loads(
             write_author_banned_phrase(
                 author_slug="ethan-cole",
@@ -275,17 +321,19 @@ class TestWriteAuthorBannedPhrase:
             )
         )
         assert result["written"] is True
-        content = (author_setup["author_dir"] / "vocabulary.md").read_text(encoding="utf-8")
-        assert "thing" in content
+
+        conn = _open_authors_db(author_setup)
+        rows = conn.execute(
+            "SELECT * FROM author_discoveries WHERE discovery_type='donts'"
+        ).fetchall()
+        conn.close()
+        assert len(rows) == 1
+        assert "thing" in rows[0]["text"]
 
     def test_idempotent_already_present(self, author_setup):
-        # `delve` is in the fixture vocabulary already.
+        write_author_banned_phrase(author_slug="ethan-cole", phrase="delve", reason="AI tell")
         result = json.loads(
-            write_author_banned_phrase(
-                author_slug="ethan-cole",
-                phrase="delve",
-                reason="generic AI tell",
-            )
+            write_author_banned_phrase(author_slug="ethan-cole", phrase="delve", reason="AI tell")
         )
         assert result["written"] is False
 
@@ -301,8 +349,7 @@ class TestWriteAuthorBannedPhrase:
 
 
 # ---------------------------------------------------------------------------
-# Cache invalidation — both tools must invalidate so subsequent get_author()
-# reflects the write.
+# Cache invalidation — both tools must invalidate
 # ---------------------------------------------------------------------------
 
 

--- a/tests/server/test_update_character_snapshot.py
+++ b/tests/server/test_update_character_snapshot.py
@@ -1,17 +1,17 @@
-"""Tests for the ``update_character_snapshot`` MCP tool (Issues #157 / #160).
+"""Tests for update_character_snapshot MCP tool — Issues #157 / #160 / #281.
 
-The tool persists end-of-chapter POV character state back to the character
-file's frontmatter so the next brief picks it up from the highest-priority
-``frontmatter`` source rather than falling through to timeline heuristics.
+Phase 3 rewrite: snapshots now write to character_snapshots in SQLite
+(per-series DB) instead of YAML frontmatter in characters/*.md.
+Character files still exist for validation; they are not modified.
 """
 
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 
 import pytest
-import yaml
 
 import routers._app as _app
 from routers.claudemd import update_character_snapshot
@@ -40,15 +40,21 @@ def mock_config(content_root: Path, monkeypatch: pytest.MonkeyPatch) -> dict:
     }
     monkeypatch.setattr(_app, "load_config", lambda: cfg)
     _app._cache.invalidate()
+
+    import tools.db.connection as conn_mod
+    db_dir = content_root.parent / "db"
+    db_dir.mkdir(exist_ok=True)
+    monkeypatch.setattr(conn_mod, "DB_DIR", db_dir)
+
     return cfg
 
 
-def _make_char(content_root: Path, book: str, slug: str, extra: str = "") -> Path:
+def _make_char(content_root: Path, book: str, slug: str) -> Path:
     char_dir = content_root / "projects" / book / "characters"
     char_dir.mkdir(parents=True, exist_ok=True)
     char_file = char_dir / f"{slug}.md"
     char_file.write_text(
-        f"---\nname: {slug}\nrole: protagonist\n---\n\nProfile body.\n{extra}",
+        f"---\nname: {slug}\nrole: protagonist\n---\n\nProfile body.\n",
         encoding="utf-8",
     )
     return char_file
@@ -65,14 +71,40 @@ def _make_person(content_root: Path, book: str, slug: str) -> Path:
     return person_file
 
 
+def _get_snapshot(content_root: Path, book_slug: str, char_slug: str) -> dict | None:
+    """Read latest snapshot for char from the book's DB."""
+    db_dir = content_root.parent / "db"
+    db_path = db_dir / f"{book_slug}.db"
+    if not db_path.exists():
+        return None
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT * FROM character_snapshots WHERE char_slug=? ORDER BY book_num DESC, chapter_num DESC LIMIT 1",
+        (char_slug,),
+    ).fetchone()
+    conn.close()
+    if not row:
+        return None
+    result = dict(row)
+    for field in ("injuries", "clothing", "inventory", "altered_states"):
+        raw = result.get(field)
+        if isinstance(raw, str):
+            try:
+                result[field] = json.loads(raw)
+            except json.JSONDecodeError:
+                result[field] = []
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Happy path — fiction
 # ---------------------------------------------------------------------------
 
 
 class TestUpdateCharacterSnapshotFiction:
-    def test_writes_inventory_list(self, mock_config, content_root: Path):
-        char_file = _make_char(content_root, "my-book", "theo")
+    def test_writes_inventory_to_db(self, mock_config, content_root: Path):
+        _make_char(content_root, "my-book", "theo")
 
         result = json.loads(
             update_character_snapshot(
@@ -84,11 +116,12 @@ class TestUpdateCharacterSnapshotFiction:
 
         assert result["success"] is True
         assert "current_inventory" in result["updated_fields"]
-        meta = yaml.safe_load(char_file.read_text(encoding="utf-8").split("---")[1])
-        assert meta["current_inventory"] == ["compass", "silver knife", "no-signal phone"]
+        snap = _get_snapshot(content_root, "my-book", "theo")
+        assert snap is not None
+        assert snap["inventory"] == ["compass", "silver knife", "no-signal phone"]
 
     def test_writes_all_snapshot_fields(self, mock_config, content_root: Path):
-        char_file = _make_char(content_root, "my-book", "theo")
+        _make_char(content_root, "my-book", "theo")
         snapshot = {
             "current_inventory": ["compass", "knife"],
             "current_clothing": ["tactical boots", "mission jacket"],
@@ -101,57 +134,57 @@ class TestUpdateCharacterSnapshotFiction:
         result = json.loads(update_character_snapshot("my-book", "theo", json.dumps(snapshot)))
 
         assert result["success"] is True
-        meta = yaml.safe_load(char_file.read_text(encoding="utf-8").split("---")[1])
-        assert meta["current_inventory"] == ["compass", "knife"]
-        assert meta["current_clothing"] == ["tactical boots", "mission jacket"]
-        assert meta["current_injuries"] == ["bandaged left hand"]
-        assert meta["altered_states"] == ["running on 3 hours sleep"]
-        assert meta["environmental_limiters"] == []
-        assert meta["as_of_chapter"] == "26-the-basement"
+        snap = _get_snapshot(content_root, "my-book", "theo")
+        assert snap is not None
+        assert snap["inventory"] == ["compass", "knife"]
+        assert snap["clothing"] == ["tactical boots", "mission jacket"]
+        assert snap["injuries"] == ["bandaged left hand"]
+        assert snap["altered_states"] == ["running on 3 hours sleep"]
+        assert snap["chapter_num"] == 26
 
-    def test_preserves_existing_non_snapshot_fields(self, mock_config, content_root: Path):
+    def test_character_file_not_modified(self, mock_config, content_root: Path):
         char_file = _make_char(content_root, "my-book", "theo")
+        original = char_file.read_text(encoding="utf-8")
 
         update_character_snapshot(
             "my-book", "theo", json.dumps({"current_inventory": ["compass"]})
         )
 
-        meta = yaml.safe_load(char_file.read_text(encoding="utf-8").split("---")[1])
-        assert meta["name"] == "theo"
-        assert meta["role"] == "protagonist"
+        assert char_file.read_text(encoding="utf-8") == original
 
-    def test_overwrites_stale_inventory(self, mock_config, content_root: Path):
-        char_dir = content_root / "projects" / "my-book" / "characters"
-        char_dir.mkdir(parents=True, exist_ok=True)
-        char_file = char_dir / "theo.md"
-        char_file.write_text(
-            "---\ncurrent_inventory:\n- old item\n---\nBody.\n", encoding="utf-8"
-        )
-
+    def test_overwrites_previous_snapshot_same_chapter(self, mock_config, content_root: Path):
+        _make_char(content_root, "my-book", "theo")
         update_character_snapshot(
-            "my-book", "theo", json.dumps({"current_inventory": ["new item"]})
+            "my-book", "theo",
+            json.dumps({"current_inventory": ["old item"], "as_of_chapter": "5-scene"}),
         )
-
-        meta = yaml.safe_load(char_file.read_text(encoding="utf-8").split("---")[1])
-        assert meta["current_inventory"] == ["new item"]
-
-    def test_partial_snapshot_only_updates_given_fields(self, mock_config, content_root: Path):
-        char_dir = content_root / "projects" / "my-book" / "characters"
-        char_dir.mkdir(parents=True, exist_ok=True)
-        char_file = char_dir / "theo.md"
-        char_file.write_text(
-            "---\ncurrent_inventory:\n- compass\ncurrent_clothing:\n- jacket\n---\nBody.\n",
-            encoding="utf-8",
-        )
-
         update_character_snapshot(
-            "my-book", "theo", json.dumps({"current_injuries": ["bruised ribs"]})
+            "my-book", "theo",
+            json.dumps({"current_inventory": ["new item"], "as_of_chapter": "5-scene"}),
         )
+        snap = _get_snapshot(content_root, "my-book", "theo")
+        assert snap is not None
+        assert snap["inventory"] == ["new item"]
 
-        meta = yaml.safe_load(char_file.read_text(encoding="utf-8").split("---")[1])
-        assert meta["current_inventory"] == ["compass"]
-        assert meta["current_clothing"] == ["jacket"]
-        assert meta["current_injuries"] == ["bruised ribs"]
+    def test_partial_snapshot_merges_with_existing(self, mock_config, content_root: Path):
+        _make_char(content_root, "my-book", "theo")
+        update_character_snapshot(
+            "my-book", "theo",
+            json.dumps({
+                "current_inventory": ["compass"],
+                "current_clothing": ["jacket"],
+                "as_of_chapter": "5-setup",
+            }),
+        )
+        update_character_snapshot(
+            "my-book", "theo",
+            json.dumps({"current_injuries": ["bruised ribs"], "as_of_chapter": "6-fight"}),
+        )
+        snap = _get_snapshot(content_root, "my-book", "theo")
+        assert snap is not None
+        assert snap["inventory"] == ["compass"]
+        assert snap["clothing"] == ["jacket"]
+        assert snap["injuries"] == ["bruised ribs"]
 
     def test_empty_list_is_valid(self, mock_config, content_root: Path):
         _make_char(content_root, "my-book", "theo")
@@ -164,15 +197,15 @@ class TestUpdateCharacterSnapshotFiction:
 
         assert result["success"] is True
 
-    def test_body_text_is_preserved(self, mock_config, content_root: Path):
-        char_file = _make_char(content_root, "my-book", "theo")
-
-        update_character_snapshot(
-            "my-book", "theo", json.dumps({"current_inventory": ["compass"]})
-        )
-
-        content = char_file.read_text(encoding="utf-8")
-        assert "Profile body." in content
+    def test_updated_fields_in_response(self, mock_config, content_root: Path):
+        _make_char(content_root, "my-book", "theo")
+        snapshot = {
+            "current_inventory": ["compass"],
+            "as_of_chapter": "26-the-basement",
+        }
+        result = json.loads(update_character_snapshot("my-book", "theo", json.dumps(snapshot)))
+        assert result["success"] is True
+        assert result["updated_fields"] == sorted(snapshot.keys())
 
 
 # ---------------------------------------------------------------------------
@@ -181,8 +214,8 @@ class TestUpdateCharacterSnapshotFiction:
 
 
 class TestUpdateCharacterSnapshotMemoir:
-    def test_writes_to_people_dir(self, mock_config, content_root: Path):
-        person_file = _make_person(content_root, "my-memoir", "jane")
+    def test_writes_to_db_for_memoir(self, mock_config, content_root: Path):
+        _make_person(content_root, "my-memoir", "jane")
 
         result = json.loads(
             update_character_snapshot(
@@ -194,13 +227,13 @@ class TestUpdateCharacterSnapshotMemoir:
         )
 
         assert result["success"] is True
-        meta = yaml.safe_load(person_file.read_text(encoding="utf-8").split("---")[1])
-        assert meta["current_inventory"] == ["notebook", "pen"]
-        assert meta["consent_status"] == "confirmed"
+        snap = _get_snapshot(content_root, "my-memoir", "jane")
+        assert snap is not None
+        assert snap["inventory"] == ["notebook", "pen"]
 
-    def test_memoir_does_not_touch_characters_dir(self, mock_config, content_root: Path):
-        _make_person(content_root, "my-memoir", "jane")
-        chars_dir = content_root / "projects" / "my-memoir" / "characters"
+    def test_memoir_does_not_touch_people_file(self, mock_config, content_root: Path):
+        person_file = _make_person(content_root, "my-memoir", "jane")
+        original = person_file.read_text(encoding="utf-8")
 
         update_character_snapshot(
             "my-memoir",
@@ -209,7 +242,7 @@ class TestUpdateCharacterSnapshotMemoir:
             book_category="memoir",
         )
 
-        assert not chars_dir.exists()
+        assert person_file.read_text(encoding="utf-8") == original
 
 
 # ---------------------------------------------------------------------------
@@ -302,7 +335,6 @@ class TestUpdateCharacterSnapshotSecurity:
     def test_rejects_traversal_via_character_slug(
         self, mock_config, content_root: Path, tmp_path: Path
     ):
-        """A slug with '..' must not escape content_root."""
         from tools.shared.paths import resolve_project_path
 
         import pytest as _pytest

--- a/tests/state/test_parsers.py
+++ b/tests/state/test_parsers.py
@@ -123,9 +123,9 @@ class TestParseCharacterFile:
 
 
 class TestParseAuthorProfile:
-    """Issue #151 — parse_author_profile must extract the body's Writing
-    Discoveries section so chapter-writer / chapter-reviewer can load author
-    tics, style principles, and don'ts that emerged across books."""
+    """Issue #281 — parse_author_profile now returns only frontmatter metadata.
+    Writing Discoveries are read from SQLite via get_author() in the router,
+    not from the Markdown body."""
 
     def _write_profile(self, tmp_path: Path, body: str, frontmatter_extras: str = "") -> Path:
         author_dir = tmp_path / "ethan-cole"
@@ -140,248 +140,18 @@ class TestParseAuthorProfile:
         profile.write_text(fm + body, encoding="utf-8")
         return profile
 
-    def test_legacy_profile_without_discoveries_returns_empty_lists(self, tmp_path):
-        """Books written before #151 must keep working — empty discoveries OK."""
+    def test_returns_frontmatter_metadata(self, tmp_path):
+        """parse_author_profile returns frontmatter fields only (Issue #281).
+        Writing Discoveries are now in SQLite — parse_author_profile no longer parses the body."""
         profile = self._write_profile(tmp_path, "# Ethan Cole\n\n## Writing Style\n\nDark and lean.\n")
 
         result = parse_author_profile(profile)
 
         assert result["slug"] == "ethan-cole"
         assert result["name"] == "Ethan Cole"
-        assert result["writing_discoveries"] == {
-            "recurring_tics": [],
-            "style_principles": [],
-            "donts": [],
-        }
-
-    def test_parses_recurring_tics_with_origin(self, tmp_path):
-        body = (
-            "# Ethan Cole\n\n## Writing Discoveries\n\n"
-            "_Insights that emerged across books._\n\n"
-            "### Recurring Tics\n\n"
-            "- **\"math\" as analytical metaphor** — cut on sight unless POV demands. "
-            "_(emerged from firelight, 2026-05)_\n"
-            "- **Blocking pattern \"[Character] moved to [location]\"** — replace with sensory anchor. "
-            "_(emerged from firelight, 2026-05)_\n"
-        )
-        profile = self._write_profile(tmp_path, body)
-
-        result = parse_author_profile(profile)
-
-        tics = result["writing_discoveries"]["recurring_tics"]
-        assert len(tics) == 2
-        assert "math" in tics[0]["text"]
-        assert tics[0]["origins"] == [{"book": "firelight", "date": "2026-05"}]
-        assert "Blocking pattern" in tics[1]["text"]
-
-    def test_parses_style_principles_and_donts(self, tmp_path):
-        body = (
-            "# Ethan Cole\n\n## Writing Discoveries\n\n"
-            "### Style Principles\n\n"
-            "- Fast dialog without tags works up to ~8 turns. _(emerged from firelight, 2026-05)_\n\n"
-            "### Don'ts (beyond banned phrases)\n\n"
-            "- Never start a chapter with weather. _(emerged from firelight, 2026-05)_\n"
-        )
-        profile = self._write_profile(tmp_path, body)
-
-        result = parse_author_profile(profile)
-        disc = result["writing_discoveries"]
-
-        assert len(disc["style_principles"]) == 1
-        assert "Fast dialog" in disc["style_principles"][0]["text"]
-        assert len(disc["donts"]) == 1
-        assert "weather" in disc["donts"][0]["text"]
-
-    def test_multiple_origins_for_recurring_pattern(self, tmp_path):
-        """When a pattern resurfaces in a second book, both origin tags survive."""
-        body = (
-            "# Ethan Cole\n\n## Writing Discoveries\n\n"
-            "### Recurring Tics\n\n"
-            "- **\"math\" as analytical metaphor** — cut on sight. "
-            "_(emerged from firelight, 2026-05)_ _(emerged from emberkeep, 2026-09)_\n"
-        )
-        profile = self._write_profile(tmp_path, body)
-
-        tic = parse_author_profile(profile)["writing_discoveries"]["recurring_tics"][0]
-        assert tic["origins"] == [
-            {"book": "firelight", "date": "2026-05"},
-            {"book": "emberkeep", "date": "2026-09"},
-        ]
-
-    def test_entry_without_origin_tag_still_parses(self, tmp_path):
-        """User-edited entries may lack an origin tag — must not crash."""
-        body = (
-            "# Ethan Cole\n\n## Writing Discoveries\n\n"
-            "### Recurring Tics\n\n"
-            "- **\"just\" as a hedge** — strike when not load-bearing.\n"
-        )
-        profile = self._write_profile(tmp_path, body)
-
-        tic = parse_author_profile(profile)["writing_discoveries"]["recurring_tics"][0]
-        assert "just" in tic["text"]
-        assert tic["origins"] == []
-
-    def test_empty_subsections_are_tolerated(self, tmp_path):
-        """A bare `_Frei._` placeholder under a heading must not register as a finding."""
-        body = (
-            "# Ethan Cole\n\n## Writing Discoveries\n\n"
-            "### Recurring Tics\n\n"
-            "- **\"math\"** — analytical tic. _(emerged from firelight, 2026-05)_\n\n"
-            "### Style Principles\n\n"
-            "_Frei._\n\n"
-            "### Don'ts (beyond banned phrases)\n\n"
-            "_Frei._\n"
-        )
-        profile = self._write_profile(tmp_path, body)
-
-        disc = parse_author_profile(profile)["writing_discoveries"]
-        assert len(disc["recurring_tics"]) == 1
-        assert disc["style_principles"] == []
-        assert disc["donts"] == []
-
-
-class TestParseWritingDiscoveriesExamples:
-    """Test that example blocks (Issue #268) are extracted correctly."""
-
-    def _write_profile(self, tmp_path: Path, body: str) -> Path:
-        fm = '---\nname: "Ethan Cole"\nslug: "ethan-cole"\n---\n\n'
-        profile = tmp_path / "profile.md"
-        profile.write_text(fm + body, encoding="utf-8")
-        return profile
-
-    def test_style_principle_with_example_block(self, tmp_path):
-        body = (
-            "# Ethan Cole\n\n## Writing Discoveries\n\n"
-            "### Style Principles\n\n"
-            "- **Short-register under pressure** — trust-based exchanges.\n"
-            "  `example:`\n"
-            '  > "Get up."\n'
-            '  > "In a minute."\n'
-            "  _(emerged from firelight, 2026-06)_\n"
-        )
-        profile = self._write_profile(tmp_path, body)
-        disc = parse_author_profile(profile)["writing_discoveries"]
-        principles = disc["style_principles"]
-        assert len(principles) == 1
-        assert "Short-register" in principles[0]["text"]
-        assert "example" in principles[0]
-        assert "Get up." in principles[0]["example"]
-        assert "In a minute." in principles[0]["example"]
-
-    def test_example_stripped_from_text(self, tmp_path):
-        body = (
-            "# Ethan Cole\n\n## Writing Discoveries\n\n"
-            "### Style Principles\n\n"
-            "- **Principle** — description.\n"
-            "  `example:`\n"
-            "  > Demo line.\n"
-            "  _(emerged from firelight, 2026-06)_\n"
-        )
-        profile = self._write_profile(tmp_path, body)
-        principle = parse_author_profile(profile)["writing_discoveries"]["style_principles"][0]
-        # The example block must NOT appear in the text field.
-        assert "`example:`" not in principle["text"]
-        assert "Demo line" not in principle["text"]
-
-    def test_principle_without_example_has_no_example_key(self, tmp_path):
-        body = (
-            "# Ethan Cole\n\n## Writing Discoveries\n\n"
-            "### Style Principles\n\n"
-            "- **Plain principle** — no example. _(emerged from firelight, 2026-05)_\n"
-        )
-        profile = self._write_profile(tmp_path, body)
-        principle = parse_author_profile(profile)["writing_discoveries"]["style_principles"][0]
-        assert "example" not in principle
-
-    def test_recurring_tic_never_has_example_key(self, tmp_path):
-        body = (
-            "# Ethan Cole\n\n## Writing Discoveries\n\n"
-            "### Recurring Tics\n\n"
-            "- **Tic** — cut on sight.\n"
-            "  `example:`\n"
-            "  > Some line.\n"
-            "  _(emerged from firelight, 2026-05)_\n"
-        )
-        profile = self._write_profile(tmp_path, body)
-        tic = parse_author_profile(profile)["writing_discoveries"]["recurring_tics"][0]
-        # Parser extracts example from ANY section — but _build_discovery_entry
-        # strips the example block from `text`. The `example` key is allowed.
-        # What matters: text field does not include the example content.
-        assert "`example:`" not in tic["text"]
-
-    def test_origins_still_parsed_with_example(self, tmp_path):
-        body = (
-            "# Ethan Cole\n\n## Writing Discoveries\n\n"
-            "### Style Principles\n\n"
-            "- **Principle** — desc.\n"
-            "  `example:`\n"
-            "  > Line.\n"
-            "  _(emerged from firelight, 2026-06)_\n"
-        )
-        profile = self._write_profile(tmp_path, body)
-        principle = parse_author_profile(profile)["writing_discoveries"]["style_principles"][0]
-        assert principle["origins"] == [{"book": "firelight", "date": "2026-06"}]
-
-
-class TestParseWritingDiscoveriesGenres:
-    """Test that when: genre-tag blocks (Issue #266) are extracted correctly."""
-
-    def _write_profile(self, tmp_path: Path, body: str) -> Path:
-        fm = '---\nname: "Ethan Cole"\nslug: "ethan-cole"\n---\n\n'
-        profile = tmp_path / "profile.md"
-        profile.write_text(fm + body, encoding="utf-8")
-        return profile
-
-    def test_when_block_parsed_to_genres_list(self, tmp_path):
-        body = (
-            "# Ethan Cole\n\n## Writing Discoveries\n\n"
-            "### Style Principles\n\n"
-            "- **Banter density** — 4–6 turns.\n"
-            "  `when: light-fantasy, comedy-fantasy`\n"
-            "  _(emerged from fractured-doors, 2026-06)_\n"
-        )
-        profile = self._write_profile(tmp_path, body)
-        principle = parse_author_profile(profile)["writing_discoveries"]["style_principles"][0]
-        assert principle["genres"] == ["light-fantasy", "comedy-fantasy"]
-        assert "Banter density" in principle["text"]
-
-    def test_principle_without_when_has_no_genres_key(self, tmp_path):
-        body = (
-            "# Ethan Cole\n\n## Writing Discoveries\n\n"
-            "### Style Principles\n\n"
-            "- **Universal principle** — no genre tag. _(emerged from firelight, 2026-05)_\n"
-        )
-        profile = self._write_profile(tmp_path, body)
-        principle = parse_author_profile(profile)["writing_discoveries"]["style_principles"][0]
-        assert "genres" not in principle
-
-    def test_when_and_example_combined(self, tmp_path):
-        body = (
-            "# Ethan Cole\n\n## Writing Discoveries\n\n"
-            "### Style Principles\n\n"
-            "- **Banter density** — 4–6 turns.\n"
-            '  `when: light-fantasy`\n'
-            "  `example:`\n"
-            '  > "You\'re impossible."\n'
-            "  _(emerged from fractured-doors, 2026-06)_\n"
-        )
-        profile = self._write_profile(tmp_path, body)
-        principle = parse_author_profile(profile)["writing_discoveries"]["style_principles"][0]
-        assert principle["genres"] == ["light-fantasy"]
-        assert "impossible" in principle["example"]
-        assert principle["origins"] == [{"book": "fractured-doors", "date": "2026-06"}]
-
-    def test_when_block_stripped_from_text(self, tmp_path):
-        body = (
-            "# Ethan Cole\n\n## Writing Discoveries\n\n"
-            "### Style Principles\n\n"
-            "- **Banter density** — 4–6 turns.\n"
-            "  `when: light-fantasy`\n"
-            "  _(emerged from fractured-doors, 2026-06)_\n"
-        )
-        profile = self._write_profile(tmp_path, body)
-        principle = parse_author_profile(profile)["writing_discoveries"]["style_principles"][0]
-        assert "`when:" not in principle["text"]
+        assert result["narrative_voice"] == "third-limited"
+        assert result["tense"] == "past"
+        assert "writing_discoveries" not in result
 
 
 class TestCountWords:

--- a/tools/db/author_discoveries.py
+++ b/tools/db/author_discoveries.py
@@ -1,0 +1,116 @@
+"""CRUD helpers for the author_discoveries table — Issue #281."""
+
+from __future__ import annotations
+
+import sqlite3
+
+VALID_TYPES: frozenset[str] = frozenset({"recurring_tics", "style_principles", "donts"})
+
+
+def insert_discovery(
+    conn: sqlite3.Connection,
+    *,
+    author_slug: str,
+    discovery_type: str,
+    text: str,
+    book_slug: str = "",
+    source_genres: str = "",
+    universal: bool = False,
+    example: str = "",
+    date_added: str = "",
+) -> bool:
+    """Insert a discovery. Returns True if inserted, False if duplicate (UNIQUE ignored)."""
+    cur = conn.execute(
+        """
+        INSERT OR IGNORE INTO author_discoveries
+            (author_slug, discovery_type, text, book_slug, source_genres, universal, example, date_added)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (author_slug, discovery_type, text, book_slug, source_genres, int(universal), example, date_added),
+    )
+    conn.commit()
+    return cur.rowcount == 1
+
+
+def get_discoveries(
+    conn: sqlite3.Connection,
+    author_slug: str,
+    discovery_type: str | None = None,
+) -> list[dict]:
+    """Return all discoveries for an author, optionally filtered by type."""
+    cols = "id, author_slug, discovery_type, text, book_slug, source_genres, universal, example, date_added"
+    if discovery_type:
+        rows = conn.execute(
+            f"SELECT {cols} FROM author_discoveries WHERE author_slug=? AND discovery_type=? ORDER BY id",
+            (author_slug, discovery_type),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            f"SELECT {cols} FROM author_discoveries WHERE author_slug=? ORDER BY discovery_type, id",
+            (author_slug,),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def discovery_exists(
+    conn: sqlite3.Connection,
+    author_slug: str,
+    discovery_type: str,
+    text: str,
+) -> bool:
+    """Return True if an exact duplicate exists (same author+type+text)."""
+    row = conn.execute(
+        "SELECT 1 FROM author_discoveries WHERE author_slug=? AND discovery_type=? AND text=?",
+        (author_slug, discovery_type, text),
+    ).fetchone()
+    return row is not None
+
+
+def update_source_genres(
+    conn: sqlite3.Connection,
+    *,
+    author_slug: str,
+    book_slug: str,
+    source_genres: str,
+) -> int:
+    """Set source_genres for all discoveries from a specific book. Returns updated row count."""
+    cur = conn.execute(
+        """
+        UPDATE author_discoveries
+        SET source_genres=?, updated_at=CURRENT_TIMESTAMP
+        WHERE author_slug=? AND book_slug=?
+        """,
+        (source_genres, author_slug, book_slug),
+    )
+    conn.commit()
+    return cur.rowcount
+
+
+def discoveries_as_writing_discoveries(rows: list[dict]) -> dict[str, list[dict]]:
+    """Convert DB rows to the writing_discoveries format consumed by get_author().
+
+    Output is backward-compatible with the old _parse_writing_discoveries() shape:
+    {"recurring_tics": [...], "style_principles": [...], "donts": [...]}
+    Each entry: {"text", "origins": [{"book", "date"}], "genres"?, "example"?}
+    """
+    result: dict[str, list[dict]] = {"recurring_tics": [], "style_principles": [], "donts": []}
+    for row in rows:
+        dtype = row.get("discovery_type", "")
+        if dtype not in result:
+            continue
+        entry: dict = {
+            "text": row["text"],
+            "origins": (
+                [{"book": row["book_slug"], "date": row["date_added"]}]
+                if row.get("book_slug")
+                else []
+            ),
+        }
+        if row.get("source_genres"):
+            entry["genres"] = [g.strip() for g in row["source_genres"].split(",") if g.strip()]
+        if row.get("example"):
+            entry["example"] = row["example"]
+        if row.get("universal"):
+            entry["universal"] = bool(row["universal"])
+        result[dtype].append(entry)
+    return result

--- a/tools/db/character_snapshots.py
+++ b/tools/db/character_snapshots.py
@@ -1,0 +1,119 @@
+"""CRUD helpers for the character_snapshots table — Issue #281."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+_LIST_FIELDS = ("injuries", "clothing", "inventory", "altered_states")
+_COLS = "char_slug, book_num, chapter_num, injuries, clothing, inventory, altered_states, environmental_limiters, updated_at"
+
+
+def upsert_snapshot(
+    conn: sqlite3.Connection,
+    *,
+    char_slug: str,
+    book_num: int,
+    chapter_num: int,
+    injuries: list[str] | None = None,
+    clothing: list[str] | None = None,
+    inventory: list[str] | None = None,
+    altered_states: list[str] | None = None,
+    environmental_limiters: str | None = None,
+) -> None:
+    """Insert or replace a character snapshot, merging with the latest prior state.
+
+    Fields not provided (None) are inherited from the latest existing snapshot for
+    (char_slug, book_num) so partial updates don't erase established state.
+    """
+    existing = get_latest_snapshot_for_book(conn, char_slug, book_num) or {}
+
+    merged_injuries = injuries if injuries is not None else existing.get("injuries", [])
+    merged_clothing = clothing if clothing is not None else existing.get("clothing", [])
+    merged_inventory = inventory if inventory is not None else existing.get("inventory", [])
+    merged_states = altered_states if altered_states is not None else existing.get("altered_states", [])
+    merged_env = (
+        environmental_limiters
+        if environmental_limiters is not None
+        else existing.get("environmental_limiters", "")
+    )
+
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO character_snapshots
+            (char_slug, book_num, chapter_num, injuries, clothing, inventory,
+             altered_states, environmental_limiters, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+        """,
+        (
+            char_slug,
+            book_num,
+            chapter_num,
+            json.dumps(merged_injuries),
+            json.dumps(merged_clothing),
+            json.dumps(merged_inventory),
+            json.dumps(merged_states),
+            merged_env or "",
+        ),
+    )
+    conn.commit()
+
+
+def get_latest_snapshot(conn: sqlite3.Connection, char_slug: str) -> dict | None:
+    """Return the most recent snapshot for a character across all books."""
+    row = conn.execute(
+        f"SELECT {_COLS} FROM character_snapshots WHERE char_slug=? ORDER BY book_num DESC, chapter_num DESC LIMIT 1",
+        (char_slug,),
+    ).fetchone()
+    return _decode_row(dict(row)) if row else None
+
+
+def get_latest_snapshot_for_book(
+    conn: sqlite3.Connection,
+    char_slug: str,
+    book_num: int,
+) -> dict | None:
+    """Return the most recent snapshot for a character within a specific book."""
+    row = conn.execute(
+        f"SELECT {_COLS} FROM character_snapshots WHERE char_slug=? AND book_num=? ORDER BY chapter_num DESC LIMIT 1",
+        (char_slug, book_num),
+    ).fetchone()
+    return _decode_row(dict(row)) if row else None
+
+
+def get_all_latest_snapshots(conn: sqlite3.Connection) -> list[dict]:
+    """Return the latest snapshot per character (for the continuity brief).
+
+    Uses a subquery to pick the row with the highest combined sort key.
+    Assumes chapter_num < 100_000 (i.e., no book has more than 99999 chapters).
+    """
+    rows = conn.execute(
+        f"""
+        SELECT {", ".join(f"cs.{c.strip()}" for c in _COLS.split(","))}
+        FROM character_snapshots cs
+        INNER JOIN (
+            SELECT char_slug,
+                   MAX(book_num * 100000 + chapter_num) AS max_key
+            FROM character_snapshots
+            GROUP BY char_slug
+        ) latest
+            ON cs.char_slug = latest.char_slug
+            AND (cs.book_num * 100000 + cs.chapter_num) = latest.max_key
+        ORDER BY cs.char_slug
+        """
+    ).fetchall()
+    return [_decode_row(dict(r)) for r in rows]
+
+
+def _decode_row(row: dict) -> dict:
+    """Decode JSON list columns back to Python lists."""
+    for field in _LIST_FIELDS:
+        raw = row.get(field)
+        if isinstance(raw, str):
+            try:
+                row[field] = json.loads(raw)
+            except json.JSONDecodeError:
+                row[field] = []
+        elif raw is None:
+            row[field] = []
+    return row

--- a/tools/db/connection.py
+++ b/tools/db/connection.py
@@ -1,10 +1,11 @@
-"""SQLite connection management for StoryForge — Issue #280.
+"""SQLite connection management for StoryForge — Issues #280 / #281.
 
 DB layout:
-  ~/.storyforge/db/{series-slug}.db  — canon_facts per series
+  ~/.storyforge/db/{series-slug}.db  — canon_facts + character_snapshots per series
   ~/.storyforge/db/storyforge.db     — global sessions table
+  ~/.storyforge/db/authors.db        — author_discoveries (global, cross-series)
 
-All tables are created lazily via ensure_schema().
+All tables are created lazily via ensure_schema() / ensure_authors_schema().
 """
 
 from __future__ import annotations
@@ -28,7 +29,7 @@ def open_db(db_path: Path) -> sqlite3.Connection:
 
 
 def ensure_schema(conn: sqlite3.Connection) -> None:
-    """Create all tables and indexes if they don't exist yet (idempotent)."""
+    """Create series/session tables and indexes if they don't exist yet (idempotent)."""
     conn.executescript("""
         CREATE TABLE IF NOT EXISTS canon_facts (
             id               INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -58,8 +59,65 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             notes             TEXT DEFAULT '{}',
             last_updated      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         );
+
+        CREATE TABLE IF NOT EXISTS character_snapshots (
+            char_slug               TEXT NOT NULL,
+            book_num                INTEGER NOT NULL,
+            chapter_num             INTEGER NOT NULL,
+            injuries                TEXT,
+            clothing                TEXT,
+            inventory               TEXT,
+            altered_states          TEXT,
+            environmental_limiters  TEXT DEFAULT '',
+            updated_at              TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (char_slug, book_num, chapter_num)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_cs
+            ON character_snapshots(char_slug, book_num, chapter_num);
     """)
     conn.commit()
+
+
+def ensure_authors_schema(conn: sqlite3.Connection) -> None:
+    """Create the author_discoveries table and index (idempotent) — Issue #281."""
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS author_discoveries (
+            id             INTEGER PRIMARY KEY AUTOINCREMENT,
+            author_slug    TEXT NOT NULL,
+            discovery_type TEXT NOT NULL,
+            text           TEXT NOT NULL,
+            book_slug      TEXT DEFAULT '',
+            source_genres  TEXT DEFAULT '',
+            universal      BOOLEAN DEFAULT FALSE,
+            example        TEXT DEFAULT '',
+            date_added     TEXT DEFAULT '',
+            created_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(author_slug, discovery_type, text)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_ad
+            ON author_discoveries(author_slug, discovery_type);
+    """)
+    conn.commit()
+
+
+def get_authors_db_path() -> Path:
+    """Return the path to the global author_discoveries database."""
+    return DB_DIR / "authors.db"
+
+
+def open_authors_db() -> sqlite3.Connection:
+    """Open the global authors DB (author_discoveries table)."""
+    path = get_authors_db_path()
+    conn = open_db(path)
+    try:
+        ensure_authors_schema(conn)
+    except sqlite3.Error:
+        conn.close()
+        raise
+    return conn
 
 
 def get_canon_db_path(series_or_book_slug: str) -> Path:

--- a/tools/state/continuity_brief.py
+++ b/tools/state/continuity_brief.py
@@ -17,6 +17,8 @@ from typing import Any
 
 from tools.analysis.timeline_validator import parse_plot_timeline
 from tools.db.brief_helpers import load_canon_facts_for_brief
+from tools.db.character_snapshots import get_all_latest_snapshots
+from tools.db.connection import get_db_slug_for_book, open_canon_db
 from tools.state.chapter_timeline_parser import parse_chapter_timeline_grid
 from tools.state.parsers import parse_frontmatter
 from tools.state.review_brief import (
@@ -177,6 +179,21 @@ def build_continuity_brief(
         [],
     )
 
+    # ----- character snapshots from DB (Issue #281) -------------------------
+    def _load_character_snapshots() -> list[dict]:
+        db_slug = get_db_slug_for_book(book_root)
+        conn = open_canon_db(db_slug)
+        try:
+            return get_all_latest_snapshots(conn)
+        finally:
+            conn.close()
+
+    character_snapshots: list[dict] = recorder.run(
+        "character_snapshots",
+        _load_character_snapshots,
+        [],
+    )
+
     return {
         "book_slug": book_slug,
         "canonical_calendar": canonical_calendar,
@@ -184,5 +201,6 @@ def build_continuity_brief(
         "canon_log_facts": canon_log_facts,
         "character_index": character_index,
         "chapter_timelines": chapter_timelines,
+        "character_snapshots": character_snapshots,
         "errors": list(recorder.errors),
     }

--- a/tools/state/parsers.py
+++ b/tools/state/parsers.py
@@ -198,21 +198,16 @@ def parse_person_file(path: Path) -> dict[str, Any]:
 
 
 def parse_author_profile(path: Path) -> dict[str, Any]:
-    """Parse an author profile.md into structured data.
+    """Parse an author profile.md into structured data — Issue #281.
 
-    Issue #151 — also extracts the body's ``## Writing Discoveries`` section
-    so chapter-writer and chapter-reviewer can apply author-level findings
-    that emerged across books. Three sub-sections are supported:
-
-    - ``### Recurring Tics`` — habitual word/metaphor/structure tics
-    - ``### Style Principles`` — positive craft heuristics
-    - ``### Don'ts`` (also matches "Don'ts (beyond banned phrases)")
-
-    Each entry is parsed into ``{"text": str, "origins": [{"book", "date"}, ...]}``.
-    Profiles without the section get empty lists (back-compat for legacy authors).
+    Writing Discoveries are no longer parsed from Markdown; they are read
+    from the author_discoveries SQLite table by get_author() in the router.
+    ``writing_discoveries`` is omitted here so the state cache does not carry
+    stale Markdown data — the router always merges fresh DB rows before
+    returning get_author() responses.
     """
     text = path.read_text(encoding="utf-8")
-    meta, body = parse_frontmatter(text)
+    meta, _ = parse_frontmatter(text)
 
     return {
         "slug": path.parent.name,
@@ -229,142 +224,9 @@ def parse_author_profile(path: Path) -> dict[str, Any]:
         "influences": meta.get("influences", []),
         "avoid": meta.get("avoid", []),
         "author_writing_mode": meta.get("author_writing_mode", "outliner"),
-        "writing_discoveries": _parse_writing_discoveries(body),
         "created": str(meta.get("created", "")),
         "updated": str(meta.get("updated", "")),
     }
-
-
-# --- Writing Discoveries parser (Issue #151) ---
-
-# Match the H2 section header. We capture everything until the next H2 or EOF.
-_RE_DISCOVERIES_SECTION = re.compile(
-    r"^##\s+Writing\s+Discoveries\s*$(.*?)(?=^##\s|\Z)",
-    re.MULTILINE | re.DOTALL | re.IGNORECASE,
-)
-
-# Sub-section headers map to canonical bucket keys. The "Don'ts" header is
-# matched loosely — "Don'ts", "Donts", and "Don'ts (beyond banned phrases)"
-# all bucket the same way.
-_DISCOVERY_BUCKETS: tuple[tuple[str, re.Pattern[str]], ...] = (
-    ("recurring_tics", re.compile(r"^###\s+Recurring\s+Tics\s*$", re.IGNORECASE)),
-    ("style_principles", re.compile(r"^###\s+Style\s+Principles\s*$", re.IGNORECASE)),
-    ("donts", re.compile(r"^###\s+Don[’'`´]?ts.*$", re.IGNORECASE)),
-)
-
-# A bullet entry. Captures the text after `- ` and lets the origin parser
-# walk over what's there. A line that is just `_Frei._` (German) or `_Free._`
-# placeholder must NOT register as an entry.
-_RE_BULLET = re.compile(r"^-\s+(?P<text>.+?)\s*$", re.MULTILINE)
-_RE_PLACEHOLDER = re.compile(r"^_(?:frei|free|empty|tba|tbd)\.?_\s*$", re.IGNORECASE)
-
-# Origin tag: `_(emerged from {book-slug}, {YYYY-MM})_`. Multiple tags can be
-# stacked when a discovery resurfaces across books.
-_RE_ORIGIN = re.compile(
-    r"_\(\s*emerged\s+from\s+(?P<book>[a-z0-9][a-z0-9_-]*)\s*,\s*(?P<date>\d{4}-\d{2})\s*\)_",
-    re.IGNORECASE,
-)
-
-
-_RE_EXAMPLE_BLOCK = re.compile(r"`example:`\s*\n((?:[ \t]*>[ \t]*.+\n?)+)", re.MULTILINE)
-_RE_WHEN_BLOCK = re.compile(r"`when:\s*([^`\n]+)`", re.MULTILINE)
-
-
-def _parse_writing_discoveries(body: str) -> dict[str, list[dict[str, Any]]]:
-    """Extract structured discoveries from the profile body.
-
-    Returns a dict with three buckets — ``recurring_tics``, ``style_principles``,
-    ``donts`` — each a list of ``{"text", "origins"}`` entries.
-    ``style_principles`` entries may carry ``"example"`` (Issue #268) and/or
-    ``"genres"`` (Issue #266) keys when the corresponding blocks are present.
-    """
-    empty = {"recurring_tics": [], "style_principles": [], "donts": []}
-    section = _RE_DISCOVERIES_SECTION.search(body)
-    if not section:
-        return empty
-
-    section_text = section.group(1)
-
-    result: dict[str, list[dict[str, Any]]] = {key: [] for key, _ in _DISCOVERY_BUCKETS}
-    current_bucket: str | None = None
-    pending: list[str] = []  # accumulates lines for the current bullet
-
-    def _flush() -> None:
-        if not pending or current_bucket is None:
-            return
-        entry = _build_discovery_entry("\n".join(pending))
-        if entry:
-            result[current_bucket].append(entry)
-        pending.clear()
-
-    for line in section_text.splitlines():
-        stripped = line.strip()
-        bucket_match = _match_subsection(stripped)
-        if bucket_match is not None:
-            _flush()
-            current_bucket = bucket_match
-            continue
-        if current_bucket is None:
-            continue
-        if _RE_PLACEHOLDER.match(stripped):
-            continue
-        if stripped.startswith("- "):
-            _flush()
-            pending.append(stripped[2:].strip())
-        elif stripped and pending:
-            # Continuation line (example block, blockquote, extra description).
-            pending.append(stripped)
-
-    _flush()
-    return result
-
-
-def _build_discovery_entry(raw: str) -> dict[str, Any] | None:
-    """Build a single discovery entry dict from accumulated bullet text lines."""
-    genres: list[str] = []
-    example = ""
-
-    # Extract when: genre tags before any other stripping.
-    when_match = _RE_WHEN_BLOCK.search(raw)
-    if when_match:
-        genres = [g.strip() for g in when_match.group(1).split(",") if g.strip()]
-        raw = _RE_WHEN_BLOCK.sub("", raw).strip()
-
-    # Extract example block; origins may follow it — extract before truncating.
-    ex_match = _RE_EXAMPLE_BLOCK.search(raw)
-    if ex_match:
-        example_raw = ex_match.group(1)
-        example = "\n".join(
-            ln.strip().lstrip(">").strip()
-            for ln in example_raw.splitlines()
-            if ln.strip()
-        )
-        origins = _extract_origins(raw)
-        raw = raw[: ex_match.start()].strip()
-    else:
-        origins = _extract_origins(raw)
-
-    cleaned = _RE_ORIGIN.sub("", raw).rstrip(" \t_").strip()
-    cleaned = re.sub(r"\s{2,}", " ", cleaned).strip()
-    if not cleaned:
-        return None
-    entry: dict[str, Any] = {"text": cleaned, "origins": origins}
-    if example:
-        entry["example"] = example
-    if genres:
-        entry["genres"] = genres
-    return entry
-
-
-def _match_subsection(line: str) -> str | None:
-    for bucket_key, pattern in _DISCOVERY_BUCKETS:
-        if pattern.match(line):
-            return bucket_key
-    return None
-
-
-def _extract_origins(text: str) -> list[dict[str, str]]:
-    return [{"book": m.group("book"), "date": m.group("date")} for m in _RE_ORIGIN.finditer(text)]
 
 
 def parse_series_readme(path: Path) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

- Migrates `author_discoveries` and `character_snapshots` from Markdown/YAML frontmatter to SQLite, completing Phase 3 of the SQLite + Series Architecture (Issue #278)
- Adds dedicated CRUD modules (`tools/db/author_discoveries.py`, `tools/db/character_snapshots.py`) with full test coverage
- Removes ~150 lines of dead Markdown-parsing code from `tools/state/parsers.py`; `continuity_brief.py` now loads character snapshots from DB
- Provides a one-time idempotent migration script (`scripts/migrate_phase3.py`) to import existing data

## Type of Change

- [ ] Bug fix
- [x] Refactor (non-breaking behavior change — see Breaking Changes below)
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Test coverage

## Changes

### New Files

| File | Description |
|------|-------------|
| `tools/db/author_discoveries.py` | CRUD for `author_discoveries` table (insert, get, exists, update) |
| `tools/db/character_snapshots.py` | CRUD for `character_snapshots` table (upsert with merge) |
| `tests/db/test_author_discoveries.py` | 21 unit tests |
| `tests/db/test_character_snapshots.py` | 15 unit tests |
| `scripts/migrate_phase3.py` | One-time migration script (dry-run + execute mode, idempotent) |

### Modified Files

**Database layer**
- `tools/db/connection.py` — Added `ensure_authors_schema`, `open_authors_db`, `character_snapshots` table definition in `ensure_schema`

**Server routers**
- `servers/storyforge-server/routers/authors.py` — `write_author_discovery` / `banned_phrase` write to DB instead of Markdown; new `update_discovery_metadata` MCP tool
- `servers/storyforge-server/routers/claudemd.py` — `update_character_snapshot` writes to SQLite (YAML frontmatter writes removed)

**State / parsers**
- `tools/state/continuity_brief.py` — Character snapshots loaded from DB
- `tools/state/parsers.py` — Removed ~150 lines of dead Markdown parsing (`_parse_writing_discoveries` etc.)

**Tests**
- `tests/server/test_author_write_tools.py` — Rewritten to assert DB rows instead of file content
- `tests/server/test_update_character_snapshot.py` — Rewritten to assert DB rows
- `tests/state/test_parsers.py` — Orphaned `writing_discoveries` tests removed, 1 new test added

## Test Results

```
2022 / 2022 tests passed (0 failed)
  36  new DB unit tests
  39  server tests rewritten against new DB backend
  12  smoke tests
ruff: 0 violations
```

## Migration Notes

Run the one-time migration **before** deploying this branch:

```bash
# Dry run (no writes, inspect what would be migrated)
python scripts/migrate_phase3.py --dry-run

# Execute
python scripts/migrate_phase3.py
```

The script is idempotent — safe to run multiple times. It imports all existing Markdown-based `author_discoveries` and `character_snapshots` data into SQLite and leaves the source files untouched.

## Breaking Changes

| What changed | Impact |
|---|---|
| `parse_author_profile()` no longer returns `writing_discoveries` key | Internal only — callers outside this repo should not be affected; tests updated |
| `update_character_snapshot()` writes to SQLite instead of character `.md` files | Any tooling that reads YAML frontmatter from character files for snapshots will no longer see updates |
| `scripts/migrate_phase3.py` must be run once | Existing data is not auto-migrated on startup |

## Reviewer Checklist

- [ ] DB schema additions in `connection.py` are backwards-compatible with Phase 2 tables
- [ ] `migrate_phase3.py` dry-run output looks correct for a sample project
- [ ] `update_character_snapshot` no longer touches `.md` files — verify no regression in character file structure
- [ ] `authors.py` router: `update_discovery_metadata` MCP tool is documented and returns sensible errors on missing records
- [ ] All 2022 tests pass locally (`pytest` + `ruff check .`)
- [ ] No `writing_discoveries` references remain in production code paths (dead code fully removed)

---

*Part of Issue #278 — SQLite + Series Architecture. Previous phase: #280 / PR #285 (canon_facts + session tables).*