### PR TITLE
security: sanitize exception messages and STORYFORGE_DB_DIR (#327 #329)

### DIFF
--- a/servers/storyforge-server/routers/gates.py
+++ b/servers/storyforge-server/routers/gates.py
@@ -134,7 +134,7 @@ def validate_timeline_consistency(book_slug: str) -> str:
         return json.dumps({"error": f"Book '{book_slug}' not found at {book_path}"})
     try:
         result = validate_timeline(book_path)
-    except Exception as exc:  # noqa: BLE001
+    except Exception:  # noqa: BLE001
         logger.exception("Timeline validation failed for book %s", book_slug)
         return json.dumps({"error": "Timeline validation failed due to an internal error", "book_slug": book_slug})
     gate = derive_from_timeline_validation(result)

--- a/servers/storyforge-server/routers/gates.py
+++ b/servers/storyforge-server/routers/gates.py
@@ -9,7 +9,10 @@ and merges the results into one ``GateResult`` envelope.
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 from tools.analysis.callback_validator import verify_callbacks as _verify_callbacks_impl
 from tools.analysis.chapter_validator import (
@@ -132,7 +135,8 @@ def validate_timeline_consistency(book_slug: str) -> str:
     try:
         result = validate_timeline(book_path)
     except Exception as exc:  # noqa: BLE001
-        return json.dumps({"error": str(exc), "book_slug": book_slug})
+        logger.exception("Timeline validation failed for book %s", book_slug)
+        return json.dumps({"error": "Timeline validation failed due to an internal error", "book_slug": book_slug})
     gate = derive_from_timeline_validation(result)
     return json.dumps(wrap_legacy(result, gate), indent=2, ensure_ascii=False)
 
@@ -512,10 +516,11 @@ def run_quality_gates(book_slug: str) -> str:
         scan_gate = derive_from_manuscript_scan(scan_result)
         per_gate["manuscript"] = scan_gate.to_json_dict()
         gates.append(scan_gate)
-    except Exception as exc:  # noqa: BLE001
+    except Exception:  # noqa: BLE001
+        logger.exception("Manuscript scan failed for book %s", book_slug)
         per_gate["manuscript"] = {
             "status": "WARN",
-            "reasons": [f"manuscript scan skipped: {exc}"],
+            "reasons": ["manuscript scan skipped due to an internal error"],
             "findings": [],
             "metadata": {},
         }
@@ -526,10 +531,11 @@ def run_quality_gates(book_slug: str) -> str:
         timeline_gate = derive_from_timeline_validation(timeline_result)
         per_gate["timeline"] = timeline_gate.to_json_dict()
         gates.append(timeline_gate)
-    except Exception as exc:  # noqa: BLE001
+    except Exception:  # noqa: BLE001
+        logger.exception("Timeline validation failed for book %s", book_slug)
         per_gate["timeline"] = {
             "status": "WARN",
-            "reasons": [f"timeline validation skipped: {exc}"],
+            "reasons": ["timeline validation skipped due to an internal error"],
             "findings": [],
             "metadata": {},
         }
@@ -542,10 +548,11 @@ def run_quality_gates(book_slug: str) -> str:
             cb_gate = derive_from_callback_verification(cb_result)
             per_gate["callbacks"] = cb_gate.to_json_dict()
             gates.append(cb_gate)
-        except Exception as exc:  # noqa: BLE001
+        except Exception:  # noqa: BLE001
+            logger.exception("Callback verification failed for book %s", book_slug)
             per_gate["callbacks"] = {
                 "status": "WARN",
-                "reasons": [f"callback verification skipped: {exc}"],
+                "reasons": ["callback verification skipped due to an internal error"],
                 "findings": [],
                 "metadata": {},
             }
@@ -556,10 +563,11 @@ def run_quality_gates(book_slug: str) -> str:
         plot_gate = GateResult.from_dict(plot_result["gate"])
         per_gate["plot_logic"] = plot_gate.to_json_dict()
         gates.append(plot_gate)
-    except Exception as exc:  # noqa: BLE001
+    except Exception:  # noqa: BLE001
+        logger.exception("Plot-logic analysis failed for book %s", book_slug)
         per_gate["plot_logic"] = {
             "status": "WARN",
-            "reasons": [f"plot-logic analysis skipped: {exc}"],
+            "reasons": ["plot-logic analysis skipped due to an internal error"],
             "findings": [],
             "metadata": {},
         }

--- a/tests/db/test_db_schema.py
+++ b/tests/db/test_db_schema.py
@@ -122,3 +122,39 @@ class TestGetCanonDbPathSlugValidation:
 
         path = get_canon_db_path("")
         assert path.name == ".db"
+
+
+# ---------------------------------------------------------------------------
+# STORYFORGE_DB_DIR validation (Issue #329)
+# ---------------------------------------------------------------------------
+
+
+class TestStoryforgeDbDirValidation:
+    """Issue #329 — STORYFORGE_DB_DIR must be sanitized against traversal."""
+
+    def test_valid_tmp_path_accepted(self, tmp_path: Path):
+        import importlib
+        import sys
+
+        env = {**__import__("os").environ, "STORYFORGE_DB_DIR": str(tmp_path)}
+        result = __import__("subprocess").run(
+            [sys.executable, "-c",
+             "from tools.db.connection import DB_DIR; print(DB_DIR)"],
+            capture_output=True, text=True,
+            cwd="/home/markus/projekte/storyforge",
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr
+        assert str(tmp_path) in result.stdout
+
+    def test_dotdot_traversal_rejected(self, tmp_path: Path):
+        import sys
+        env = {**__import__("os").environ, "STORYFORGE_DB_DIR": "/tmp/../etc/evil"}
+        result = __import__("subprocess").run(
+            [sys.executable, "-c", "from tools.db.connection import DB_DIR"],
+            capture_output=True, text=True,
+            cwd="/home/markus/projekte/storyforge",
+            env=env,
+        )
+        assert result.returncode != 0
+        assert "invalid path components" in result.stderr

--- a/tests/db/test_db_schema.py
+++ b/tests/db/test_db_schema.py
@@ -129,6 +129,9 @@ class TestGetCanonDbPathSlugValidation:
 # ---------------------------------------------------------------------------
 
 
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
 class TestStoryforgeDbDirValidation:
     """Issue #329 — STORYFORGE_DB_DIR must be sanitized against traversal."""
 
@@ -140,7 +143,7 @@ class TestStoryforgeDbDirValidation:
             [sys.executable, "-c",
              "from tools.db.connection import DB_DIR; print(DB_DIR)"],
             capture_output=True, text=True,
-            cwd="/home/markus/projekte/storyforge",
+            cwd=str(_PROJECT_ROOT),
             env=env,
         )
         assert result.returncode == 0, result.stderr
@@ -152,7 +155,7 @@ class TestStoryforgeDbDirValidation:
         result = __import__("subprocess").run(
             [sys.executable, "-c", "from tools.db.connection import DB_DIR"],
             capture_output=True, text=True,
-            cwd="/home/markus/projekte/storyforge",
+            cwd=str(_PROJECT_ROOT),
             env=env,
         )
         assert result.returncode != 0

--- a/tests/db/test_db_schema.py
+++ b/tests/db/test_db_schema.py
@@ -133,7 +133,6 @@ class TestStoryforgeDbDirValidation:
     """Issue #329 — STORYFORGE_DB_DIR must be sanitized against traversal."""
 
     def test_valid_tmp_path_accepted(self, tmp_path: Path):
-        import importlib
         import sys
 
         env = {**__import__("os").environ, "STORYFORGE_DB_DIR": str(tmp_path)}

--- a/tools/db/connection.py
+++ b/tools/db/connection.py
@@ -18,7 +18,14 @@ from tools.shared.config import CACHE_DIR
 from tools.shared.paths import _validate_slug
 
 # Override with STORYFORGE_DB_DIR to redirect DB lookups (used in subprocess tests).
-DB_DIR: Path = Path(os.environ["STORYFORGE_DB_DIR"]) if "STORYFORGE_DB_DIR" in os.environ else CACHE_DIR.parent / "db"
+# Validated to prevent null-byte and path-traversal tricks (Issue #329).
+if "STORYFORGE_DB_DIR" in os.environ:
+    _raw = os.environ["STORYFORGE_DB_DIR"]
+    if "\x00" in _raw or ".." in _raw.split(os.sep):
+        raise RuntimeError(f"STORYFORGE_DB_DIR contains invalid path components: {_raw!r}")
+    DB_DIR: Path = Path(_raw).resolve()
+else:
+    DB_DIR = CACHE_DIR.parent / "db"
 
 
 def open_db(db_path: Path) -> sqlite3.Connection:


### PR DESCRIPTION
## Summary

- **#327** — Broad `except Exception` catches in `gates.py` loggen jetzt via `logger.exception()` und geben generische Fehlermeldungen zurück. Systempfade und Stack-Details leaken nicht mehr in MCP-Tool-Responses.
- **#329** — `STORYFORGE_DB_DIR` wird auf Null-Bytes und `..`-Komponenten geprüft bevor der Wert als Pfad verwendet wird. `RuntimeError` bei ungültigem Input.

## Test plan

- [ ] CI grün
- [ ] `TestStoryforgeDbDirValidation` — valid path accepted, dotdot rejected
- [ ] Alle 2143 Tests grün

Closes #327, Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)