### PR TITLE
chore: fix stale CLAUDE.md storage references in skills after #282 DB migration

### DIFF
--- a/servers/storyforge-server/routers/chapters.py
+++ b/servers/storyforge-server/routers/chapters.py
@@ -205,8 +205,8 @@ def get_chapter_writing_brief(book_slug: str, chapter_slug: str) -> str:
           items with source pointers; extraction_method ∈ {frontmatter,
           timeline_regex, draft_heuristic, none}; warnings surface gaps
           so the writer asks instead of inventing — Issue #157)
-        - rules_to_honor (book CLAUDE.md ## Rules with severity)
-        - callbacks_in_register (book CLAUDE.md ## Callback Register)
+        - rules_to_honor (book_rules DB rule entries with severity)
+        - callbacks_in_register (book_rules DB callback entries)
         - banned_phrases (deduplicated book + author + global banlist)
         - recent_simile_count_per_chapter
         - tone_litmus_questions (from plot/tone.md if present)
@@ -261,8 +261,8 @@ def get_review_brief(book_slug: str, chapter_slug: str) -> str:
         travel_matrix           — parsed world/setting.md Travel Matrix rows
         canon_log_facts         — parsed plot/canon-log.md Established Facts
         tonal_rules             — non-negotiable rules, litmus, banned patterns
-        active_rules            — book CLAUDE.md ## Rules with severity
-        active_callbacks        — book CLAUDE.md ## Callback Register items
+        active_rules            — book_rules DB (rule_type: rule) with severity
+        active_callbacks        — book_rules DB (rule_type: callback)
         errors                  — partial failures (brief ships with degraded data)
     """
     book_root = resolve_project_path(_app.load_config(), book_slug)

--- a/skills/chapter-reviewer-memoir/SKILL.md
+++ b/skills/chapter-reviewer-memoir/SKILL.md
@@ -37,8 +37,8 @@ Call MCP `get_review_brief(book_slug, chapter_slug)`. This returns:
 - `canon_log_facts` — empty for memoir; use `people-log` instead
 - `consent_status_warnings` — people with non-approved consent status
 - `tonal_rules` — non-negotiable rules, litmus test, banned patterns from `plot/tone.md`
-- `active_rules` — book CLAUDE.md ## Rules with severity
-- `active_callbacks` — book CLAUDE.md ## Callback Register items
+- `active_rules` — book_rules DB (rule_type: rule) with severity
+- `active_callbacks` — book_rules DB (rule_type: callback)
 - `errors` — non-empty means some files missing; degrade gracefully, do not invent
 
 People facts are read from DB via `canon_brief` (Issue #297). `plot/people-log.md` is a legacy archive — use `get_canon_brief(book_slug, chapter_slug)` for the authoritative DB-backed fact list. Run `scripts/migrate_canon_log_to_db.py` on books whose people-log was not yet migrated.

--- a/skills/chapter-reviewer/SKILL.md
+++ b/skills/chapter-reviewer/SKILL.md
@@ -31,8 +31,8 @@ Call MCP `get_review_brief(book_slug, chapter_slug)`. This returns:
 - `travel_matrix` — parsed `world/setting.md` Travel Matrix rows
 - `canon_log_facts` — canon facts from DB (Issue #297; `plot/canon-log.md` no longer read by `get_review_brief`)
 - `tonal_rules` — non-negotiable rules, litmus test, banned patterns from `plot/tone.md`
-- `active_rules` — book CLAUDE.md ## Rules with severity
-- `active_callbacks` — book CLAUDE.md ## Callback Register items
+- `active_rules` — book_rules DB (rule_type: rule) with severity
+- `active_callbacks` — book_rules DB (rule_type: callback)
 - `errors` — non-empty means some files missing; degrade gracefully, do not invent
 
 Honor every populated field. Empty lists / null means "file missing — degrade gracefully."

--- a/skills/register-callback/SKILL.md
+++ b/skills/register-callback/SKILL.md
@@ -5,7 +5,7 @@ description: |
   Use when: (1) User types a line starting with `Regel:`, `Workflow:`, or `Callback:`,
   (2) User says "merke dir", "callback", "neue Regel", "ab jetzt immer",
   (3) User wants to persist a detail across sessions (e.g. "Gary soll wiederkommen").
-  The entry is appended to the book's CLAUDE.md and survives context compaction.
+  The entry is stored in the book_rules database and survives context compaction.
 model: claude-haiku-4-5
 user-invocable: true
 argument-hint: "<Regel|Workflow|Callback>: <text>"
@@ -41,7 +41,7 @@ Deterministic persistence of per-book context. No creativity needed — just ext
    - workflow → `append_book_workflow(book_slug, text)`
    - callback → `append_book_callback(book_slug, text)`
 
-5. **Confirm** — One-line confirmation: `✅ [kind] gespeichert in CLAUDE.md: "[text]"`
+5. **Confirm** — One-line confirmation: `✅ [kind] gespeichert in der Book-Rules-Datenbank: "[text]"`
 
 ## Batch Mode
 

--- a/skills/report-issue/SKILL.md
+++ b/skills/report-issue/SKILL.md
@@ -43,11 +43,11 @@ Ask (AskUserQuestion, up to 3 questions in one call):
 
 3. **Scope** — "Where should this rule apply?"
    Options:
-   - This book only — writes to book CLAUDE.md `## Rules`
+   - This book only — writes to book_rules DB
    - This author only — writes to author `vocabulary.md` (applies to all books by this author)
    - Global (all books, all authors) — writes to `reference/craft/anti-ai-patterns.md`
 
-For structural rules (walking order, POV boundary) that cannot be expressed as a phrase: scope defaults to book CLAUDE.md and severity to warn. Skip Step 4 (no scan).
+For structural rules (walking order, POV boundary) that cannot be expressed as a phrase: scope defaults to book_rules DB and severity to warn. Skip Step 4 (no scan).
 
 ## Step 4: Scan for Existing Occurrences
 
@@ -120,6 +120,6 @@ Rule added:
 ## Important Behavior
 
 - **Never blindly accept user's first phrasing.** If the regex is too broad (e.g. `"the"`) or the description is vague, ask for a more specific trigger. A rule that fires on everything is worse than no rule.
-- **Structural rules** (walking order, POV boundary) go in book CLAUDE.md as freeform rules, not phrase patterns. The manuscript-checker cannot scan them, but the skill prompts (chapter-writer, chapter-reviewer) will honor them.
+- **Structural rules** (walking order, POV boundary) go in book_rules DB as freeform rules, not phrase patterns. The manuscript-checker cannot scan them, but the skill prompts (chapter-writer, chapter-reviewer) will honor them.
 - **Dedup**: If the phrase already exists at the requested scope, report this and offer to escalate scope instead of adding a duplicate.
 - **Phase ordering**: Clarify first → scan → confirm → write. Never write without explicit confirmation.


### PR DESCRIPTION
## Summary

After PR #282 migrated rules/callbacks/workflows from CLAUDE.md HTML-marker blocks to the `book_rules` SQLite DB, several skills and docstrings still referred to the old storage location. This PR corrects all the stale text found during the #289-sprint audit.

### Changes

- **`register-callback`**: frontmatter description + step 5 confirmation updated from "gespeichert in CLAUDE.md" to "gespeichert in der Book-Rules-Datenbank"
- **`chapter-reviewer` + `chapter-reviewer-memoir`**: brief-field descriptions for `active_rules` and `active_callbacks` updated from "book CLAUDE.md ## Rules / Callback Register" to "book_rules DB (rule_type: ...)"
- **`report-issue`**: scope option label, structural-rule default text, and Important Behavior note updated to "book_rules DB" (Step 6 already called `append_book_rule` correctly — only the human-readable description was stale)
- **`chapters.py` docstrings**: `rules_to_honor`, `callbacks_in_register`, `active_rules`, `active_callbacks` descriptions updated to reflect DB source

### harvest-author-rules

The "-> profile.md" heading mentioned in the issue was already corrected in an earlier commit (Cluster C — PR #303). No action needed.

### Related: data pipeline bug filed as #304

`review_brief.py` and `chapter_writing_brief.py` still load `active_rules`/`active_callbacks` from CLAUDE.md markers (which are intentionally empty post-migration). This means the briefs return empty rule lists, so chapter-reviewer and chapter-writer silently ignore all DB-stored rules. That bug is tracked separately in #304 and requires test rewrites — it is out of scope for this text-only fix PR.

## Test plan

- [ ] Verify no skill logic was changed — diff is 100% text replacements in descriptions and docstrings
- [ ] Check that `register-callback` confirmation message reads correctly after a Regel:/Callback: entry
- [ ] Smoke tests: `pytest tests/smoke/ -q`

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)
