### PR TITLE
security: field allowlist for update_author, format guard for update_field (#328)

### DIFF
--- a/servers/storyforge-server/routers/authors.py
+++ b/servers/storyforge-server/routers/authors.py
@@ -45,6 +45,25 @@ from tools.state.parsers import parse_author_profile, parse_book_readme, parse_f
 from . import _app
 from ._app import _cache, mcp
 
+# Fields that may be written via update_author() — anything not in this set is
+# rejected. Keeps prompt-injection from adding arbitrary YAML keys to profiles.
+_ALLOWED_AUTHOR_FIELDS: frozenset[str] = frozenset({
+    # Core identity (set at creation)
+    "name", "updated",
+    # Narrative settings
+    "primary_genres", "narrative_voice", "tense", "tone",
+    "sentence_style", "vocabulary_level", "dialog_style", "pacing",
+    "themes", "influences", "avoid",
+    # Writing-mode config (set by create-author / new-book)
+    "author_writing_mode",
+    # Language / locale
+    "native_language", "preferred_writing_language",
+    # Memoir-specific (set by create-author memoir mode)
+    "subject_position", "off_limits", "relationship_to_material",
+    # Misc profile meta
+    "pen_name", "bio", "website", "social_media", "mood", "voice",
+})
+
 
 @mcp.tool()
 def list_authors() -> str:
@@ -595,6 +614,10 @@ def update_author(slug: str, field: str, value: str) -> str:
 
     if not profile_path.exists():
         return json.dumps({"error": f"Author '{slug}' not found"})
+
+    if field not in _ALLOWED_AUTHOR_FIELDS:
+        allowed = ", ".join(sorted(_ALLOWED_AUTHOR_FIELDS))
+        return json.dumps({"error": f"Field '{field}' is not an allowed author profile field. Allowed: {allowed}"})
 
     text = profile_path.read_text(encoding="utf-8")
     meta, body = parse_frontmatter(text)

--- a/servers/storyforge-server/routers/state.py
+++ b/servers/storyforge-server/routers/state.py
@@ -7,6 +7,7 @@ knowledge bundles) since it's a thin filesystem-state helper.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 from tools.db.connection import open_session_db
@@ -24,6 +25,13 @@ _SESSION_USER_ID = "local"
 # Phase 1 only ships fiction + memoir. Other non-fiction subtypes
 # (biography, how-to, academic, history) are deferred per #49 / #97.
 _ALLOWED_BOOK_CATEGORIES = ("fiction", "memoir")
+
+# Field-name format guard for update_field(). Accepts the same identifiers
+# that appear throughout the YAML frontmatter schema: letters, digits,
+# underscores, hyphens; must start with a letter; max 64 chars.
+# Rejects null bytes, shell metacharacters, path separators, and injected
+# YAML structure characters.
+_FIELD_NAME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_-]{0,63}$")
 
 
 @mcp.tool()
@@ -128,6 +136,9 @@ def update_field(file_path: str, field: str, value: str) -> str:
 
     if not any(resolved.is_relative_to(root) for root in allowed_roots):
         return json.dumps({"error": (f"file_path must be within content_root or authors_root (got: {file_path})")})
+
+    if not _FIELD_NAME_RE.match(field):
+        return json.dumps({"error": f"Invalid field name '{field}': must match [a-zA-Z][a-zA-Z0-9_-]{{0,63}}"})
 
     path = Path(file_path)
     if not path.exists():

