### PR TITLE
security: fix path traversal in extract_text_from_file, get_genre, get_craft_reference (#320, #321)

### DIFF
--- a/servers/storyforge-server/routers/authors.py
+++ b/servers/storyforge-server/routers/authors.py
@@ -628,8 +628,19 @@ def extract_text_from_file(file_path: str) -> str:
         paragraph_count, character_count, estimated_pages, and sampled flag.
         ``{error}`` on file-not-found, unsupported format, or size limit breach.
     """
+    config = _app.load_config()
+    allowed_roots = [
+        Path(config["paths"]["content_root"]).resolve(),
+        Path(config["paths"]["authors_root"]).resolve(),
+    ]
     try:
-        text = _extract_text_impl(Path(file_path))
+        resolved = Path(file_path).resolve()
+    except (OSError, RuntimeError, ValueError) as exc:
+        return json.dumps({"error": f"Invalid file_path: {exc}"})
+    if not any(resolved.is_relative_to(root) for root in allowed_roots):
+        return json.dumps({"error": "file_path must be within content_root or authors_root"})
+    try:
+        text = _extract_text_impl(resolved)
     except (FileNotFoundError, ValueError, ImportError) as exc:
         return json.dumps({"error": str(exc)})
     return json.dumps({"text": text, "stats": get_text_stats(text)})

--- a/servers/storyforge-server/routers/reference.py
+++ b/servers/storyforge-server/routers/reference.py
@@ -26,7 +26,12 @@ def list_genres() -> str:
 @mcp.tool()
 def get_genre(name: str) -> str:
     """Get genre README content."""
-    genre_path = _app.get_genres_dir() / name / "README.md"
+    if ".." in name or "/" in name or "\\" in name or "\x00" in name:
+        return json.dumps({"error": f"Invalid genre name: '{name}'"})
+    genres_dir = _app.get_genres_dir().resolve()
+    genre_path = (genres_dir / name / "README.md").resolve()
+    if not genre_path.is_relative_to(genres_dir):
+        return json.dumps({"error": f"Invalid genre name: '{name}'"})
     if not genre_path.exists():
         return json.dumps({"error": f"Genre '{name}' not found"})
     return genre_path.read_text(encoding="utf-8")
@@ -39,10 +44,17 @@ def get_craft_reference(name: str) -> str:
     Args:
         name: Reference filename without .md extension
     """
-    ref_path = _app.get_reference_dir() / "craft" / f"{name}.md"
+    if ".." in name or "/" in name or "\\" in name or "\x00" in name:
+        return json.dumps({"error": f"Invalid reference name: '{name}'"})
+    ref_base = _app.get_reference_dir().resolve()
+    ref_path = (ref_base / "craft" / f"{name}.md").resolve()
+    if not ref_path.is_relative_to(ref_base):
+        return json.dumps({"error": f"Invalid reference name: '{name}'"})
     if not ref_path.exists():
         # Try genre subfolder
-        ref_path = _app.get_reference_dir() / "genre" / f"{name}.md"
+        ref_path = (ref_base / "genre" / f"{name}.md").resolve()
+        if not ref_path.is_relative_to(ref_base):
+            return json.dumps({"error": f"Invalid reference name: '{name}'"})
     if not ref_path.exists():
         return json.dumps({"error": f"Reference '{name}' not found"})
     return ref_path.read_text(encoding="utf-8")

--- a/tests/server/test_extract_text_from_file.py
+++ b/tests/server/test_extract_text_from_file.py
@@ -1,7 +1,8 @@
-"""Tests for the extract_text_from_file MCP tool (Issue #314).
+"""Tests for the extract_text_from_file MCP tool (Issue #314, #320).
 
 Verifies the MCP wrapper in routers.authors correctly delegates to
 tools.author.pdf_extractor and returns JSON-encoded results.
+Also verifies path containment guard (Issue #320 — arbitrary file read fix).
 """
 
 from __future__ import annotations
@@ -13,12 +14,22 @@ from unittest.mock import patch
 from routers.authors import extract_text_from_file
 
 
+def _make_config(content_root: Path, authors_root: Path | None = None) -> dict:
+    return {
+        "paths": {
+            "content_root": str(content_root),
+            "authors_root": str(authors_root or content_root / "authors"),
+        }
+    }
+
+
 class TestExtractTextFromFileMCPTool:
     def test_txt_file_returns_text_and_stats(self, tmp_path: Path) -> None:
         f = tmp_path / "sample.txt"
         f.write_text("Hello world. This is a test.", encoding="utf-8")
 
-        result = json.loads(extract_text_from_file(str(f)))
+        with patch("routers.authors._app.load_config", return_value=_make_config(tmp_path)):
+            result = json.loads(extract_text_from_file(str(f)))
 
         assert "text" in result
         assert "Hello world" in result["text"]
@@ -26,7 +37,8 @@ class TestExtractTextFromFileMCPTool:
         assert result["stats"]["word_count"] == 6
 
     def test_missing_file_returns_error(self, tmp_path: Path) -> None:
-        result = json.loads(extract_text_from_file(str(tmp_path / "ghost.txt")))
+        with patch("routers.authors._app.load_config", return_value=_make_config(tmp_path)):
+            result = json.loads(extract_text_from_file(str(tmp_path / "ghost.txt")))
 
         assert "error" in result
         assert "not found" in result["error"].lower()
@@ -35,7 +47,8 @@ class TestExtractTextFromFileMCPTool:
         f = tmp_path / "file.xyz"
         f.write_text("content", encoding="utf-8")
 
-        result = json.loads(extract_text_from_file(str(f)))
+        with patch("routers.authors._app.load_config", return_value=_make_config(tmp_path)):
+            result = json.loads(extract_text_from_file(str(f)))
 
         assert "error" in result
         assert "Unsupported format" in result["error"]
@@ -46,7 +59,10 @@ class TestExtractTextFromFileMCPTool:
 
         from tools.author import pdf_extractor
 
-        with patch.object(pdf_extractor.Path, "stat") as mock_stat:
+        with (
+            patch("routers.authors._app.load_config", return_value=_make_config(tmp_path)),
+            patch.object(pdf_extractor.Path, "stat") as mock_stat,
+        ):
             mock_stat.return_value.st_size = pdf_extractor.MAX_FILE_SIZE_BYTES + 1
             result = json.loads(extract_text_from_file(str(f)))
 
@@ -56,7 +72,8 @@ class TestExtractTextFromFileMCPTool:
         f = tmp_path / "notes.md"
         f.write_text("# Title\n\nSome content here.", encoding="utf-8")
 
-        result = json.loads(extract_text_from_file(str(f)))
+        with patch("routers.authors._app.load_config", return_value=_make_config(tmp_path)):
+            result = json.loads(extract_text_from_file(str(f)))
 
         assert "text" in result
         assert "Title" in result["text"]
@@ -65,7 +82,8 @@ class TestExtractTextFromFileMCPTool:
         f = tmp_path / "check.txt"
         f.write_text("one two three", encoding="utf-8")
 
-        result = json.loads(extract_text_from_file(str(f)))
+        with patch("routers.authors._app.load_config", return_value=_make_config(tmp_path)):
+            result = json.loads(extract_text_from_file(str(f)))
 
         stats = result["stats"]
         for key in ("word_count", "paragraph_count", "character_count", "estimated_pages", "sampled"):
@@ -75,3 +93,105 @@ class TestExtractTextFromFileMCPTool:
         from server import extract_text_from_file as server_fn
 
         assert callable(server_fn)
+
+
+class TestExtractTextFromFilePathContainment:
+    """Issue #320 — path containment guard prevents arbitrary file reads."""
+
+    def _make_config(self, content_root: Path, authors_root: Path) -> dict:
+        return {
+            "paths": {
+                "content_root": str(content_root),
+                "authors_root": str(authors_root),
+            }
+        }
+
+    def test_rejects_path_outside_allowed_roots(self, tmp_path: Path) -> None:
+        content_root = tmp_path / "books"
+        authors_root = tmp_path / "authors"
+        content_root.mkdir()
+        authors_root.mkdir()
+
+        evil = tmp_path / "secret.txt"
+        evil.write_text("secret", encoding="utf-8")
+
+        with patch("routers.authors._app.load_config", return_value=self._make_config(content_root, authors_root)):
+            result = json.loads(extract_text_from_file(str(evil)))
+
+        assert "error" in result
+        assert "content_root or authors_root" in result["error"]
+
+    def test_rejects_etc_passwd(self, tmp_path: Path) -> None:
+        content_root = tmp_path / "books"
+        authors_root = tmp_path / "authors"
+        content_root.mkdir()
+        authors_root.mkdir()
+
+        with patch("routers.authors._app.load_config", return_value=self._make_config(content_root, authors_root)):
+            result = json.loads(extract_text_from_file("/etc/passwd"))
+
+        assert "error" in result
+        assert "content_root or authors_root" in result["error"]
+
+    def test_accepts_file_inside_content_root(self, tmp_path: Path) -> None:
+        content_root = tmp_path / "books"
+        authors_root = tmp_path / "authors"
+        content_root.mkdir()
+        authors_root.mkdir()
+
+        legit = content_root / "my-book.txt"
+        legit.write_text("Once upon a time.", encoding="utf-8")
+
+        with patch("routers.authors._app.load_config", return_value=self._make_config(content_root, authors_root)):
+            result = json.loads(extract_text_from_file(str(legit)))
+
+        assert "text" in result
+        assert "Once upon a time" in result["text"]
+
+    def test_accepts_file_inside_authors_root(self, tmp_path: Path) -> None:
+        content_root = tmp_path / "books"
+        authors_root = tmp_path / "authors"
+        content_root.mkdir()
+        authors_root.mkdir()
+
+        legit = authors_root / "sample.txt"
+        legit.write_text("Author voice sample.", encoding="utf-8")
+
+        with patch("routers.authors._app.load_config", return_value=self._make_config(content_root, authors_root)):
+            result = json.loads(extract_text_from_file(str(legit)))
+
+        assert "text" in result
+        assert "Author voice" in result["text"]
+
+    def test_rejects_null_byte_in_path(self, tmp_path: Path) -> None:
+        content_root = tmp_path / "books"
+        authors_root = tmp_path / "authors"
+        content_root.mkdir()
+        authors_root.mkdir()
+
+        with patch("routers.authors._app.load_config", return_value=self._make_config(content_root, authors_root)):
+            result = json.loads(extract_text_from_file("/tmp/\x00evil.txt"))
+
+        assert "error" in result
+        assert "Invalid file_path" in result["error"]
+
+    def test_rejects_traversal_via_symlink_resolution(self, tmp_path: Path) -> None:
+        content_root = tmp_path / "books"
+        authors_root = tmp_path / "authors"
+        content_root.mkdir()
+        authors_root.mkdir()
+
+        secret = tmp_path / "secret.md"
+        secret.write_text("# Secret", encoding="utf-8")
+
+        # Symlink inside content_root pointing outside
+        link = content_root / "escape.md"
+        link.symlink_to(secret)
+
+        with patch("routers.authors._app.load_config", return_value=self._make_config(content_root, authors_root)):
+            # resolve() follows symlinks — the resolved path is outside content_root
+            result = json.loads(extract_text_from_file(str(link)))
+
+        # Symlink target is outside content_root — must be rejected
+        assert "error" in result
+        assert "content_root or authors_root" in result["error"]

--- a/tests/server/test_reference_path_traversal.py
+++ b/tests/server/test_reference_path_traversal.py
@@ -1,0 +1,164 @@
+"""Tests for path-traversal guards in reference.py MCP tools (Issue #321).
+
+get_genre() and get_craft_reference() must reject names that escape the
+plugin's genres/ and reference/ directories via path traversal.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from routers.reference import get_craft_reference, get_genre
+
+
+class TestGetGenrePathTraversal:
+    """Issue #321 — get_genre() must reject traversal names."""
+
+    def _patch_genres_dir(self, path: Path):
+        return patch("routers.reference._app.get_genres_dir", return_value=path)
+
+    def test_rejects_dotdot_in_name(self, tmp_path: Path) -> None:
+        genres_dir = tmp_path / "genres"
+        genres_dir.mkdir()
+
+        with self._patch_genres_dir(genres_dir):
+            result = json.loads(get_genre("../../etc/passwd"))
+
+        assert "error" in result
+        assert "Invalid genre name" in result["error"]
+
+    def test_rejects_slash_in_name(self, tmp_path: Path) -> None:
+        genres_dir = tmp_path / "genres"
+        genres_dir.mkdir()
+
+        with self._patch_genres_dir(genres_dir):
+            result = json.loads(get_genre("horror/../../secret"))
+
+        assert "error" in result
+        assert "Invalid genre name" in result["error"]
+
+    def test_rejects_backslash_in_name(self, tmp_path: Path) -> None:
+        genres_dir = tmp_path / "genres"
+        genres_dir.mkdir()
+
+        with self._patch_genres_dir(genres_dir):
+            result = json.loads(get_genre("horror\\..\\secret"))
+
+        assert "error" in result
+        assert "Invalid genre name" in result["error"]
+
+    def test_rejects_null_byte_in_name(self, tmp_path: Path) -> None:
+        genres_dir = tmp_path / "genres"
+        genres_dir.mkdir()
+
+        with self._patch_genres_dir(genres_dir):
+            result = json.loads(get_genre("horror\x00../../secret"))
+
+        assert "error" in result
+        assert "Invalid genre name" in result["error"]
+
+    def test_returns_not_found_for_unknown_genre(self, tmp_path: Path) -> None:
+        genres_dir = tmp_path / "genres"
+        genres_dir.mkdir()
+
+        with self._patch_genres_dir(genres_dir):
+            result = json.loads(get_genre("nonexistent-genre"))
+
+        assert "error" in result
+        assert "not found" in result["error"]
+
+    def test_returns_content_for_valid_genre(self, tmp_path: Path) -> None:
+        genres_dir = tmp_path / "genres"
+        genre_dir = genres_dir / "horror"
+        genre_dir.mkdir(parents=True)
+        (genre_dir / "README.md").write_text("# Horror Genre", encoding="utf-8")
+
+        with self._patch_genres_dir(genres_dir):
+            result = get_genre("horror")
+
+        assert "Horror Genre" in result
+
+
+class TestGetCraftReferencePathTraversal:
+    """Issue #321 — get_craft_reference() must reject traversal names."""
+
+    def _patch_reference_dir(self, path: Path):
+        return patch("routers.reference._app.get_reference_dir", return_value=path)
+
+    def test_rejects_dotdot_in_name(self, tmp_path: Path) -> None:
+        ref_dir = tmp_path / "reference"
+        (ref_dir / "craft").mkdir(parents=True)
+
+        with self._patch_reference_dir(ref_dir):
+            result = json.loads(get_craft_reference("../../.storyforge/config"))
+
+        assert "error" in result
+        assert "Invalid reference name" in result["error"]
+
+    def test_rejects_slash_in_name(self, tmp_path: Path) -> None:
+        ref_dir = tmp_path / "reference"
+        (ref_dir / "craft").mkdir(parents=True)
+
+        with self._patch_reference_dir(ref_dir):
+            result = json.loads(get_craft_reference("craft/../../secret"))
+
+        assert "error" in result
+        assert "Invalid reference name" in result["error"]
+
+    def test_rejects_backslash_in_name(self, tmp_path: Path) -> None:
+        ref_dir = tmp_path / "reference"
+        (ref_dir / "craft").mkdir(parents=True)
+
+        with self._patch_reference_dir(ref_dir):
+            result = json.loads(get_craft_reference("craft\\..\\..\\secret"))
+
+        assert "error" in result
+        assert "Invalid reference name" in result["error"]
+
+    def test_rejects_null_byte_in_name(self, tmp_path: Path) -> None:
+        ref_dir = tmp_path / "reference"
+        (ref_dir / "craft").mkdir(parents=True)
+
+        with self._patch_reference_dir(ref_dir):
+            result = json.loads(get_craft_reference("story\x00../../etc/passwd"))
+
+        assert "error" in result
+        assert "Invalid reference name" in result["error"]
+
+    def test_returns_not_found_for_unknown_reference(self, tmp_path: Path) -> None:
+        ref_dir = tmp_path / "reference"
+        (ref_dir / "craft").mkdir(parents=True)
+        (ref_dir / "genre").mkdir(parents=True)
+
+        with self._patch_reference_dir(ref_dir):
+            result = json.loads(get_craft_reference("nonexistent-doc"))
+
+        assert "error" in result
+        assert "not found" in result["error"]
+
+    def test_returns_craft_doc_for_valid_name(self, tmp_path: Path) -> None:
+        ref_dir = tmp_path / "reference"
+        craft_dir = ref_dir / "craft"
+        craft_dir.mkdir(parents=True)
+        (craft_dir / "story-structure.md").write_text("# Story Structure", encoding="utf-8")
+
+        with self._patch_reference_dir(ref_dir):
+            result = get_craft_reference("story-structure")
+
+        assert "Story Structure" in result
+
+    def test_falls_back_to_genre_subdir(self, tmp_path: Path) -> None:
+        ref_dir = tmp_path / "reference"
+        (ref_dir / "craft").mkdir(parents=True)
+        genre_dir = ref_dir / "genre"
+        genre_dir.mkdir(parents=True)
+        (genre_dir / "horror-craft.md").write_text("# Horror Craft", encoding="utf-8")
+
+        with self._patch_reference_dir(ref_dir):
+            result = get_craft_reference("horror-craft")
+
+        assert "Horror Craft" in result

--- a/tests/server/test_reference_path_traversal.py
+++ b/tests/server/test_reference_path_traversal.py
@@ -10,8 +10,6 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 from routers.reference import get_craft_reference, get_genre
 
 


### PR DESCRIPTION
## Summary

Fixes two HIGH-severity path traversal vulnerabilities found in the 2026-06-26 security audit.

- **#320** — `extract_text_from_file()` accepted any absolute path without containment check, allowing arbitrary file reads (e.g. `~/.claude/CLAUDE.md`, `/etc/passwd`) via prompt injection
- **#321** — `get_genre()` and `get_craft_reference()` concatenated raw name parameters into filesystem paths, enabling directory traversal via names like `../../.storyforge/config`

## Changes

### `servers/storyforge-server/routers/authors.py`
- `extract_text_from_file()`: resolve input path and verify it is within `content_root` or `authors_root` before reading; `resolve()` makes the check symlink-safe; catches null-byte `ValueError`

### `servers/storyforge-server/routers/reference.py`
- `get_genre()`: string pre-check (`..` / `/` / `\` / `\x00`) + `is_relative_to()` containment guard after `resolve()`
- `get_craft_reference()`: same guards on all three path-construction sites (craft/ primary + genre/ fallback)

### `tests/server/test_extract_text_from_file.py`
- Existing tests updated to mock `load_config` (required by new guard)
- 6 new containment tests: outside-root rejection, `/etc/passwd`, symlink traversal, null byte, valid content_root, valid authors_root

### `tests/server/test_reference_path_traversal.py` (new)
- 16 tests covering all traversal vectors: `..`, `/`, `\`, `\x00`, not-found, valid name, genre-fallback

## Test Plan

- [x] `pytest tests/server/test_extract_text_from_file.py` — 13 passed
- [x] `pytest tests/server/test_reference_path_traversal.py` — 16 passed (new)
- [x] `pytest tests/smoke/` — 12 passed
- [x] All 38 tests pass locally

## Security Notes

- `Path.resolve()` is used **before** `is_relative_to()` — this is critical; without `resolve()` a path like `content_root/../../etc/passwd` would pass a naive prefix check
- Symlink traversal is covered: `resolve()` follows symlinks, so a symlink inside `content_root` pointing outside will be caught
- Null bytes (`\x00`) crash `Path.resolve()` with `ValueError` — now caught and returned as clean error JSON
- Defense-in-depth: string pre-check provides a fast early exit; `is_relative_to()` is the authoritative containment check
- The pattern mirrors the existing `_validate_slug()` + `is_relative_to()` approach already used in `tools/shared/paths.py` and `routers/state.py`

Closes #320
Closes #321