### PR TITLE
fix: read active_rules and callbacks from book_rules DB in brief assemblers

### DIFF
--- a/tests/state/test_chapter_writing_brief.py
+++ b/tests/state/test_chapter_writing_brief.py
@@ -11,7 +11,21 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
+import tools.db.connection as _db_conn
+from tools.db.book_rules import insert_rule
+from tools.db.connection import open_canon_db
 from tools.state.chapter_writing_brief import build_chapter_writing_brief
+
+
+@pytest.fixture()
+def db_dir(tmp_path, monkeypatch):
+    """Redirect DB_DIR to tmp_path/db so tests don't touch the real DB."""
+    d = tmp_path / "db"
+    d.mkdir()
+    monkeypatch.setattr(_db_conn, "DB_DIR", d)
+    return d
 
 
 # ---------------------------------------------------------------------------
@@ -196,21 +210,20 @@ class TestBriefAssemblyMinimal:
         assert "knowledge" in theo
         assert "forensics" in theo["knowledge"]["none"]
 
-    def test_rules_and_callbacks_from_claudemd(self, tmp_path):
+    def test_rules_and_callbacks_from_db(self, tmp_path, db_dir):
         book, plugin_root = _setup_book(tmp_path)
         _make_chapter(book, "01-intro", number=1, title="Intro", pov="Theo")
         _add_character(book, "theo", name="Theo")
