### PR TITLE
refactor(db): Phase 5 — parser cleanup + source_genres skill chain (Issue #283)

### DIFF
--- a/scripts/migrate_book_rules.py
+++ b/scripts/migrate_book_rules.py
@@ -135,15 +135,23 @@ def main() -> None:
         config.setdefault("paths", {})["content_root"] = args.content_root
 
     content_root = Path(config["paths"]["content_root"])
-    projects_dir = content_root / "projects"
-    if not projects_dir.exists():
-        print(f"projects/ not found at {projects_dir}", file=sys.stderr)
-        sys.exit(1)
 
-    book_slugs = [d.name for d in sorted(projects_dir.iterdir()) if d.is_dir()]
+    # Collect book slugs from both legacy projects/ and series/*/ structure (Issue #279).
+    book_slugs: list[str] = []
+    projects_dir = content_root / "projects"
+    if projects_dir.exists():
+        book_slugs.extend(d.name for d in sorted(projects_dir.iterdir()) if d.is_dir())
+    series_root = content_root / "series"
+    if series_root.exists():
+        for series_dir in sorted(series_root.iterdir()):
+            if series_dir.is_dir():
+                book_slugs.extend(d.name for d in sorted(series_dir.iterdir()) if d.is_dir() and (d / "CLAUDE.md").exists())
+
+    book_slugs = list(dict.fromkeys(book_slugs))  # dedup, preserve order
+
     if not book_slugs:
-        print("No books found.")
-        return
+        print("No books found in projects/ or series/.", file=sys.stderr)
+        sys.exit(1)
 
     total_rules = total_callbacks = total_workflows = 0
     prefix = "[DRY RUN] " if args.dry_run else ""

--- a/skills/backfill-style-principles/SKILL.md
+++ b/skills/backfill-style-principles/SKILL.md
@@ -177,12 +177,14 @@ different genre. Examples:
 - Flavor-word tic discipline → universal
 
 For genre-specific patterns: determine the source book's genres. Read the
-first lines of the analysis file for a `genres:` field in frontmatter, or
-derive from context (title, tone descriptors). If unclear, ask the user:
+first lines of the analysis file for a `source_genres:` field in frontmatter
+(set by `study-author` Phase 1 since Phase 5 / #283). If the field is absent
+(older analysis files), fall back to a `genres:` field, or derive from context
+(title, tone descriptors). If still unclear, ask the user:
 > "Is '{book_slug}' primarily light-fantasy / comedy / other? I'll tag genre-
 > specific patterns so chapter-writer skips them in different-genre books."
 
-Collect the `genres` value as a comma-separated slug list (e.g.
+Collect the value as a comma-separated slug list (e.g.
 `light-fantasy, comedy-fantasy`). Universal patterns get an empty `genres`.
 
 **2. Is there a prose example worth preserving?**

--- a/skills/migrate-source-genres/SKILL.md
+++ b/skills/migrate-source-genres/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: migrate-source-genres
+description: |
+  Backfill source_genres on existing author_discoveries DB rows by reading the
+  source_genres (or legacy genres) field from studied-works analysis file frontmatter.
+  Use when: (1) User says "migrate source genres", "source_genres backfill",
+  "/storyforge:migrate-source-genres", (2) Writing Discoveries in the DB have no
+  source_genres set because they were created before Phase 5 (#283),
+  (3) chapter-writer or author-check genre filter is not working as expected.
+model: claude-sonnet-4-6
+user-invocable: true
+argument-hint: "[author-slug]"
+---
+
+# migrate-source-genres
+
+Backfill `source_genres` on author_discoveries DB rows that were written before
+Phase 5 (Issue #283) added the `source_genres:` frontmatter field to analysis files.
+
+## When to use
+
+- You ran `study-author` before Phase 5 and the `genres=` parameter was not passed
+  to `write_author_discovery`
+- `chapter-writer` Audit 4.5 genre filter skips all style_principles (no genres set)
+- `author-check` genre filter finds nothing to check
+
+## Step 1: Identify author
+
+If no author slug was passed as argument, show list via MCP `list_authors()` and
+ask the user which author to process.
+
+## Step 2: Scan analysis files
+
+List all files in `~/.storyforge/authors/{slug}/studied-works/analysis-*.md`.
+
+For each file:
+1. Read the first ~30 lines (frontmatter section only)
+2. Extract `source_genres:` — preferred field (set by study-author Phase 1 post-#283)
+3. If `source_genres:` is absent, fall back to `genres:` field (legacy)
+4. Derive `book_slug` from the filename: `analysis-{book_slug}.md` → `{book_slug}`
+
+Report what was found before making changes:
+
+```
+Author: {slug}
+Analysis files found: {N}
+
+  analysis-firelight.md          source_genres: light-supernatural, comedy-supernatural
+  analysis-some-book.md          source_genres: (none found — will skip)
+  analysis-other-book.md         genres: dark-fantasy  (legacy field)
+
+Proceed? (yes/no)
+```
+
+## Step 3: Apply updates
+
+For each file where `source_genres` or `genres` was found, call:
+
+```
+update_discovery_metadata(
+  author_slug=<slug>,
+  book_slug=<derived-slug>,
+  source_genres=<comma-separated genres>
+)
+```
+
+This sets `source_genres` on ALL discovery rows for that `book_slug` in one SQL UPDATE.
+It does not touch rows from other books.
+
+Files with no genre field are skipped (not updated).
+
+## Step 4: Report
+
+```
+migrate-source-genres complete: {slug}
+────────────────────────────────────────
+Files processed:     {N}
+DB rows updated:     {total from all update_discovery_metadata responses}
+Files skipped:       {N} (no source_genres / genres field)
+────────────────────────────────────────
+```
+
+Remind the user: chapter-writer and author-check now apply the genre filter
+automatically. No session restart needed.
+
+## Notes
+
+- `update_discovery_metadata` is idempotent — running twice sets the same value again
+- Only `source_genres` is updated; `text`, `example`, `universal`, and other fields
+  are untouched
+- For the special case `universal: true` rows: these are not affected by genre filtering
+  regardless of `source_genres` — they apply to all books always

--- a/skills/study-author/SKILL.md
+++ b/skills/study-author/SKILL.md
@@ -32,7 +32,9 @@ Alternatively, detect from context: if the book linked to the author slug has `b
 ### Phase 1: Input
 1. **Get file path** — User provides path to PDF, EPUB, DOCX, TXT, or MD file (max 50 MB)
 2. **Get author** — Which author profile to update? Show list via MCP `list_authors()`
-3. **Read the file** — Use the Read tool for text/markdown/PDF files. For EPUB and DOCX, the MCP server's `extract_text_from_file()` handles extraction. Supported: PDF, EPUB, DOCX, TXT, MD. Max 50 MB, max 200k words (larger files are auto-sampled from beginning, middle, and end).
+3. **Registry-Check** — Derive a `book_slug` from the file name (lowercase, hyphens). Check `~/.storyforge/authors/{slug}/studied-works/` for an existing `analysis-{book_slug}.md`. If found, warn the user: "This text has already been analyzed (`analysis-{book_slug}.md` exists). Re-analyzing may create duplicate Writing Discoveries. Continue anyway?"
+4. **Source genres** — Ask: *"What genre(s) is this text? (e.g. dark-fantasy, thriller, lgbtq-romance) — leave blank if unknown or cross-genre."* Store as `source_genres` (comma-separated slug list). Used to tag genre-specific Writing Discoveries so chapter-writer skips them in different-genre books.
+5. **Read the file** — Use the Read tool for text/markdown/PDF files. For EPUB and DOCX, the MCP server's `extract_text_from_file()` handles extraction. Supported: PDF, EPUB, DOCX, TXT, MD. Max 50 MB, max 200k words (larger files are auto-sampled from beginning, middle, and end).
 
 ### Phase 1.5: Build Positive Extraction Checklist
 
@@ -101,6 +103,7 @@ author_of_source: "Original Author Name"
 analyzed: "2026-04-03"
 word_count: 85000
 mode: fiction
+source_genres: "dark-fantasy, lgbtq"
 ---
 
 # Style Analysis: {Title}
@@ -128,8 +131,8 @@ mode: fiction
 Update the author's profile using MCP tools to ensure cache invalidation:
 
 - **Tone / sentence_style / other frontmatter fields** — MCP `update_author(slug, field, value)` per field
-- **Positive style markers found** — **MANDATORY for every checklist item where a pattern was found.** MCP `write_author_discovery(author_slug, section="style_principles", text=<marker>, book_slug=<analyzed-work-slug>)` per item. Format: `**[Marker name]** — [concrete observation from this text, with frequency or ratio if measurable].` A positive finding that only lives in `studied-works/analysis-{title}.md` is invisible to chapter-writer. Every found positive marker must become a `style_principles` Writing Discovery. "Not found" items are skipped.
-- **Signature Techniques discovered** (beyond the checklist) — MCP `write_author_discovery(author_slug, section="style_principles", text=<technique>, book_slug=<analyzed-work-slug>)`
+- **Positive style markers found** — **MANDATORY for every checklist item where a pattern was found.** MCP `write_author_discovery(author_slug, section="style_principles", text=<marker>, book_slug=<analyzed-work-slug>, genres=<source_genres from Phase 1 — empty string if unknown/universal>)` per item. Format: `**[Marker name]** — [concrete observation from this text, with frequency or ratio if measurable].` A positive finding that only lives in `studied-works/analysis-{title}.md` is invisible to chapter-writer. Every found positive marker must become a `style_principles` Writing Discovery. "Not found" items are skipped.
+- **Signature Techniques discovered** (beyond the checklist) — MCP `write_author_discovery(author_slug, section="style_principles", text=<technique>, book_slug=<analyzed-work-slug>, genres=<source_genres from Phase 1>)`
 - **Anti-patterns to avoid** — MCP `write_author_banned_phrase(author_slug, phrase, reason=<why-avoid>)` per phrase
 - **Preferred Words / Deliberate Imperfections** — Direct Write to `~/.storyforge/authors/{slug}/vocabulary.md` (no MCP tool for these sections)
 

--- a/tests/author/test_discovery_writer.py
+++ b/tests/author/test_discovery_writer.py
@@ -1,18 +1,11 @@
-"""Tests for ``tools.author.discovery_writer`` (Issue #151).
+"""Tests for ``tools.author.discovery_writer``.
 
-Two write paths:
+Covers ``remove_book_rule_after_promotion`` — the cleanup path after a rule
+has been promoted from a book CLAUDE.md to the author profile.
 
-- ``write_discovery`` — append an entry to ``profile.md`` under
-  ``## Writing Discoveries`` → matching sub-section. Idempotent: if the entry
-  already exists, append an additional origin tag instead of duplicating.
-- ``write_banned_phrase_via_vocabulary`` — a thin wrapper around
-  ``tools.rule_writer.write_author_rule`` so the harvest skill has a single
-  call surface for all promotions.
-
-Plus the cleanup half:
-
-- ``remove_book_rule_after_promotion`` — removes a rule from a book CLAUDE.md
-  once it's been promoted, optionally leaving a "promoted" note bullet.
+Note: The old ``write_discovery`` Markdown write path was removed in Phase 5
+(#283). Writing Discoveries now go through the ``write_author_discovery`` MCP
+tool which persists to the author_discoveries SQLite table (Issue #281).
 """
 
 from __future__ import annotations
@@ -21,212 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from tools.author.discovery_writer import (
-    AlreadyPresent,
-    SectionMissing,
-    write_discovery,
-)
-
-
-_PROFILE_WITH_DISCOVERIES = """\
----
-name: "Ethan Cole"
-slug: "ethan-cole"
-primary_genres: ["dark-fantasy"]
-narrative_voice: "third-limited"
-tense: "past"
-tone: ["brooding"]
----
-
-# Ethan Cole
-
-## Writing Style
-
-Dark and lean.
-
-## Writing Discoveries
-
-*Insights that emerged across books.*
-
-### Recurring Tics
-
-_Frei._
-
-### Style Principles
-
-_Frei._
-
-### Don'ts (beyond banned phrases)
-
-_Frei._
-"""
-
-
-_PROFILE_WITHOUT_DISCOVERIES = """\
----
-name: "Ethan Cole"
-slug: "ethan-cole"
----
-
-# Ethan Cole
-
-## Writing Style
-
-Dark.
-"""
-
-
-@pytest.fixture
-def author_dir(tmp_path: Path) -> Path:
-    d = tmp_path / "ethan-cole"
-    d.mkdir()
-    (d / "profile.md").write_text(_PROFILE_WITH_DISCOVERIES, encoding="utf-8")
-    return d
-
-
-# ---------------------------------------------------------------------------
-# write_discovery — recurring_tics
-# ---------------------------------------------------------------------------
-
-
-class TestWriteDiscovery:
-    def test_appends_recurring_tic_with_origin_tag(self, author_dir: Path):
-        result = write_discovery(
-            profile_path=author_dir / "profile.md",
-            section="recurring_tics",
-            text='**"math" as analytical metaphor** — cut on sight unless POV demands.',
-            book_slug="firelight",
-            year_month="2026-05",
-        )
-        assert result.written is True
-
-        content = (author_dir / "profile.md").read_text(encoding="utf-8")
-        assert '**"math" as analytical metaphor**' in content
-        assert "_(emerged from firelight, 2026-05)_" in content
-        # Placeholder must be removed when first real entry lands.
-        recurring_section = _section_body(content, "Recurring Tics")
-        assert "_Frei._" not in recurring_section
-
-    def test_appends_to_style_principles(self, author_dir: Path):
-        write_discovery(
-            profile_path=author_dir / "profile.md",
-            section="style_principles",
-            text="Fast dialog without tags works up to ~8 turns.",
-            book_slug="firelight",
-            year_month="2026-05",
-        )
-        content = (author_dir / "profile.md").read_text(encoding="utf-8")
-        principles = _section_body(content, "Style Principles")
-        assert "Fast dialog" in principles
-        # Recurring Tics section must NOT be touched.
-        assert "_Frei._" in _section_body(content, "Recurring Tics")
-
-    def test_appends_to_donts(self, author_dir: Path):
-        write_discovery(
-            profile_path=author_dir / "profile.md",
-            section="donts",
-            text="Never start a chapter with weather.",
-            book_slug="firelight",
-            year_month="2026-05",
-        )
-        content = (author_dir / "profile.md").read_text(encoding="utf-8")
-        assert "weather" in _section_body(content, "Don'ts")
-
-    def test_idempotent_when_entry_already_present_returns_already(self, author_dir: Path):
-        write_discovery(
-            profile_path=author_dir / "profile.md",
-            section="recurring_tics",
-            text='**"math" as analytical metaphor** — cut on sight.',
-            book_slug="firelight",
-            year_month="2026-05",
-        )
-        result = write_discovery(
-            profile_path=author_dir / "profile.md",
-            section="recurring_tics",
-            text='**"math" as analytical metaphor** — cut on sight.',
-            book_slug="firelight",
-            year_month="2026-05",
-        )
-        assert isinstance(result, AlreadyPresent)
-        # No duplicate — only one origin tag for the same book.
-        content = (author_dir / "profile.md").read_text(encoding="utf-8")
-        assert content.count("_(emerged from firelight, 2026-05)_") == 1
-
-    def test_recurring_in_second_book_appends_extra_origin_tag(self, author_dir: Path):
-        """When a discovery resurfaces in a new book, append a second origin tag."""
-        write_discovery(
-            profile_path=author_dir / "profile.md",
-            section="recurring_tics",
-            text='**"math" as analytical metaphor** — cut on sight.',
-            book_slug="firelight",
-            year_month="2026-05",
-        )
-        result = write_discovery(
-            profile_path=author_dir / "profile.md",
-            section="recurring_tics",
-            text='**"math" as analytical metaphor** — cut on sight.',
-            book_slug="emberkeep",
-            year_month="2026-09",
-        )
-        # Second write to same text but new book → not "AlreadyPresent" because
-        # the new origin tag IS new information.
-        assert result.written is True
-        content = (author_dir / "profile.md").read_text(encoding="utf-8")
-        assert "_(emerged from firelight, 2026-05)_" in content
-        assert "_(emerged from emberkeep, 2026-09)_" in content
-        # Still only ONE bullet — both tags stacked on the same entry.
-        recurring_section = _section_body(content, "Recurring Tics")
-        bullet_count = sum(1 for line in recurring_section.splitlines() if line.strip().startswith("- "))
-        assert bullet_count == 1
-
-    def test_rejects_unknown_section(self, author_dir: Path):
-        with pytest.raises(ValueError):
-            write_discovery(
-                profile_path=author_dir / "profile.md",
-                section="unknown_bucket",
-                text="x",
-                book_slug="firelight",
-                year_month="2026-05",
-            )
-
-    def test_raises_when_writing_discoveries_section_missing(self, tmp_path: Path):
-        legacy = tmp_path / "old-author"
-        legacy.mkdir()
-        (legacy / "profile.md").write_text(_PROFILE_WITHOUT_DISCOVERIES, encoding="utf-8")
-
-        with pytest.raises(SectionMissing):
-            write_discovery(
-                profile_path=legacy / "profile.md",
-                section="recurring_tics",
-                text="x",
-                book_slug="firelight",
-                year_month="2026-05",
-            )
-
-    def test_creates_subsection_if_missing(self, tmp_path: Path):
-        """A profile with `## Writing Discoveries` but no `### Recurring Tics`
-        sub-heading should auto-create the sub-heading + bullet."""
-        d = tmp_path / "ethan-cole"
-        d.mkdir()
-        (d / "profile.md").write_text(
-            "---\nname: x\n---\n\n# x\n\n## Writing Discoveries\n\n_Frei._\n",
-            encoding="utf-8",
-        )
-        write_discovery(
-            profile_path=d / "profile.md",
-            section="recurring_tics",
-            text="**foo** — bar.",
-            book_slug="firelight",
-            year_month="2026-05",
-        )
-        content = (d / "profile.md").read_text(encoding="utf-8")
-        assert "### Recurring Tics" in content
-        assert "**foo**" in content
-
-
-# ---------------------------------------------------------------------------
-# remove_book_rule_after_promotion
-# ---------------------------------------------------------------------------
+from tools.author.discovery_writer import remove_book_rule_after_promotion
 
 
 _BOOK_CLAUDEMD = """\
@@ -241,133 +29,11 @@ _BOOK_CLAUDEMD = """\
 """
 
 
-# ---------------------------------------------------------------------------
-# write_discovery — example block (Issue #268)
-# ---------------------------------------------------------------------------
-
-
-class TestWriteDiscoveryExample:
-    def test_example_stored_as_blockquote_block(self, author_dir: Path):
-        write_discovery(
-            profile_path=author_dir / "profile.md",
-            section="style_principles",
-            text="**Short-register under pressure** — short, trust-based exchanges.",
-            book_slug="firelight",
-            year_month="2026-06",
-            example='"Get up."\n"In a minute."\n"Now."\nKael looked at him. Got up.',
-        )
-        content = (author_dir / "profile.md").read_text(encoding="utf-8")
-        principles = _section_body(content, "Style Principles")
-        assert "`example:`" in principles
-        assert '> "Get up."' in principles
-        assert "_(emerged from firelight, 2026-06)_" in principles
-
-    def test_example_only_for_style_principles(self, author_dir: Path):
-        write_discovery(
-            profile_path=author_dir / "profile.md",
-            section="recurring_tics",
-            text='**"math"** — analytical tic, cut on sight.',
-            book_slug="firelight",
-            year_month="2026-06",
-            example="Some example that should be ignored.",
-        )
-        content = (author_dir / "profile.md").read_text(encoding="utf-8")
-        tics = _section_body(content, "Recurring Tics")
-        assert "`example:`" not in tics
-
-    def test_idempotent_with_example(self, author_dir: Path):
-        for _ in range(2):
-            write_discovery(
-                profile_path=author_dir / "profile.md",
-                section="style_principles",
-                text="**Short-register under pressure** — trust-based.",
-                book_slug="firelight",
-                year_month="2026-06",
-                example='"Get up." / "Now."',
-            )
-        content = (author_dir / "profile.md").read_text(encoding="utf-8")
-        assert content.count("`example:`") == 1
-
-    def test_example_blockquote_prefix_applied(self, author_dir: Path):
-        write_discovery(
-            profile_path=author_dir / "profile.md",
-            section="style_principles",
-            text="**Short-register** — trust-based.",
-            book_slug="firelight",
-            year_month="2026-06",
-            example="Get up.\nIn a minute.",
-        )
-        content = (author_dir / "profile.md").read_text(encoding="utf-8")
-        assert "  > Get up." in content
-        assert "  > In a minute." in content
-
-
-class TestWriteDiscoveryGenres:
-    """Issue #266 — genre-tagging via `when:` field on style_principles."""
-
-    def test_genres_stored_as_when_block(self, author_dir: Path):
-        write_discovery(
-            profile_path=author_dir / "profile.md",
-            section="style_principles",
-            text="**Banter density** — 4–6 turns per scene with a partner.",
-            book_slug="fractured-doors",
-            year_month="2026-06",
-            genres=["light-fantasy", "comedy-fantasy"],
-        )
-        content = (author_dir / "profile.md").read_text(encoding="utf-8")
-        principles = _section_body(content, "Style Principles")
-        assert "`when: light-fantasy, comedy-fantasy`" in principles
-
-    def test_genres_only_for_style_principles(self, author_dir: Path):
-        write_discovery(
-            profile_path=author_dir / "profile.md",
-            section="recurring_tics",
-            text='**"math"** — analytical tic.',
-            book_slug="firelight",
-            year_month="2026-06",
-            genres=["dark-fantasy"],
-        )
-        content = (author_dir / "profile.md").read_text(encoding="utf-8")
-        tics = _section_body(content, "Recurring Tics")
-        assert "`when:" not in tics
-
-    def test_genres_and_example_combined(self, author_dir: Path):
-        write_discovery(
-            profile_path=author_dir / "profile.md",
-            section="style_principles",
-            text="**Banter density** — 4–6 turns.",
-            book_slug="fractured-doors",
-            year_month="2026-06",
-            example='"You\'re impossible." / "I know."',
-            genres=["light-fantasy"],
-        )
-        content = (author_dir / "profile.md").read_text(encoding="utf-8")
-        principles = _section_body(content, "Style Principles")
-        assert "`when: light-fantasy`" in principles
-        assert "`example:`" in principles
-        assert '> "You\'re impossible."' in principles
-
-    def test_idempotent_with_genres(self, author_dir: Path):
-        for _ in range(2):
-            write_discovery(
-                profile_path=author_dir / "profile.md",
-                section="style_principles",
-                text="**Banter density** — 4–6 turns.",
-                book_slug="fractured-doors",
-                year_month="2026-06",
-                genres=["light-fantasy"],
-            )
-        content = (author_dir / "profile.md").read_text(encoding="utf-8")
-        assert content.count("`when: light-fantasy`") == 1
-
-
 class TestRemoveBookRuleAfterPromotion:
     """Cleanup half: when the user accepts a promotion, the original rule
     should optionally disappear from the book CLAUDE.md."""
 
     def test_removes_matched_rule(self, tmp_path: Path):
-        from tools.author.discovery_writer import remove_book_rule_after_promotion
-
         book_dir = tmp_path / "firelight"
         book_dir.mkdir()
         (book_dir / "CLAUDE.md").write_text(_BOOK_CLAUDEMD, encoding="utf-8")
@@ -384,8 +50,6 @@ class TestRemoveBookRuleAfterPromotion:
         assert "Pattern" in content
 
     def test_keeps_rule_with_promoted_note(self, tmp_path: Path):
-        from tools.author.discovery_writer import remove_book_rule_after_promotion
-
         book_dir = tmp_path / "firelight"
         book_dir.mkdir()
         (book_dir / "CLAUDE.md").write_text(_BOOK_CLAUDEMD, encoding="utf-8")
@@ -401,19 +65,3 @@ class TestRemoveBookRuleAfterPromotion:
         content = (book_dir / "CLAUDE.md").read_text(encoding="utf-8")
         assert "Math metaphor" in content
         assert "promoted to author profile" in content.lower()
-
-
-# ---------------------------------------------------------------------------
-# helpers
-# ---------------------------------------------------------------------------
-
-
-def _section_body(content: str, heading: str) -> str:
-    """Return the body text under `### {heading}` up to the next heading."""
-    import re
-    pat = re.compile(
-        rf"^###\s+{re.escape(heading)}.*?$(.*?)(?=^###?\s|\Z)",
-        re.MULTILINE | re.DOTALL | re.IGNORECASE,
-    )
-    m = pat.search(content)
-    return m.group(1) if m else ""

--- a/tools/author/discovery_writer.py
+++ b/tools/author/discovery_writer.py
@@ -1,25 +1,17 @@
-"""Write Writing Discoveries to ``profile.md`` and clean up book CLAUDE.md (Issue #151).
+"""Post-promotion cleanup helpers for author-profile and book CLAUDE.md.
 
-Two write paths:
+``remove_book_rule_after_promotion`` — once a rule has been promoted to the
+author profile, the user can choose to remove it from the book CLAUDE.md
+(``mode="remove"``) or leave it with a "promoted to author profile" annotation
+(``mode="annotate"``).
 
-- ``write_discovery`` — append/extend an entry under ``## Writing Discoveries``
-  → ``### {Recurring Tics | Style Principles | Don'ts}``. Idempotent: if the
-  entry text already exists, append an additional origin tag instead of
-  duplicating the bullet. This implements the "second-origin-tag-on-recurrence"
-  rule from Issue #151.
-
-- ``remove_book_rule_after_promotion`` — once a rule has been promoted to the
-  author profile, the user can choose to remove it from the book CLAUDE.md
-  (``mode="remove"``) or leave it with a "promoted to author profile" annotation
-  (``mode="annotate"``).
-
-The discovery_writer does NOT handle banned-phrase promotions — those go via
-``tools.rule_writer.write_author_rule`` which already writes to ``vocabulary.md``.
+Writing Discoveries are now persisted to the ``author_discoveries`` SQLite table
+via ``write_author_discovery`` in the MCP router (Issue #281). The old
+``write_discovery`` Markdown write path was removed in Phase 5 (#283).
 """
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
@@ -27,9 +19,7 @@ from pathlib import Path
 from tools.claudemd.rules_editor import MarkersNotFoundError
 
 # ---------------------------------------------------------------------------
-# CLAUDE.md RULES-block helpers (moved here from rules_editor in Phase 4;
-# remove_book_rule_after_promotion still uses the legacy marker format for
-# pre-migration books — harvest-author-rules will be updated in Phase 5).
+# CLAUDE.md RULES-block helpers
 # ---------------------------------------------------------------------------
 
 _RULES_START = "<!-- RULES:START -->"
@@ -80,50 +70,7 @@ def _serialize_block(bodies: list[str]) -> str:
 # Public types
 # ---------------------------------------------------------------------------
 
-
 VALID_SECTIONS: tuple[str, ...] = ("recurring_tics", "style_principles", "donts")
-
-_SECTION_HEADERS: dict[str, str] = {
-    "recurring_tics": "### Recurring Tics",
-    "style_principles": "### Style Principles",
-    "donts": "### Don'ts (beyond banned phrases)",
-}
-
-# Placeholder bullet used in fresh templates. Removed when the first real
-# entry lands so the section doesn't carry "_Frei._" alongside real content.
-_PLACEHOLDER_RE = re.compile(r"^_(?:frei|free|empty|tba|tbd)\.?_\s*$", re.IGNORECASE)
-
-# Origin tag written by `write_discovery`. Format kept identical to the
-# parser in `tools/state/parsers.py` so the round-trip is lossless.
-_ORIGIN_TAG_RE = re.compile(
-    r"_\(\s*emerged\s+from\s+(?P<book>[a-z0-9][a-z0-9_-]*)\s*,\s*(?P<date>\d{4}-\d{2})\s*\)_",
-    re.IGNORECASE,
-)
-
-
-class SectionMissing(Exception):
-    """Raised when the profile lacks a ``## Writing Discoveries`` section.
-
-    The skill catches this and offers to migrate the profile (insert the
-    template section) before retrying.
-    """
-
-
-@dataclass
-class WriteResult:
-    written: bool
-    path: Path
-    message: str
-
-
-@dataclass
-class AlreadyPresent:
-    """Idempotent no-op result. The discovery + this exact origin tag are
-    already in the profile."""
-
-    written: bool
-    path: Path
-    message: str
 
 
 @dataclass
@@ -132,238 +79,6 @@ class RemovalResult:
     annotated: bool
     path: Path
     message: str
-
-
-# ---------------------------------------------------------------------------
-# write_discovery
-# ---------------------------------------------------------------------------
-
-
-_DISCOVERIES_SECTION_RE = re.compile(
-    r"^##\s+Writing\s+Discoveries\s*$",
-    re.MULTILINE | re.IGNORECASE,
-)
-
-
-def write_discovery(
-    *,
-    profile_path: Path,
-    section: str,
-    text: str,
-    book_slug: str,
-    year_month: str,
-    example: str = "",
-    genres: list[str] | None = None,
-) -> WriteResult | AlreadyPresent:
-    """Append a discovery to ``profile.md`` under the matching sub-section.
-
-    Args:
-        profile_path: Path to the author's ``profile.md``.
-        section: One of ``recurring_tics``, ``style_principles``, ``donts``.
-        text: Entry body (single line), e.g. ``**"math"** — cut on sight.``.
-            The origin tag is appended automatically.
-        book_slug: Book the discovery emerged from (used in the origin tag).
-        year_month: ``YYYY-MM`` date stamp (used in the origin tag).
-        example: Optional prose or dialogue demonstration of the principle.
-            Stored as a blockquote block under the entry. Only valid for
-            ``style_principles`` — silently ignored for other sections.
-        genres: Optional list of genre slugs (Issue #266). Stored as a
-            `` `when: genre1, genre2` `` line. Only valid for
-            ``style_principles`` — silently ignored for other sections.
-            Entries without genres are treated as universal by chapter-writer.
-
-    Returns either ``WriteResult(written=True)`` on a real change, or
-    ``AlreadyPresent`` when the entry plus the *same* origin tag already exist
-    (true idempotent). When the same entry text exists but with a different
-    origin, the new origin tag is appended to the existing bullet — counted
-    as ``written=True`` because the new tag IS new information.
-
-    Raises:
-        ValueError: ``section`` is not in ``VALID_SECTIONS``.
-        SectionMissing: ``profile.md`` has no ``## Writing Discoveries`` section.
-        FileNotFoundError: ``profile.md`` does not exist.
-    """
-    if section not in VALID_SECTIONS:
-        raise ValueError(f"Invalid section: {section}. Valid: {VALID_SECTIONS}")
-
-    if not profile_path.is_file():
-        raise FileNotFoundError(f"Profile not found: {profile_path}")
-
-    content = profile_path.read_text(encoding="utf-8")
-    if not _DISCOVERIES_SECTION_RE.search(content):
-        raise SectionMissing(
-            f"profile.md has no '## Writing Discoveries' section. "
-            f"Add the template scaffold first: {profile_path}"
-        )
-
-    new_origin_tag = _format_origin_tag(book_slug, year_month)
-    sub_heading = _SECTION_HEADERS[section]
-
-    # Locate the sub-section. If missing, create it inside the Writing
-    # Discoveries section.
-    sub_section_match = re.search(
-        rf"^{re.escape(sub_heading)}\s*$",
-        content,
-        re.MULTILINE,
-    )
-    if sub_section_match is None:
-        content = _create_subsection(content, sub_heading)
-        sub_section_match = re.search(
-            rf"^{re.escape(sub_heading)}\s*$",
-            content,
-            re.MULTILINE,
-        )
-        assert sub_section_match is not None  # we just inserted it
-
-    # Slice out the sub-section body up to the next H3 / H2 / EOF.
-    sub_start = sub_section_match.end()
-    next_header = re.search(r"^##\s|^###\s", content[sub_start:], re.MULTILINE)
-    sub_end = sub_start + next_header.start() if next_header else len(content)
-    sub_body = content[sub_start:sub_end]
-
-    normalized_text = _normalize_entry_text(text)
-
-    # Walk existing bullets in the sub-section. If we find a bullet whose
-    # core text matches the candidate, either skip (origin tag already there)
-    # or append the new origin tag.
-    bullet_match, body_text, body_origins = _find_matching_bullet(sub_body, normalized_text)
-    if bullet_match is not None:
-        if any(_origin_matches(o, book_slug, year_month) for o in body_origins):
-            return AlreadyPresent(
-                written=False,
-                path=profile_path,
-                message=f"Discovery already present with this origin: {profile_path}",
-            )
-        # Append new origin tag to the existing bullet.
-        new_bullet = bullet_match.group(0).rstrip() + f" {new_origin_tag}\n"
-        new_sub_body = sub_body[: bullet_match.start()] + new_bullet + sub_body[bullet_match.end() :]
-    else:
-        # Append new bullet. Strip placeholder if present.
-        new_sub_body = _strip_placeholder(sub_body)
-        use_multiline = section == "style_principles" and (example.strip() or genres)
-        if use_multiline:
-            bullet = _format_multiline_bullet(
-                text, new_origin_tag,
-                example=example if section == "style_principles" else "",
-                genres=genres if section == "style_principles" else None,
-            )
-        else:
-            bullet = f"- {text.strip()} {new_origin_tag}"
-        if not new_sub_body.endswith("\n"):
-            new_sub_body += "\n"
-        new_sub_body += bullet + "\n"
-
-    new_content = content[:sub_start] + new_sub_body + content[sub_end:]
-    profile_path.write_text(new_content, encoding="utf-8")
-    return WriteResult(
-        written=True,
-        path=profile_path,
-        message=f"Discovery written to {profile_path}",
-    )
-
-
-def _format_origin_tag(book_slug: str, year_month: str) -> str:
-    return f"_(emerged from {book_slug}, {year_month})_"
-
-
-def _format_multiline_bullet(
-    text: str,
-    origin_tag: str,
-    *,
-    example: str = "",
-    genres: list[str] | None = None,
-) -> str:
-    """Format a multi-line style_principles bullet with optional blocks.
-
-    Output format (all optional blocks shown)::
-
-        - **Principle** — description
-          `when: genre1, genre2`
-          `example:`
-          > line 1
-          _(emerged from book, YYYY-MM)_
-    """
-    lines = [f"- {text.strip()}"]
-    if genres:
-        lines.append(f"  `when: {', '.join(genres)}`")
-    if example:
-        lines.append("  `example:`")
-        for ln in example.strip().splitlines():
-            stripped = ln.strip()
-            if stripped.startswith("> "):
-                lines.append(f"  {stripped}")
-            else:
-                lines.append(f"  > {stripped}")
-    lines.append(f"  {origin_tag}")
-    return "\n".join(lines)
-
-
-def _origin_matches(origin: dict[str, str], book_slug: str, year_month: str) -> bool:
-    return origin["book"].lower() == book_slug.lower() and origin["date"] == year_month
-
-
-def _normalize_entry_text(text: str) -> str:
-    """Normalize entry text for duplicate detection.
-
-    Strips origin tags, collapses whitespace, lowercases. Keeps the bold
-    title intact so `**math**` matches `**math**`.
-    """
-    cleaned = _ORIGIN_TAG_RE.sub("", text)
-    cleaned = re.sub(r"\s+", " ", cleaned).strip().lower()
-    return cleaned
-
-
-def _find_matching_bullet(
-    sub_body: str,
-    normalized_target: str,
-) -> tuple[re.Match[str] | None, str, list[dict[str, str]]]:
-    """Find a bullet in ``sub_body`` whose normalized first line matches the target.
-
-    Captures multi-line bullets (including example blocks) by matching up to
-    the next ``- `` bullet or end of body.
-
-    Returns ``(match, first_line_body, origins)`` or ``(None, "", [])``.
-    """
-    # Match a bullet + all its continuation lines up to the next bullet or EOF.
-    bullet_re = re.compile(r"^(-\s+.+?)(?=^-\s|\Z)", re.MULTILINE | re.DOTALL)
-    for match in bullet_re.finditer(sub_body):
-        full_bullet = match.group(0)
-        first_line = full_bullet.splitlines()[0]
-        body = first_line[2:].strip()  # strip leading "- "
-        normalized_existing = _normalize_entry_text(body)
-        if normalized_existing == normalized_target:
-            origins = [
-                {"book": m.group("book"), "date": m.group("date")}
-                for m in _ORIGIN_TAG_RE.finditer(full_bullet)
-            ]
-            return match, body, origins
-    return None, "", []
-
-
-def _strip_placeholder(sub_body: str) -> str:
-    """Remove a `_Frei._` (or similar) placeholder line from the sub-section."""
-    lines = sub_body.splitlines(keepends=True)
-    filtered = [ln for ln in lines if not _PLACEHOLDER_RE.match(ln.strip())]
-    out = "".join(filtered)
-    # Collapse 3+ consecutive newlines that may result.
-    out = re.sub(r"\n{3,}", "\n\n", out)
-    return out
-
-
-def _create_subsection(content: str, sub_heading: str) -> str:
-    """Insert a missing sub-heading at the end of the Writing Discoveries section."""
-    section_match = _DISCOVERIES_SECTION_RE.search(content)
-    if section_match is None:
-        # Caller must already have checked this — defensive guard.
-        raise SectionMissing("Writing Discoveries section missing")
-
-    # Find end of Writing Discoveries section (next ## or EOF).
-    after_section = content[section_match.end():]
-    next_h2 = re.search(r"^##\s", after_section, re.MULTILINE)
-    insertion_point = section_match.end() + (next_h2.start() if next_h2 else len(after_section))
-
-    insertion = f"\n{sub_heading}\n\n"
-    return content[:insertion_point].rstrip() + "\n\n" + insertion + content[insertion_point:].lstrip()
 
 
 # ---------------------------------------------------------------------------
@@ -435,12 +150,8 @@ def remove_book_rule_after_promotion(
 
 
 __all__ = [
-    "AlreadyPresent",
     "MarkersNotFoundError",
     "RemovalResult",
-    "SectionMissing",
     "VALID_SECTIONS",
-    "WriteResult",
     "remove_book_rule_after_promotion",
-    "write_discovery",
 ]

--- a/tools/state/indexer.py
+++ b/tools/state/indexer.py
@@ -1,7 +1,14 @@
-"""State indexer for StoryForge — builds and maintains the state cache.
+"""State indexer for StoryForge — builds and maintains the filesystem index.
 
-Scans the content directory for books, chapters, characters, and authors,
-then writes a consolidated state.json for fast MCP tool queries.
+Scans the content directory for books, chapters, characters, series, and authors,
+reading YAML frontmatter only. Writes a consolidated state.json used by MCP tools
+for list/get operations.
+
+Scope (Phase 5 / Issue #283):
+Structured data (Writing Discoveries, character snapshots, book rules, canon facts,
+sessions) is owned by SQLite and always current — the indexer does not need to
+re-derive those. rebuild_state() is now a lightweight filesystem rescan: it tells
+you which books/authors exist and their basic metadata, nothing more.
 """
 
 from __future__ import annotations

--- a/tools/state/parsers.py
+++ b/tools/state/parsers.py
@@ -1,4 +1,17 @@
-"""Markdown and YAML frontmatter parsers for StoryForge project files."""
+"""Markdown and YAML frontmatter parsers for StoryForge project files.
+
+Scope (Phase 5 / Issue #283):
+- Book, chapter, character, series, and person file parsing (YAML frontmatter)
+- Status normalization and rank helpers
+- Word counting and book-status derivation from chapter aggregates
+
+NOT in scope — these live in SQLite (Issues #280–#282):
+- Writing Discoveries (author_discoveries table)
+- Character snapshots (character_snapshots table)
+- Book rules / callbacks (book_rules table)
+- Sessions (sessions table)
+- Canon facts (canon_facts table)
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

- **Removes dead Markdown write path** — `write_discovery()` and 8 helpers in `discovery_writer.py` were replaced by SQLite in Phase 3 (#281). The MCP router already calls `insert_discovery()` directly; this path had zero callers. 16 test classes covering it are removed alongside it (−673 lines net).
- **Adds `source_genres` to the study-author pipeline** — Phase 1 now captures which genre(s) the analyzed text belongs to. The value is stored in `analysis-{book_slug}.md` frontmatter as `source_genres: "slug1, slug2"` and passed as `genres=` to every `write_author_discovery()` call in Phase 4. This lets `chapter-writer` and `author-check` skip genre-specific style_principles when writing in a different-genre book.
- **New `migrate-source-genres` skill** — Backfills `source_genres` on `author_discoveries` DB rows created before Phase 5, by reading `source_genres:` / legacy `genres:` from existing `analysis-*.md` frontmatter and calling `update_discovery_metadata()`.
- **`migrate_book_rules.py` fix** — Script now scans `series/*/` directories (Phase 1 restructured all books from `projects/` into `series/{slug}/{book}/`). Added dedup on collected slugs.
- **Scope docstrings** — `parsers.py` and `indexer.py` get scope clarifications: Writing Discoveries, character snapshots, book rules, sessions, and canon facts are SQLite-owned; the filesystem index covers books/chapters/characters/series only.

## Files Changed

| File | Change |
|------|--------|
| `tools/author/discovery_writer.py` | Remove `write_discovery()` + helpers; keep `remove_book_rule_after_promotion()` |
| `tests/author/test_discovery_writer.py` | Remove 16 dead test classes; keep 2 tests for remaining function |
| `skills/study-author/SKILL.md` | Add Phase 1 Steps 3–4 (registry check + source_genres capture); update Phase 3 frontmatter template; pass `genres=` in Phase 4 |
| `skills/backfill-style-principles/SKILL.md` | Prefer `source_genres:` field, fallback to legacy `genres:` |
| `skills/migrate-source-genres/SKILL.md` | New skill — 4-step source_genres backfill via `update_discovery_metadata()` |
| `tools/state/parsers.py` | Scope docstring: clarify SQLite data is excluded |
| `tools/state/indexer.py` | Scope docstring: `rebuild_state()` is a lightweight filesystem rescan |
| `scripts/migrate_book_rules.py` | Scan `series/*/` + dedup collected slugs |

## Test Plan

- [x] `pytest tests/author/test_discovery_writer.py` — 2 tests passing (removed dead tests, kept live ones)
- [x] `pytest tests/smoke/` — 12/12 passing
- [x] Full suite: 2026 passed, 4 pre-existing hook failures (unrelated to this PR — already failing on `main` before Phase 5)
- [x] `scripts/migrate_book_rules.py --dry-run` executed successfully on BaB: Firelight (11 rules, 2 callbacks, 1 workflow found in `series/` path)
- [x] `scripts/migrate_book_rules.py --clear-markers` ran successfully — DB populated, CLAUDE.md marker content cleared

## Related

- Closes #283
- Part of #278 (SQLite + Series Architecture refactor)
- Depends on: #285 (schema), #286 (author_discoveries), #287 (book_rules) — all merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)