--- a/tests/server/test_field_allowlist.py
+++ b/tests/server/test_field_allowlist.py
@@ -1,0 +1,173 @@
+"""Tests for field allowlist validation — Issue #328.
+
+update_author() enforces a strict allowlist of known profile fields.
+update_field() enforces a field-name format regex that rejects null bytes,
+shell metacharacters, and path-like strings.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirrors test_update_field.py setup)
+# ---------------------------------------------------------------------------
+
+
+import pytest
+
+
+@pytest.fixture
+def content_root(tmp_path: Path) -> Path:
+    root = tmp_path / "content"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def mock_config(content_root: Path):
+    fake_config = {
+        "paths": {
+            "content_root": str(content_root),
+            "authors_root": str(content_root / "authors"),
+        },
+        "defaults": {"language": "en", "book_type": "novel"},
+    }
+
+    import routers._app as server_mod
+    from tools.state import indexer as indexer_mod
+
+    fake_state_path = content_root / "_cache" / "state.json"
+
+    with (
+        patch.object(server_mod, "load_config", return_value=fake_config),
+        patch.object(server_mod, "get_content_root", return_value=content_root),
+        patch.object(indexer_mod, "load_config", return_value=fake_config),
+        patch.object(indexer_mod, "STATE_PATH", fake_state_path),
+        patch.object(indexer_mod, "CACHE_DIR", fake_state_path.parent),
+    ):
+        server_mod._cache.invalidate()
+        yield fake_config
+
+
+@pytest.fixture
+def server_module(mock_config):
+    import server as server_mod
+    return server_mod
+
+
+@pytest.fixture
+def author_dir(content_root: Path) -> Path:
+    authors_root = content_root / "authors"
+    author = authors_root / "test-author"
+    author.mkdir(parents=True)
+    profile = author / "profile.md"
+    profile.write_text(
+        '---\nname: "Test Author"\nslug: "test-author"\ntone: []\n---\n',
+        encoding="utf-8",
+    )
+    return author
+
+
+# ---------------------------------------------------------------------------
+# update_author — allowlist enforcement (Issue #328)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateAuthorAllowlist:
+    def test_allowed_field_accepted(self, server_module, author_dir: Path):
+        result = json.loads(server_module.update_author("test-author", "tone", "dark"))
+        assert result.get("success") is True
+
+    def test_disallowed_field_rejected(self, server_module, author_dir: Path):
+        result = json.loads(server_module.update_author("test-author", "status", "published"))
+        assert "error" in result
+        assert "status" in result["error"]
+
+    def test_internal_slug_field_rejected(self, server_module, author_dir: Path):
+        result = json.loads(server_module.update_author("test-author", "slug", "hacked"))
+        assert "error" in result
+
+    def test_arbitrary_key_rejected(self, server_module, author_dir: Path):
+        result = json.loads(server_module.update_author("test-author", "is_admin", "true"))
+        assert "error" in result
+
+    def test_author_writing_mode_accepted(self, server_module, author_dir: Path):
+        result = json.loads(server_module.update_author("test-author", "author_writing_mode", "discovery"))
+        assert result.get("success") is True
+
+    def test_native_language_accepted(self, server_module, author_dir: Path):
+        result = json.loads(server_module.update_author("test-author", "native_language", "de"))
+        assert result.get("success") is True
+
+    def test_subject_position_memoir_accepted(self, server_module, author_dir: Path):
+        result = json.loads(server_module.update_author("test-author", "subject_position", "writing-self"))
+        assert result.get("success") is True
+
+    def test_unknown_author_still_returns_error(self, server_module, content_root: Path):
+        result = json.loads(server_module.update_author("no-such-author", "tone", "bright"))
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# update_field — field name format validation (Issue #328)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateFieldNameValidation:
+    def test_valid_snake_case_field_accepted(self, server_module, content_root: Path):
+        target = content_root / "README.md"
+        target.write_text("---\nstatus: Draft\n---\n", encoding="utf-8")
+        result = json.loads(server_module.update_field(str(target), "author_writing_mode", "discovery"))
+        assert result.get("success") is True
+
+    def test_valid_hyphenated_field_accepted(self, server_module, content_root: Path):
+        target = content_root / "README.md"
+        target.write_text("---\nstatus: Draft\n---\n", encoding="utf-8")
+        result = json.loads(server_module.update_field(str(target), "book-category", "fiction"))
+        assert result.get("success") is True
+
+    def test_field_with_null_byte_rejected(self, server_module, content_root: Path):
+        target = content_root / "README.md"
+        target.write_text("---\nstatus: Draft\n---\n", encoding="utf-8")
+        result = json.loads(server_module.update_field(str(target), "field\x00inject", "val"))
+        assert "error" in result
+
+    def test_field_with_newline_rejected(self, server_module, content_root: Path):
+        target = content_root / "README.md"
+        target.write_text("---\nstatus: Draft\n---\n", encoding="utf-8")
+        result = json.loads(server_module.update_field(str(target), "field\nevil: true\n#", "val"))
+        assert "error" in result
+
+    def test_field_starting_with_digit_rejected(self, server_module, content_root: Path):
+        target = content_root / "README.md"
+        target.write_text("---\nstatus: Draft\n---\n", encoding="utf-8")
+        result = json.loads(server_module.update_field(str(target), "1field", "val"))
+        assert "error" in result
+
+    def test_field_with_colon_rejected(self, server_module, content_root: Path):
+        target = content_root / "README.md"
+        target.write_text("---\nstatus: Draft\n---\n", encoding="utf-8")
+        result = json.loads(server_module.update_field(str(target), "key: injected", "val"))
+        assert "error" in result
+
+    def test_empty_field_rejected(self, server_module, content_root: Path):
+        target = content_root / "README.md"
+        target.write_text("---\nstatus: Draft\n---\n", encoding="utf-8")
+        result = json.loads(server_module.update_field(str(target), "", "val"))
+        assert "error" in result
+
+    def test_very_long_field_rejected(self, server_module, content_root: Path):
+        target = content_root / "README.md"
+        target.write_text("---\nstatus: Draft\n---\n", encoding="utf-8")
+        result = json.loads(server_module.update_field(str(target), "a" * 65, "val"))
+        assert "error" in result
+
+    def test_status_field_accepted(self, server_module, content_root: Path):
+        target = content_root / "README.md"
+        target.write_text("---\nstatus: Draft\n---\n", encoding="utf-8")
+        result = json.loads(server_module.update_field(str(target), "status", "Review"))
+        assert result.get("success") is True


### PR DESCRIPTION
## Summary

- **update_author()**: striktes Allowlist aller bekannten Author-Profil-Felder (`_ALLOWED_AUTHOR_FIELDS`). Felder wie `status`, `published`, `is_admin`, `slug` werden abgelehnt.
- **update_field()**: Feldname-Format-Validierung via Regex `^[a-zA-Z][a-zA-Z0-9_-]{0,63}$`. Rejects null bytes, Newlines, Sonderzeichen, leere Strings und überlange Namen. Kein vollständiges Allowlist (Tool ist file-agnostisch und schreibt in viele verschiedene YAML-Dateitypen).

## Test plan

- [ ] CI grün
- [ ] `TestUpdateAuthorAllowlist` — 8 Tests
- [ ] `TestUpdateFieldNameValidation` — 9 Tests
- [ ] Alle 2160 Tests grün

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)