### PR TITLE
security: fix DB slug traversal, pandoc metadata injection, rule body limit (#323 #324 #325)

### DIFF
--- a/tests/claudemd/test_claudemd.py
+++ b/tests/claudemd/test_claudemd.py
@@ -96,6 +96,33 @@ class TestParser:
         assert extract_prefixed_lines("") == []
         assert extract_prefixed_lines("no prefixes here\nnothing") == []
 
+    def test_body_at_max_length_accepted(self):
+        # Bodies exactly at the limit are fine — real rules can be verbose.
+        from tools.claudemd.parser import MAX_RULE_BODY_LEN
+
+        body = "x" * MAX_RULE_BODY_LEN
+        result = parse_prefixed_entry(f"Regel: {body}")
+        assert result is not None
+        assert result[1] == body
+
+    def test_body_exceeding_max_length_rejected(self):
+        # Prompt-injection bodies are typically long — reject them silently
+        # (Issue #325).
+        from tools.claudemd.parser import MAX_RULE_BODY_LEN
+
+        body = "x" * (MAX_RULE_BODY_LEN + 1)
+        assert parse_prefixed_entry(f"Regel: {body}") is None
+
+    def test_injection_body_filtered_in_extract(self):
+        # An injected long rule must not appear in the extracted list.
+        from tools.claudemd.parser import MAX_RULE_BODY_LEN
+
+        evil = "x" * (MAX_RULE_BODY_LEN + 1)
+        text = f"Normal line.\nRegel: {evil}\nCallback: Gary\n"
+        result = extract_prefixed_lines(text)
+        assert len(result) == 1
+        assert result[0] == ("callback", "Gary")
+
 
 class TestResolvePath:
     def test_resolve_claudemd_path(self, book_config):

--- a/tests/db/test_db_schema.py
+++ b/tests/db/test_db_schema.py
@@ -68,3 +68,57 @@ class TestEnsureSchema:
         conn.close()
         assert "idx_cf" in indexes
         assert "idx_cf_subject" in indexes
+
+
+# ---------------------------------------------------------------------------
+# get_canon_db_path — slug validation (Issue #323)
+# ---------------------------------------------------------------------------
+
+
+class TestGetCanonDbPathSlugValidation:
+    """Issue #323 — get_canon_db_path() must reject traversal slugs."""
+
+    def test_valid_slug_returns_path(self):
+        from tools.db.connection import get_canon_db_path
+
+        path = get_canon_db_path("my-series")
+        assert path.name == "my-series.db"
+
+    def test_rejects_dotdot_traversal(self):
+        import pytest
+
+        from tools.db.connection import get_canon_db_path
+
+        with pytest.raises(ValueError, match="Invalid"):
+            get_canon_db_path("../../.bashrc")
+
+    def test_rejects_slash_in_slug(self):
+        import pytest
+
+        from tools.db.connection import get_canon_db_path
+
+        with pytest.raises(ValueError, match="Invalid"):
+            get_canon_db_path("good/evil")
+
+    def test_rejects_backslash_in_slug(self):
+        import pytest
+
+        from tools.db.connection import get_canon_db_path
+
+        with pytest.raises(ValueError, match="Invalid"):
+            get_canon_db_path("good\\evil")
+
+    def test_rejects_null_byte(self):
+        import pytest
+
+        from tools.db.connection import get_canon_db_path
+
+        with pytest.raises(ValueError, match="Invalid"):
+            get_canon_db_path("slug\x00evil")
+
+    def test_empty_slug_passes_through(self):
+        # _validate_slug treats empty as a no-op sentinel used by callers
+        from tools.db.connection import get_canon_db_path
+
+        path = get_canon_db_path("")
+        assert path.name == ".db"

--- a/tests/export/test_pandoc.py
+++ b/tests/export/test_pandoc.py
@@ -291,13 +291,34 @@ class TestGenerateEpub:
         assert "path" in result
         assert result["size_bytes"] > 0
 
-    def test_includes_metadata_flags(self, mock_epub_subprocess, tmp_path: Path):
+    def test_includes_metadata_via_file(self, mock_epub_subprocess, tmp_path: Path):
+        # Metadata must flow through --metadata-file (not raw --metadata key=value)
+        # to prevent LaTeX injection via title/author (Issue #324).
         mock_run, output = mock_epub_subprocess
-        pandoc.generate_epub(tmp_path / "in.md", output, "My Book", "Test Author", language="de")
+        captured: dict = {}
+
+        real_write = pandoc._write_metadata_file
+
+        def capture_write(metadata: dict) -> Path:
+            captured.update(metadata)
+            return real_write(metadata)
+
+        with patch.object(pandoc, "_write_metadata_file", side_effect=capture_write):
+            pandoc.generate_epub(tmp_path / "in.md", output, "My Book", "Test Author", language="de")
+
         cmd = mock_run.call_args[0][0]
-        assert "title=My Book" in " ".join(cmd)
-        assert "author=Test Author" in " ".join(cmd)
-        assert "lang=de" in " ".join(cmd)
+        assert any(arg.startswith("--metadata-file=") for arg in cmd), "must use --metadata-file"
+        assert "--metadata" not in cmd, "raw --metadata must not appear"
+        assert captured == {"title": "My Book", "author": "Test Author", "lang": "de"}
+
+    def test_latex_injection_in_title_does_not_appear_in_cmd(self, mock_epub_subprocess, tmp_path: Path):
+        # LaTeX payload in title must not reach cmd args directly (Issue #324).
+        mock_run, output = mock_epub_subprocess
+        evil_title = r"}\newcommand{\x}{}\input{/etc/passwd}\title{"
+        pandoc.generate_epub(tmp_path / "in.md", output, evil_title, "Author")
+        cmd_str = " ".join(mock_run.call_args[0][0])
+        assert "\\input" not in cmd_str
+        assert "/etc/passwd" not in cmd_str
 
     def test_cover_image_included_when_exists(self, mock_epub_subprocess, tmp_path: Path):
         mock_run, output = mock_epub_subprocess

--- a/tools/claudemd/parser.py
+++ b/tools/claudemd/parser.py
@@ -16,6 +16,12 @@ from typing import Literal
 
 EntryKind = Literal["rule", "workflow", "callback"]
 
+# Genuine user-authored rules are concise. Bodies above this limit are likely
+# accidental captures (pasted manuscript text, injected content) rather than
+# intentional rules — reject them silently to prevent prompt injection via
+# persisted book rules (Issue #325).
+MAX_RULE_BODY_LEN = 300
+
 PREFIX_MAP: dict[str, EntryKind] = {
     "regel": "rule",
     "rule": "rule",
@@ -46,7 +52,7 @@ def parse_prefixed_entry(line: str) -> tuple[EntryKind, str] | None:
         return None
     kind = PREFIX_MAP[match.group("prefix").lower()]
     body = match.group("body").strip()
-    if not body:
+    if not body or len(body) > MAX_RULE_BODY_LEN:
         return None
     return kind, body
 

--- a/tools/db/connection.py
+++ b/tools/db/connection.py
@@ -15,6 +15,7 @@ import sqlite3
 from pathlib import Path
 
 from tools.shared.config import CACHE_DIR
+from tools.shared.paths import _validate_slug
 
 # Override with STORYFORGE_DB_DIR to redirect DB lookups (used in subprocess tests).
 DB_DIR: Path = Path(os.environ["STORYFORGE_DB_DIR"]) if "STORYFORGE_DB_DIR" in os.environ else CACHE_DIR.parent / "db"
@@ -136,6 +137,7 @@ def open_authors_db() -> sqlite3.Connection:
 
 def get_canon_db_path(series_or_book_slug: str) -> Path:
     """Return the DB path for a given series or standalone book slug."""
+    _validate_slug(series_or_book_slug, "series_or_book_slug")
     return DB_DIR / f"{series_or_book_slug}.db"
 
 

--- a/tools/export/pandoc.py
+++ b/tools/export/pandoc.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import json as _json
+import os
 import re
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -33,6 +36,24 @@ _FONT_SIZE_PATTERN = re.compile(r"^\d{1,2}(pt|em)$")
 
 # margin: integer or decimal + cm/mm/in/em/pt, e.g. "1in", "2.5cm", "20mm"
 _MARGIN_PATTERN = re.compile(r"^\d{1,2}(\.\d+)?(cm|mm|in|em|pt)$")
+
+
+def _write_metadata_file(metadata: dict) -> Path:
+    """Write metadata dict to a temp JSON file for --metadata-file.
+
+    Using a file avoids shell-level splitting of --metadata key=value args,
+    which lets LaTeX special characters in title/author reach the template
+    unescaped. JSON metadata files are passed verbatim and handled by Pandoc
+    before any LaTeX processing.
+    """
+    fd, path = tempfile.mkstemp(suffix=".json")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            _json.dump(metadata, f, ensure_ascii=False)
+    except Exception:
+        os.unlink(path)
+        raise
+    return Path(path)
 
 
 def _validate_pdf_args(pdf_engine: str, font: str, font_size: str, margin: str) -> str | None:
@@ -89,29 +110,28 @@ def generate_epub(
     css_path: Path | None = None,
 ) -> dict[str, Any]:
     """Generate EPUB from a Markdown manuscript."""
-    cmd = [
-        "pandoc",
-        str(manuscript_path),
-        "-o",
-        str(output_path),
-        "--metadata",
-        f"title={title}",
-        "--metadata",
-        f"author={author}",
-        "--metadata",
-        f"lang={language}",
-        "--toc",
-        "--toc-depth=1",
-        "--epub-chapter-level=1",
-    ]
+    meta_path = _write_metadata_file({"title": title, "author": author, "lang": language})
+    try:
+        cmd = [
+            "pandoc",
+            str(manuscript_path),
+            "-o",
+            str(output_path),
+            f"--metadata-file={meta_path}",
+            "--toc",
+            "--toc-depth=1",
+            "--epub-chapter-level=1",
+        ]
 
-    if cover_image and cover_image.exists():
-        cmd.extend(["--epub-cover-image", str(cover_image)])
+        if cover_image and cover_image.exists():
+            cmd.extend(["--epub-cover-image", str(cover_image)])
 
-    if css_path and css_path.exists():
-        cmd.extend(["--css", str(css_path)])
+        if css_path and css_path.exists():
+            cmd.extend(["--css", str(css_path)])
 
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    finally:
+        meta_path.unlink(missing_ok=True)
 
     if result.returncode != 0:
         return {"success": False, "error": result.stderr}
@@ -140,28 +160,29 @@ def generate_pdf(
     if error is not None:
         return {"success": False, "error": error}
 
-    cmd = [
-        "pandoc",
-        str(manuscript_path),
-        "-o",
-        str(output_path),
-        f"--pdf-engine={pdf_engine}",
-        "--metadata",
-        f"title={title}",
-        "--metadata",
-        f"author={author}",
-        "--toc",
-        "-V",
-        f"geometry:margin={margin}",
-        "-V",
-        f"fontsize={font_size}",
-        "-V",
-        f"mainfont={font}",
-        "-V",
-        "documentclass=book",
-    ]
+    meta_path = _write_metadata_file({"title": title, "author": author})
+    try:
+        cmd = [
+            "pandoc",
+            str(manuscript_path),
+            "-o",
+            str(output_path),
+            f"--pdf-engine={pdf_engine}",
+            f"--metadata-file={meta_path}",
+            "--toc",
+            "-V",
+            f"geometry:margin={margin}",
+            "-V",
+            f"fontsize={font_size}",
+            "-V",
+            f"mainfont={font}",
+            "-V",
+            "documentclass=book",
+        ]
 
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+    finally:
+        meta_path.unlink(missing_ok=True)
 
     if result.returncode != 0:
         return {"success": False, "error": result.stderr}


### PR DESCRIPTION
## Summary

- **#323** — `get_canon_db_path()` jetzt mit `_validate_slug()` abgesichert; slugs mit `/`, `\\`, `..`, Null-Bytes werfen `ValueError`
- **#324** — `generate_epub()` und `generate_pdf()` übergeben `title`/`author` via temporäres `--metadata-file=<json>` statt `--metadata title=VALUE` — verhindert LaTeX-Injection; Tempfile wird in `finally`-Block bereinigt
- **#325** — `parse_prefixed_entry()` verwirft Rule-Bodies über `MAX_RULE_BODY_LEN` (300 Zeichen); lange Bodies deuten auf injizierte Manuskript-Inhalte hin, nicht auf echte User-Regeln

## Test plan

- [ ] CI grün (Python 3.11 + 3.12)
- [ ] `TestGetCanonDbPathSlugValidation` — 6 Tests für traversal + valid slug
- [ ] `TestParser::test_body_*` — Längengrenze akzeptiert/verwirft korrekt
- [ ] `TestGenerateEpub::test_includes_metadata_via_file` — kein raw `--metadata` in cmd; LaTeX-Payload erscheint nicht in cmd-args

Closes #323, Closes #324, Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)