### PR TITLE
fix: register extract_text_from_file as MCP tool, complete server.py re-exports

### DIFF
--- a/servers/storyforge-server/routers/authors.py
+++ b/servers/storyforge-server/routers/authors.py
@@ -16,6 +16,10 @@ from typing import Any
 import yaml
 
 from tools.author.discovery_lint import lint_author_discovery
+from tools.author.pdf_extractor import (
+    extract_text_from_file as _extract_text_impl,
+    get_text_stats,
+)
 from tools.author.rule_harvester import harvest
 from tools.claudemd.rules_editor import (
     MarkersNotFoundError,
@@ -602,3 +606,30 @@ def update_author(slug: str, field: str, value: str) -> str:
 
     _cache.invalidate()
     return json.dumps({"success": True, "field": field, "value": value})
+
+
+@mcp.tool()
+def extract_text_from_file(file_path: str) -> str:
+    """Extract text from PDF, EPUB, DOCX, TXT, or MD files for style analysis.
+
+    Used by the study-author skill to read binary formats (EPUB, DOCX) that
+    Claude's native Read tool cannot parse. Text files and PDFs can be read
+    via the Read tool directly, but EPUB and DOCX require this extraction step.
+
+    Supported formats: .pdf, .epub, .docx, .txt, .md
+    Max file size: 50 MB. Max extracted text: 200,000 words.
+    Large texts are automatically sampled (beginning / middle / end).
+
+    Args:
+        file_path: Absolute path to the file.
+
+    Returns:
+        ``{text, stats}`` on success where ``stats`` contains word_count,
+        paragraph_count, character_count, estimated_pages, and sampled flag.
+        ``{error}`` on file-not-found, unsupported format, or size limit breach.
+    """
+    try:
+        text = _extract_text_impl(Path(file_path))
+    except (FileNotFoundError, ValueError, ImportError) as exc:
+        return json.dumps({"error": str(exc)})
+    return json.dumps({"text": text, "stats": get_text_stats(text)})

--- a/servers/storyforge-server/server.py
+++ b/servers/storyforge-server/server.py
@@ -1,6 +1,6 @@
 """StoryForge MCP Server — entry point and tool surface.
 
-The 60 @mcp.tool() handlers live in domain modules under routers/ (#120).
+The @mcp.tool() handlers live in domain modules under routers/ (#120).
 This file bootstraps the server and re-exports every tool function so tests
 and callers can reach them via ``import server``.
 
@@ -31,11 +31,15 @@ import routers  # noqa: E402, F401
 # ---------------------------------------------------------------------------
 
 from routers.authors import (  # noqa: E402, F401
+    add_vocabulary_entry,
     create_author,
+    delete_discovery,
+    extract_text_from_file,
     get_author,
     harvest_book_rules,
     list_authors,
     update_author,
+    update_discovery_metadata,
     write_author_banned_phrase,
     write_author_discovery,
 )
@@ -65,7 +69,10 @@ from routers.claudemd import (  # noqa: E402, F401
     append_book_workflow,
     get_book_claudemd,
     init_book_claudemd,
+    lint_book_rules,
+    list_book_rules,
     sync_book_claudemd_from_text,
+    update_book_rule,
     update_character_snapshot,
 )
 from routers.creation import (  # noqa: E402, F401
@@ -109,6 +116,7 @@ from routers.series import (  # noqa: E402, F401
     add_book_to_series,
     bootstrap_character_for_new_book,
     copy_recurring_chars_to_new_book,
+    create_character_tracker,
     create_series,
     list_series_trackers_for_book,
     read_character_for_harvest,

--- a/tests/server/test_extract_text_from_file.py
+++ b/tests/server/test_extract_text_from_file.py
@@ -1,0 +1,79 @@
+"""Tests for the extract_text_from_file MCP tool (Issue #314).
+
+Verifies the MCP wrapper in routers.authors correctly delegates to
+tools.author.pdf_extractor and returns JSON-encoded results.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from routers.authors import extract_text_from_file
+
+
+class TestExtractTextFromFileMCPTool:
+    def test_txt_file_returns_text_and_stats(self, tmp_path: Path) -> None:
+        f = tmp_path / "sample.txt"
+        f.write_text("Hello world. This is a test.", encoding="utf-8")
+
+        result = json.loads(extract_text_from_file(str(f)))
+
+        assert "text" in result
+        assert "Hello world" in result["text"]
+        assert "stats" in result
+        assert result["stats"]["word_count"] == 6
+
+    def test_missing_file_returns_error(self, tmp_path: Path) -> None:
+        result = json.loads(extract_text_from_file(str(tmp_path / "ghost.txt")))
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_unsupported_format_returns_error(self, tmp_path: Path) -> None:
+        f = tmp_path / "file.xyz"
+        f.write_text("content", encoding="utf-8")
+
+        result = json.loads(extract_text_from_file(str(f)))
+
+        assert "error" in result
+        assert "Unsupported format" in result["error"]
+
+    def test_file_too_large_returns_error(self, tmp_path: Path) -> None:
+        f = tmp_path / "big.txt"
+        f.write_text("word " * 100, encoding="utf-8")
+
+        from tools.author import pdf_extractor
+
+        with patch.object(pdf_extractor.Path, "stat") as mock_stat:
+            mock_stat.return_value.st_size = pdf_extractor.MAX_FILE_SIZE_BYTES + 1
+            result = json.loads(extract_text_from_file(str(f)))
+
+        assert "error" in result
+
+    def test_md_file_extracted_correctly(self, tmp_path: Path) -> None:
+        f = tmp_path / "notes.md"
+        f.write_text("# Title\n\nSome content here.", encoding="utf-8")
+
+        result = json.loads(extract_text_from_file(str(f)))
+
+        assert "text" in result
+        assert "Title" in result["text"]
+
+    def test_stats_keys_present(self, tmp_path: Path) -> None:
+        f = tmp_path / "check.txt"
+        f.write_text("one two three", encoding="utf-8")
+
+        result = json.loads(extract_text_from_file(str(f)))
+
+        stats = result["stats"]
+        for key in ("word_count", "paragraph_count", "character_count", "estimated_pages", "sampled"):
+            assert key in stats, f"Missing stats key: {key}"
+
+    def test_importable_from_server(self) -> None:
+        from server import extract_text_from_file as server_fn
+
+        assert callable(server_fn)

--- a/tests/server/test_extract_text_from_file.py
+++ b/tests/server/test_extract_text_from_file.py
@@ -10,8 +10,6 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 from routers.authors import extract_text_from_file
 
 


### PR DESCRIPTION
## Summary

- **#314 (Critical):** `extract_text_from_file` was referenced in `study-author` as an MCP tool but never registered as `@mcp.tool()`. EPUB/DOCX extraction via MCP was silently broken. Fixed by adding the `@mcp.tool()` wrapper in `routers/authors.py` that delegates to the existing `tools/author/pdf_extractor` implementation.
- **#308 (High):** `server.py` re-export block was incomplete — 7 tools had `@mcp.tool()` decorators and worked at runtime but were missing from the `import server` surface. Fixed by adding all 8 missing re-exports (including the new `extract_text_from_file`). Removed the stale `"The 60 @mcp.tool() handlers"` count from the docstring.

## Changes

| File | What |
|------|------|
| `routers/authors.py` | New `@mcp.tool()` `extract_text_from_file(file_path: str) -> str`; returns `{text, stats}` or `{error}` |
| `server.py` | +8 re-exports: `extract_text_from_file`, `add_vocabulary_entry`, `delete_discovery`, `update_discovery_metadata`, `lint_book_rules`, `list_book_rules`, `update_book_rule`, `create_character_tracker`; docstring cleaned |
| `tests/server/test_extract_text_from_file.py` | 7 tests: txt happy path, missing file, unsupported format, size limit, md extraction, stats keys, importability from `server` |

## Test plan

- [ ] `pytest tests/server/test_extract_text_from_file.py -v` — 7/7 pass
- [ ] `pytest tests/ -q` — 2100/2100 pass
- [ ] `ruff check servers/ tools/ hooks/` — clean
- [ ] Manual: open `/storyforge:study-author`, pass an EPUB → MCP `extract_text_from_file` is now callable

Closes #314, #308

🤖 Generated with [Claude Code](https://claude.ai/claude-code)