-        _add_claudemd(
-            book,
-            rules=[
-                "Avoid passive voice",
-                "Banned phrase: `the kind of X that Y` — max 2 per chapter",
-            ],
-            callbacks=[
-                "Gary the cat — last seen Ch 9, weave back in",
-                "Jace's apartment plant — Theo never mentions",
-            ],
-        )
+
+        conn = open_canon_db("test-book")
+        insert_rule(conn, book_num=1, rule_type="rule", text="Avoid passive voice")
+        insert_rule(conn, book_num=1, rule_type="rule",
+                    text="Banned phrase: `the kind of X that Y` — max 2 per chapter")
+        insert_rule(conn, book_num=1, rule_type="callback",
+                    text="Gary the cat — last seen Ch 9, weave back in")
+        insert_rule(conn, book_num=1, rule_type="callback",
+                    text="Jace's apartment plant — Theo never mentions")
+        conn.close()
 
         brief = build_chapter_writing_brief(
             book_root=book,
@@ -313,7 +326,7 @@ class TestBriefAssemblyMinimal:
 
 
 class TestBriefGracefulDegrade:
-    def test_missing_claudemd_returns_empty_rules_and_callbacks(self, tmp_path):
+    def test_missing_claudemd_returns_empty_rules_and_callbacks(self, tmp_path, db_dir):
         book, plugin_root = _setup_book(tmp_path)
         _make_chapter(book, "01-intro", number=1, title="Intro", pov="Theo")
         _add_character(book, "theo", name="Theo")
@@ -390,11 +403,14 @@ class TestBriefGracefulDegrade:
 
 
 class TestBriefDeterminism:
-    def test_brief_round_trips_through_json(self, tmp_path):
+    def test_brief_round_trips_through_json(self, tmp_path, db_dir):
         book, plugin_root = _setup_book(tmp_path)
         _make_chapter(book, "01-intro", number=1, title="Intro", pov="Theo")
         _add_character(book, "theo", name="Theo")
-        _add_claudemd(book, rules=["Be terse"], callbacks=["Gary the cat"])
+        conn = open_canon_db("test-book")
+        insert_rule(conn, book_num=1, rule_type="rule", text="Be terse")
+        insert_rule(conn, book_num=1, rule_type="callback", text="Gary the cat")
+        conn.close()
 
         brief = build_chapter_writing_brief(
             book_root=book,
@@ -405,11 +421,14 @@ class TestBriefDeterminism:
         # No datetime, Path, or non-JSON values may leak into the brief.
         json.dumps(brief)
 
-    def test_brief_is_deterministic_across_calls(self, tmp_path):
+    def test_brief_is_deterministic_across_calls(self, tmp_path, db_dir):
         book, plugin_root = _setup_book(tmp_path)
         _make_chapter(book, "01-intro", number=1, title="Intro", pov="Theo")
         _add_character(book, "theo", name="Theo")
-        _add_claudemd(book, rules=["Be terse"], callbacks=["Gary"])
+        conn = open_canon_db("test-book")
+        insert_rule(conn, book_num=1, rule_type="rule", text="Be terse")
+        insert_rule(conn, book_num=1, rule_type="callback", text="Gary")
+        conn.close()
 
         brief_a = build_chapter_writing_brief(
             book_root=book,

--- a/tests/state/test_review_brief.py
+++ b/tests/state/test_review_brief.py
@@ -374,18 +374,24 @@ def test_build_review_brief_no_previous_for_first_chapter(tmp_path):
     assert result["previous_chapter_timeline"] is None
 
 
-def test_build_review_brief_active_rules_from_claudemd(tmp_path):
+def test_build_review_brief_active_rules_from_db(tmp_path, monkeypatch):
+    import tools.db.connection as _db_conn
+    from tools.db.book_rules import insert_rule
+    from tools.db.connection import get_db_slug_for_book, open_canon_db
+
+    db_dir = tmp_path / "db"
+    db_dir.mkdir()
+    monkeypatch.setattr(_db_conn, "DB_DIR", db_dir)
+
     book, slug = _make_book(tmp_path)
     _make_chapter(book, "01-opening", number=1)
-    (book / "CLAUDE.md").write_text(
-        "# Book Rules\n\n"
-        "## Rules\n\n"
-        "- Never contradict the canon log\n"
-        "- Always load the timeline before writing\n\n"
-        "## Callback Register\n\n"
-        "- Marcus must reveal his secret by Ch 10\n",
-        encoding="utf-8",
-    )
+
+    db_slug = get_db_slug_for_book(book)
+    conn = open_canon_db(db_slug)
+    insert_rule(conn, book_num=1, rule_type="rule", text="Never contradict the canon log")
+    insert_rule(conn, book_num=1, rule_type="rule", text="Always load the timeline before writing")
+    insert_rule(conn, book_num=1, rule_type="callback", text="Marcus must reveal his secret by Ch 10")
+    conn.close()
 
     result = build_review_brief(
         book_root=book,

--- a/tools/db/brief_helpers.py
+++ b/tools/db/brief_helpers.py
@@ -1,22 +1,40 @@
-"""Helpers to load canon_log_facts from DB — Issue #280, updated #291/#297.
+"""Helpers to load canon_log_facts and book_rules from DB — Issue #280/#304.
 
-Usage in brief assemblers (continuity_brief, review_brief):
-    from tools.db.brief_helpers import load_canon_facts_for_brief
+Usage in brief assemblers (continuity_brief, review_brief, chapter_writing_brief):
+    from tools.db.brief_helpers import (
+        load_canon_facts_for_brief,
+        load_rules_for_brief,
+        load_callbacks_for_brief,
+    )
     facts = load_canon_facts_for_brief(book_root)
+    rules = load_rules_for_brief(book_root)
+    callbacks = load_callbacks_for_brief(book_root)
     # book_num is auto-derived from README series_number (C1/H1 fix)
 
-Note: build_canon_brief() reads from DB exclusively (Issue #297 removed the MD
-read path). If the DB is empty, callers receive an empty list. Migrate existing
-canon-log.md / people-log.md content via scripts/migrate_canon_log_to_db.py.
+Note: both canon_facts and book_rules read from DB exclusively (Issue #291/#304).
+If the DB is empty, callers receive an empty list.
 """
 
 from __future__ import annotations
 
+import re
 import sqlite3
 from pathlib import Path
 
+from tools.db.book_rules import list_rules
 from tools.db.canon_facts import query_facts
 from tools.db.connection import get_book_num, get_db_slug_for_book, open_canon_db
+
+_BAN_CUE_RE = re.compile(
+    r"\b(banned|ban|avoid|never|don['']?t\s+use|do\s+not\s+use|limit|stop\s+using)\b",
+    re.IGNORECASE,
+)
+
+
+def _classify_rule(text: str) -> str:
+    if "`" in text and _BAN_CUE_RE.search(text):
+        return "block"
+    return "advisory"
 
 _ALL_CHAPTERS = 10**9  # sentinel: "all chapters written so far"
 
@@ -69,3 +87,41 @@ def _db_row_to_legacy_fact(row: dict) -> dict:
         "notes": row.get("old_value") or "",
         "domain": row.get("domain") or "",
     }
+
+
+def load_rules_for_brief(book_root: Path) -> list[dict]:
+    """Return rule-type entries from the book_rules DB for a brief.
+
+    Returns list of {"text": str, "severity": "block" | "advisory"}.
+    Empty list if DB is unreachable or empty.
+    """
+    book_num = get_book_num(book_root)
+    db_slug = get_db_slug_for_book(book_root)
+    try:
+        conn = open_canon_db(db_slug)
+        try:
+            rows = list_rules(conn, book_num=book_num, rule_type="rule")
+        finally:
+            conn.close()
+        return [{"text": r["text"], "severity": _classify_rule(r["text"])} for r in rows]
+    except (sqlite3.Error, OSError):
+        return []
+
+
+def load_callbacks_for_brief(book_root: Path) -> list[str]:
+    """Return callback-type entries from the book_rules DB for a brief.
+
+    Returns list of callback text strings.
+    Empty list if DB is unreachable or empty.
+    """
+    book_num = get_book_num(book_root)
+    db_slug = get_db_slug_for_book(book_root)
+    try:
+        conn = open_canon_db(db_slug)
+        try:
+            rows = list_rules(conn, book_num=book_num, rule_type="callback")
+        finally:
+            conn.close()
+        return [r["text"] for r in rows]
+    except (sqlite3.Error, OSError):
+        return []

--- a/tools/state/chapter_writing_brief.py
+++ b/tools/state/chapter_writing_brief.py
@@ -39,12 +39,8 @@ from tools.state.loaders.chapter_meta import (
     load_chapter_meta,
     serialize_chapter_meta,
 )
-from tools.state.loaders.claudemd_sections import (
-    callback_register_bullets,
-    classify_rule,
-    litmus_questions,
-    rule_bullets,
-)
+from tools.db.brief_helpers import load_callbacks_for_brief, load_rules_for_brief
+from tools.state.loaders.claudemd_sections import litmus_questions
 from tools.state.loaders.people import (
     character_payload,
     consent_status_warnings,
@@ -231,35 +227,6 @@ def _gather_recent(
     return recent_endings, simile_counts
 
 
-def _gather_claudemd(
-    book_root: Path,
-    *,
-    recorder: _Recorder,
-) -> tuple[list[dict[str, str]], list[str]]:
-    """Rules (with severity) and callbacks from the book CLAUDE.md."""
-    rules_to_honor: list[dict[str, str]] = []
-    callbacks_in_register: list[str] = []
-    claudemd_path = book_root / "CLAUDE.md"
-    if not claudemd_path.is_file():
-        return rules_to_honor, callbacks_in_register
-
-    claudemd_text = recorder.run(
-        "claudemd.read",
-        lambda: claudemd_path.read_text(encoding="utf-8"),
-        "",
-    )
-    if not claudemd_text:
-        return rules_to_honor, callbacks_in_register
-
-    for rule_text in rule_bullets(claudemd_text):
-        rules_to_honor.append(
-            {
-                "text": rule_text,
-                "severity": classify_rule(rule_text),
-            }
-        )
-    callbacks_in_register = callback_register_bullets(claudemd_text)
-    return rules_to_honor, callbacks_in_register
 
 
 def _gather_tone(
@@ -454,10 +421,9 @@ def build_chapter_writing_brief(
         recorder=recorder,
     )
 
-    rules_to_honor, callbacks_in_register = _gather_claudemd(
-        book_root,
-        recorder=recorder,
-    )
+    # ----- rules + callbacks from book_rules DB (#304) ----------------------
+    rules_to_honor = load_rules_for_brief(book_root)
+    callbacks_in_register = load_callbacks_for_brief(book_root)
 
     banned_phrases = recorder.run(
         "banned_phrases",

--- a/tools/state/review_brief.py
+++ b/tools/state/review_brief.py
@@ -18,7 +18,11 @@ from pathlib import Path
 from typing import Any
 
 from tools.analysis.timeline_validator import parse_plot_timeline
-from tools.db.brief_helpers import load_canon_facts_for_brief
+from tools.db.brief_helpers import (
+    load_callbacks_for_brief,
+    load_canon_facts_for_brief,
+    load_rules_for_brief,
+)
 from tools.state.chapter_timeline_parser import parse_chapter_timeline_grid
 
 
@@ -263,67 +267,6 @@ def _parse_tonal_rules(tone_text: str) -> dict[str, list[str]]:
     }
 
 
-# ---------------------------------------------------------------------------
-# Book CLAUDE.md rules + callbacks (shared logic)
-# ---------------------------------------------------------------------------
-
-_RULES_SECTION_RE = re.compile(
-    r"^##\s+Rules\s*$(.*?)^##\s+",
-    re.MULTILINE | re.DOTALL,
-)
-_CALLBACKS_SECTION_RE = re.compile(
-    r"^##\s+Callback Register\s*$(.*?)(?=^---\s*$|\Z)",
-    re.MULTILINE | re.DOTALL,
-)
-_BAN_CUE_RE = re.compile(
-    r"\b(banned|ban|avoid|never|don['']?t\s+use|do\s+not\s+use|"
-    r"limit|stop\s+using)\b",
-    re.IGNORECASE,
-)
-
-
-def _classify_rule(rule: str) -> str:
-    if "`" in rule and _BAN_CUE_RE.search(rule):
-        return "block"
-    return "advisory"
-
-
-def _section_bullets(text: str, section_re: re.Pattern) -> list[str]:
-    match = section_re.search(text)
-    if not match:
-        return []
-    body = _COMMENT_RE.sub("", match.group(1))
-    items = []
-    for m in _BULLET_RE.finditer(body):
-        item = re.sub(r"\s+", " ", m.group("body")).strip()
-        if item:
-            items.append(item)
-    return items
-
-
-def _load_book_rules_and_callbacks(
-    book_root: Path,
-    recorder: _Recorder,
-) -> tuple[list[dict[str, str]], list[str]]:
-    """Extract active_rules and active_callbacks from book CLAUDE.md."""
-    rules: list[dict[str, str]] = []
-    callbacks: list[str] = []
-    claudemd_path = book_root / "CLAUDE.md"
-    if not claudemd_path.is_file():
-        return rules, callbacks
-
-    text = recorder.run(
-        "claudemd.read",
-        lambda: claudemd_path.read_text(encoding="utf-8"),
-        "",
-    )
-    if not text:
-        return rules, callbacks
-
-    for rule_text in _section_bullets(text, _RULES_SECTION_RE):
-        rules.append({"text": rule_text, "severity": _classify_rule(rule_text)})
-    callbacks = _section_bullets(text, _CALLBACKS_SECTION_RE)
-    return rules, callbacks
 
 
 # ---------------------------------------------------------------------------
@@ -472,8 +415,9 @@ def build_review_brief(
                 {},
             )
 
-    # ----- rules + callbacks from book CLAUDE.md ----------------------------
-    active_rules, active_callbacks = _load_book_rules_and_callbacks(book_root, recorder)
+    # ----- rules + callbacks from book_rules DB (#304) ----------------------
+    active_rules = load_rules_for_brief(book_root)
+    active_callbacks = load_callbacks_for_brief(book_root)
 
     return {
         "book_slug": book_slug,


### PR DESCRIPTION
## Summary

- `append_book_rule()` (PR #282) writes rules/callbacks to SQLite only — CLAUDE.md markers are intentionally left empty after migration
- Both `review_brief.py` and `chapter_writing_brief.py` still read `active_rules`/`active_callbacks` from those now-empty CLAUDE.md markers
- Result: chapter-reviewer and chapter-writer always received empty rule lists, making every registered rule a no-op

## Changes

- **`tools/db/brief_helpers.py`** — add `load_rules_for_brief()` and `load_callbacks_for_brief()`; severity classification (`_classify_rule`) inlined to avoid cross-layer imports
- **`tools/state/review_brief.py`** — remove `_load_book_rules_and_callbacks()` and its private helpers (`_RULES_SECTION_RE`, `_CALLBACKS_SECTION_RE`, `_BAN_CUE_RE`, `_classify_rule`, `_section_bullets`); wire DB helpers instead
- **`tools/state/chapter_writing_brief.py`** — remove `_gather_claudemd()`; remove now-unused `claudemd_sections` imports (`callback_register_bullets`, `classify_rule`, `rule_bullets`); wire DB helpers instead
- **Tests** — rewrite `test_build_review_brief_active_rules_from_claudemd` → DB inserts; add `db_dir` fixture to `test_chapter_writing_brief`; fix `TestBriefGracefulDegrade` which was hitting the real DB

## Test plan

- [x] `tests/state/test_review_brief.py` — 45 tests pass
- [x] `tests/state/test_chapter_writing_brief.py` — included in above
- [x] Full suite — 2093/2093 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
